### PR TITLE
Support prune on s3 stores as per #22 and fix handling of empty prefixes in s3 stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ go get -u github.com/folbricht/desync/cmd/desync
 - `pull`         - serve chunks using the casync protocol over stdin/stdout. Set `CASYNC_REMOTE_PATH=desync` on the client to use it.
 - `tar`          - pack a catar file, optionally chunk the catar and create an index file. Not available on Windows.
 - `untar`        - unpack a catar file or an index referencing a catar. Not available on Windows.
-- `prune`        - remove unreferenced chunks from a local store. Use with caution, can lead to data loss.
+- `prune`        - remove unreferenced chunks from a local or S3 store. Use with caution, can lead to data loss.
 - `chunk-server` - start a chunk server that serves chunks via HTTP(S)
 - `make`         - split a blob into chunks and create an index file
 - `mount-index`  - FUSE mount a blob index. Will make the blob available as single file inside the mountpoint.
 
 ### Options (not all apply to all commands)
-- `-s <store>` Location of the chunk store, can be local directory or a URL like ssh://hostname/path/to/store. Multiple stores can be specified, they'll be queried for chunks in the same order. The `chop`, `make`, and `tar` commands support updating chunk stores in S3, while `verify` and `prune` commands only operate on a local store.
+- `-s <store>` Location of the chunk store, can be local directory or a URL like ssh://hostname/path/to/store. Multiple stores can be specified, they'll be queried for chunks in the same order. The `chop`, `make`, `tar` and `prune` commands support updating chunk stores in S3, while `verify` only operates on a local store.
 - `-c <store>` Location of a *local* chunk store to be used as cache. Needs to be writable.
 - `-n <int>` Number of concurrent download jobs and ssh sessions to the chunk store.
 - `-r` Repair a local cache by removing invalid chunks. Only valid for the `verify` command.

--- a/cmd/desync/prune.go
+++ b/cmd/desync/prune.go
@@ -12,8 +12,8 @@ import (
 
 const pruneUsage = `desync prune [options] <index> [<index>..]
 
-Read chunk IDs in from index files and delete any chunks from a local store
-that are not referenced in the files.`
+Read chunk IDs in from index files and delete any chunks from a local (or s3)
+store that are not referenced in the index files.`
 
 func prune(ctx context.Context, args []string) error {
 	var (
@@ -38,10 +38,12 @@ func prune(ctx context.Context, args []string) error {
 		return errors.New("No store provided.")
 	}
 
-	s, err := desync.NewLocalStore(storeLocation)
+	// Open the target store
+	s, err := WritableStore(1, storeLocation)
 	if err != nil {
 		return err
 	}
+	defer s.Close()
 
 	// Read the input files and merge all chunk IDs in a map to de-dup them
 	ids := make(map[desync.ChunkID]struct{})

--- a/store.go
+++ b/store.go
@@ -1,6 +1,9 @@
 package desync
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // Store is a generic interface implemented by read-only stores, like SSH or
 // HTTP remote stores currently.
@@ -16,4 +19,5 @@ type WriteStore interface {
 	Store
 	HasChunk(id ChunkID) bool
 	StoreChunk(id ChunkID, b []byte) error
+	Prune(ctx context.Context, ids map[ChunkID]struct{}) error
 }


### PR DESCRIPTION
Addresses two things:
- Previously, an empty prefix in a S3 store URL would cause chunks to be created with a leading `/` which Minio for example doesn't accept. The change is to only use `/` when there really is a prefix in the URL.
- Allows pruning of S3 stores

Note: Pruning uses the supposedly slower method of deleting chunks one-by-one with https://docs.minio.io/docs/golang-client-api-reference#RemoveObject rather than the bulk delete API available in the Minio client (https://docs.minio.io/docs/golang-client-api-reference#RemoveObjects). That was done mainly for simplicity and can be easily changed later.