### PR TITLE
Add support for -t option to chunk-server command

### DIFF
--- a/cmd/desync/cache.go
+++ b/cmd/desync/cache.go
@@ -33,7 +33,7 @@ func cache(ctx context.Context, args []string) error {
 	flags.Var(storeLocations, "s", "casync store location, can be multiples")
 	flags.StringVar(&cacheLocation, "c", "", "use local store as cache")
 	flags.IntVar(&n, "n", 10, "number of goroutines")
-	flags.BoolVar(&desync.TrustInsecure, "i", false, "allow invalid certificates")
+	flags.BoolVar(&desync.TrustInsecure, "t", false, "trust invalid certificates")
 	flags.StringVar(&clientCert, "clientCert", "", "Path to Client Certificate for TLS authentication")
 	flags.StringVar(&clientKey, "clientKey", "", "Path to Client Key for TLS authentication")
 	flags.Parse(args)

--- a/cmd/desync/server.go
+++ b/cmd/desync/server.go
@@ -36,6 +36,7 @@ func server(ctx context.Context, args []string) error {
 	flags.Var(storeLocations, "s", "casync store location, can be multiples")
 	flags.StringVar(&cacheLocation, "c", "", "use local store as cache")
 	flags.IntVar(&n, "n", 10, "number of goroutines, only used for remote SSH stores")
+	flags.BoolVar(&desync.TrustInsecure, "t", false, "trust invalid certificates")
 	flags.Var(listenAddresses, "l", "listen address, can be multiples (default :http)")
 	flags.StringVar(&cert, "cert", "", "cert file in PEM format, requires -key")
 	flags.StringVar(&key, "key", "", "key file in PEM format, requires -cert")


### PR DESCRIPTION
As per #26, the `chunk-server` command should allow chaining of HTTPS stores