### PR TITLE
S3 store layout alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ This is a store running on the local machine on port 9000 without SSL.
 s3+http://127.0.0.1:9000/store
 ```
 
+#### Previous S3 storage layout
+Before April 2018, chunks in S3 stores were kept in a flat layout, with the name being the checksum of the chunk. Since then, the layout was modified to match that of local stores: `<4-checksum-chars>/<checksum>.cacnk` This change allows the use of other tools to convert or copy stores between local and S3 stores. To convert an existing s3 store from the old format, a command `upgrade-s3` is available in the tool.
+
 ### Examples:
 
 Re-assemble somefile.tar using a remote chunk store and a blob index file.

--- a/cmd/desync/main.go
+++ b/cmd/desync/main.go
@@ -30,6 +30,7 @@ untar        - extract directory tree from a catar file
 prune        - remove all unreferenced chunks from a local store
 chunk-server - start a HTTP chunk server
 mount-index  - FUSE mount an index
+upgrade-s3   - convert an s3 store from the old to the new storage layout
 `
 
 func main() {
@@ -72,6 +73,7 @@ func main() {
 		"chunk":        chunkCmd,
 		"make":         makeCmd,
 		"mount-index":  mountIdx,
+		"upgrade-s3":   upgradeS3,
 	}
 	h, ok := handlers[cmd]
 	if !ok {

--- a/cmd/desync/prune.go
+++ b/cmd/desync/prune.go
@@ -26,7 +26,7 @@ func prune(ctx context.Context, args []string) error {
 		flags.PrintDefaults()
 	}
 
-	flags.StringVar(&storeLocation, "s", "", "local store directory")
+	flags.StringVar(&storeLocation, "s", "", "local or s3 store")
 	flags.BoolVar(&accepted, "y", false, "do not ask for confirmation")
 	flags.Parse(args)
 

--- a/cmd/desync/upgrade-s3.go
+++ b/cmd/desync/upgrade-s3.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/folbricht/desync"
+)
+
+const upgradeS3Usage = `desync upgrade-s3 -s <s3-store>
+
+Upgrades an S3 store using the deprecated layout (flat structure) to the new
+layout which mirrors local stores. In the new format, each chunk is prefixed
+with the 4 first characters of the checksum and prefixed with .cacnk`
+
+func upgradeS3(ctx context.Context, args []string) error {
+	var (
+		storeLocation string
+	)
+	flags := flag.NewFlagSet("upgrade-s3", flag.ExitOnError)
+	flags.Usage = func() {
+		fmt.Fprintln(os.Stderr, pruneUsage)
+		flags.PrintDefaults()
+	}
+
+	flags.StringVar(&storeLocation, "s", "", "local store directory")
+	flags.Parse(args)
+
+	if flags.NArg() > 0 {
+		return errors.New("Too many arguments. See -h for help.")
+	}
+
+	if storeLocation == "" {
+		return errors.New("No store provided.")
+	}
+
+	// Open the target store
+	s, err := desync.NewS3Store(storeLocation)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	return s.Upgrade(ctx)
+}


### PR DESCRIPTION
As per #22, this changes the storage layout used in S3 stores to match that of local and HTTP stores. It allows other tools to copy, sync, or use chunk stores in a consistent manner, for example copying to/from S3 to local stores.

For existing chunk stores in S3 using the old layout, the `upgrade-s3` command can be used to convert them to the new layout.