### PR TITLE
return pErr instead of nil

### DIFF
--- a/touch.go
+++ b/touch.go
@@ -60,5 +60,5 @@ loop:
 	close(in)
 	wg.Wait()
 
-	return nil
+	return pErr
 }


### PR DESCRIPTION
Return pErr instead of nil in desync.Touch Fixes #16 