### PR TITLE
Introduce configurable HTTP timeout and retry on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ s3+http://127.0.0.1:9000/store
 #### Previous S3 storage layout
 Before April 2018, chunks in S3 stores were kept in a flat layout, with the name being the checksum of the chunk. Since then, the layout was modified to match that of local stores: `<4-checksum-chars>/<checksum>.cacnk` This change allows the use of other tools to convert or copy stores between local and S3 stores. To convert an existing s3 store from the old format, a command `upgrade-s3` is available in the tool.
 
+### Configuration
+
+For most use cases, it is sufficient to use the tool's default configuration not requiring a config file. Having a config file `$HOME/.config/desync/config.json` allows for further customization of internal behaviour such as timeouts or error retry that can't be set via command-line options or environment variables. To view the current configuration, use `desync config`. If no config file is present, this will show the defaults. To create a config file allowing custom values, use `desync config -w` which will write the current configuration to the file, then edit the file.
+
+Available configuration values:
+- `http-timeout` - HTTP request timeout used in HTTP stores (not S3) in nanoseconds
+- `http-error-retry` - Number of times to retry failed chunk requests from HTTP stores
+
 ### Examples:
 
 Re-assemble somefile.tar using a remote chunk store and a blob index file.

--- a/cmd/desync/config.go
+++ b/cmd/desync/config.go
@@ -55,6 +55,9 @@ func config(ctx context.Context, args []string) error {
 		if err != nil {
 			return err
 		}
+		if err = os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
+			return err
+		}
 		f, err := os.Create(filename)
 		if err != nil {
 			return err

--- a/cmd/desync/config.go
+++ b/cmd/desync/config.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/user"
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type Config struct {
+	HTTPTimeout    time.Duration `json:"http-timeout"`
+	HTTPErrorRetry int           `json:"http-error-retry"`
+}
+
+// Global config in the main packe defining the defaults. Those can be
+// overridden by loading a config file.
+var cfg = Config{
+	HTTPTimeout: time.Minute,
+}
+
+const configUsage = `desync config
+
+Shows the current internal config settings, either the defaults or the values
+from $HOME/.config/desync/config.json. The output can be used to create a custom
+config file by writing it to $HOME/.config/desync/config.json.
+`
+
+func config(ctx context.Context, args []string) error {
+	var writeConfig bool
+	flags := flag.NewFlagSet("config", flag.ExitOnError)
+	flags.Usage = func() {
+		fmt.Fprintln(os.Stderr, configUsage)
+		flags.PrintDefaults()
+	}
+	flags.BoolVar(&writeConfig, "w", false, "write current configuration to $HOME/.config/desync/config.json")
+	flags.Parse(args)
+
+	if flags.NArg() > 0 {
+		return errors.New("Too many arguments. See -h for help.")
+	}
+	b, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	var w io.Writer = os.Stderr
+	if writeConfig {
+		filename, err := configFile()
+		if err != nil {
+			return err
+		}
+		f, err := os.Create(filename)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		fmt.Println("Writing config to", filename)
+		w = f
+	}
+	_, err = w.Write(b)
+	fmt.Println()
+	return err
+}
+
+func configFile() (string, error) {
+	u, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	filename := filepath.Join(u.HomeDir, ".config", "desync", "config.json")
+	return filename, nil
+}
+
+// Look for $HOME/.config/desync and if present, load into the global config
+// instance. Values defined in the file will be set accordingly, while anything
+// that's not in the file will retain it's default values.
+func loadConfigIfPresent() error {
+	filename, err := configFile()
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		return nil
+	}
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	err = json.NewDecoder(f).Decode(&cfg)
+	return errors.Wrap(err, "reading "+filename)
+}

--- a/cmd/desync/main.go
+++ b/cmd/desync/main.go
@@ -43,6 +43,11 @@ func main() {
 		die(errors.New("No command given. See -h for help."))
 	}
 
+	// Check if there's a config file and load the values from it if there is
+	if err := loadConfigIfPresent(); err != nil {
+		die(err)
+	}
+
 	// Install a signal handler for SIGINT or SIGTERM to cancel a context in
 	// order to clean up and shut down gracefully if Ctrl+C is hit.
 	ctx, cancel := context.WithCancel(context.Background())
@@ -74,6 +79,7 @@ func main() {
 		"make":         makeCmd,
 		"mount-index":  mountIdx,
 		"upgrade-s3":   upgradeS3,
+		"config":       config,
 	}
 	h, ok := handlers[cmd]
 	if !ok {

--- a/cmd/desync/store.go
+++ b/cmd/desync/store.go
@@ -31,10 +31,13 @@ func MultiStoreWithCache(n int, cacheLocation string, clientCert string, clientK
 				return store, err
 			}
 		case "http", "https":
-			s, err = desync.NewRemoteHTTPStore(loc, n, clientCert, clientKey)
+			h, err := desync.NewRemoteHTTPStore(loc, n, clientCert, clientKey)
 			if err != nil {
 				return store, err
 			}
+			h.SetTimeout(cfg.HTTPTimeout)
+			h.SetErrorRetry(cfg.HTTPErrorRetry)
+			s = h
 		case "s3+http", "s3+https":
 			s, err = desync.NewS3Store(location)
 			if err != nil {

--- a/remotehttp.go
+++ b/remotehttp.go
@@ -8,8 +8,10 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"crypto/x509"
+
 	"github.com/pkg/errors"
 )
 
@@ -67,7 +69,7 @@ func NewRemoteHTTPStore(location *url.URL, n int, cert string, key string) (*Rem
 		}
 	}
 
-	client := &http.Client{Transport: tr}
+	client := &http.Client{Transport: tr, Timeout: time.Minute}
 
 	return &RemoteHTTP{&u, client}, nil
 }


### PR DESCRIPTION
Adds an optional config file to allow customizing internal behaviours like `http-timeout` and `http-error-retry`. Closes #29 and #30 