### PR TITLE
Add support for AWS temporary (refreshable) credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ go get -u github.com/folbricht/desync/cmd/desync
 ### Environment variables
 - `CASYNC_SSH_PATH` overrides the default "ssh" with a command to run when connecting to a remote SSH or SFTP chunk store
 - `CASYNC_REMOTE_PATH` defines the command to run on the chunk store when using SSH, default "casync"
-- `S3_ACCESS_KEY` and `S3_SECRET_KEY` can be used to define S3 store credentials if only one store is used. Caution, these values take precedence over any S3 credentials set in the config file.
+- `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_REGION` can be used to define S3 store credentials if only one store is used. Caution, these values take precedence over any S3 credentials set in the config file.
 
 ### Caching
 The `-c <store>` option can be used to either specify an existing store to act as cache or to populate a new store. Whenever a chunk is requested, it is first looked up in the cache before routing the request to the next (possibly remote) store. Any chunks downloaded from the main stores are added to the cache. In addition, when a chunk is read from the cache and it is a local store, mtime of the chunk is updated to allow for basic garbage collection based on file age. The cache store is expected to be writable. If the cache contains an invalid chunk (checksum does not match the chunk ID), the operation will fail. Invalid chunks are not skipped or removed from the cache automatically. `verfiy -r` can be used to
@@ -122,25 +122,49 @@ For most use cases, it is sufficient to use the tool's default configuration not
 Available configuration values:
 - `http-timeout` - HTTP request timeout used in HTTP stores (not S3) in nanoseconds
 - `http-error-retry` - Number of times to retry failed chunk requests from HTTP stores
-- `s3-credentials` - Defines credentials for use with S3 stores. Especially useful if more than one S3 store is used. The key in the config needs to be the URL scheme and host used for the store, excluding the path, but including the port number if used in the store URL.
+- `s3-credentials` - Defines credentials for use with S3 stores. Especially useful if more than one S3 store is used. The key in the config needs to be the URL scheme and host used for the store, excluding the path, but including the port number if used in the store URL. It is also possible to use a [standard aws credentials file](https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html) in order to store s3 credentials.
 
 **Example config**
 
-```json
+```
 {
   "http-timeout": 60000000000,
   "http-error-retry": 0,
   "s3-credentials": {
-    "http://localhost": {
-      "access-key": "MYACCESSKEY",
-      "secret-key": "MYSECRETKEY"
-    },
-    "https://127.0.0.1:9000": {
-      "access-key": "OTHERACCESSKEY",
-      "secret-key": "OTHERSECRETKEY"
-    }
+       "http://localhost": {
+           "access-key": "MYACCESSKEY",
+           "secret-key": "MYSECRETKEY"
+       },
+       "https://127.0.0.1:9000": {
+           "aws-credentials-file": "/Users/user/.aws/credentials",
+       },
+       "https://127.0.0.1:8000": {
+           "aws-credentials-file": "/Users/user/.aws/credentials",
+           "aws-profile": "profile_static"
+       },
+       "https://s3.us-west-2.amazonaws.com": {
+           "aws-credentials-file": "/Users/user/.aws/credentials",
+           "aws-region": "us-west-2",
+           "aws-profile": "profile_refreshable"
+       }
   }
 }
+```
+
+**Example aws credentials**
+```
+[default]
+aws_access_key_id = DEFAULT_PROFILE_KEY
+aws_secret_access_key = DEFAULT_PROFILE_SECRET
+
+[profile_static]
+aws_access_key_id = OTHERACCESSKEY
+aws_secret_access_key = OTHERSECRETKEY
+
+[profile_refreshable]
+aws_access_key_id = PROFILE_REFRESHABLE_KEY
+aws_secret_access_key = PROFILE_REFRESHABLE_SECRET
+aws_session_token = PROFILE_REFRESHABLE_TOKEN
 ```
 
 ### Examples:

--- a/cmd/desync/credentials.go
+++ b/cmd/desync/credentials.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"os"
+	"time"
+
+	"path/filepath"
+
+	"github.com/go-ini/ini"
+	"github.com/minio/minio-go/pkg/credentials"
+	"github.com/pkg/errors"
+)
+
+// SharedCredentialsFilename returns the SDK's default file path
+// for the shared credentials file.
+//
+// Builds the shared config file path based on the OS's platform.
+//
+//   - Linux/Unix: $HOME/.aws/credentials
+func SharedCredentialsFilename() string {
+	return filepath.Join(os.Getenv("HOME"), ".aws", "credentials")
+}
+
+// UserHomeDir returns the home directory for the user the process is
+// running under.
+func UserHomeDir() string {
+	return os.Getenv("HOME")
+}
+
+// Implements credentials.Provider from github.com/minio/minio-go/pkg/credentials
+type StaticCredentialsProvider struct {
+	creds credentials.Value
+}
+
+func (cp *StaticCredentialsProvider) IsExpired() bool {
+	return false
+}
+
+func (cp *StaticCredentialsProvider) Retrieve() (credentials.Value, error) {
+	return cp.creds, nil
+}
+
+func NewStaticCredentials(accessKey, secretKey string) *credentials.Credentials {
+	p := &StaticCredentialsProvider{
+		credentials.Value{
+			AccessKeyID:     accessKey,
+			SecretAccessKey: secretKey,
+		},
+	}
+	return credentials.New(p)
+}
+
+// A SharedCredentialsProvider retrieves credentials from the current user's home
+// directory, and keeps track if those credentials are expired.
+//
+// Profile ini file example: $HOME/.aws/credentials
+type RefreshableSharedCredentialsProvider struct {
+	// Path to the shared credentials file.
+	//
+	// If empty will look for "AWS_SHARED_CREDENTIALS_FILE" env variable. If the
+	// env value is empty will default to current user's home directory.
+	// Linux/OSX: "$HOME/.aws/credentials"
+	Filename string
+
+	// AWS Profile to extract credentials from the shared credentials file. If empty
+	// will default to environment variable "AWS_PROFILE" or "default" if
+	// environment variable is also not set.
+	Profile string
+
+	// The expiration time of the current fetched credentials.
+	exp time.Time
+
+	// The function to get the current timestamp
+	now func() time.Time
+}
+
+// NewRefreshableSharedCredentials returns a pointer to a new Credentials object
+// wrapping the Profile file provider.
+func NewRefreshableSharedCredentials(filename string, profile string, now func() time.Time) *credentials.Credentials {
+	return credentials.New(&RefreshableSharedCredentialsProvider{
+		Filename: filename,
+		Profile:  profile,
+
+		// To ensure the credentials are always valid, the provider should fetch the credentials every 5 minutes or so.
+		// It's set to 1 minute here.
+		exp: now().Add(time.Minute),
+		now: now,
+	})
+}
+
+// IsExpired returns if the shared credentials have expired.
+func (p *RefreshableSharedCredentialsProvider) IsExpired() bool {
+	return p.now().After(p.exp)
+}
+
+// Retrieve reads and extracts the shared credentials from the current
+// users home directory.
+func (p *RefreshableSharedCredentialsProvider) Retrieve() (credentials.Value, error) {
+	filename, err := p.filename()
+	if err != nil {
+		return credentials.Value{}, err
+	}
+
+	creds, err := loadProfile(filename, p.profile())
+	if err != nil {
+		return credentials.Value{}, err
+	}
+
+	// After retrieving the credentials, reset the expiration time.
+	p.exp = p.now().Add(time.Minute)
+	return creds, nil
+}
+
+// loadProfiles loads from the file pointed to by shared credentials filename for profile.
+// The credentials retrieved from the profile will be returned or error. Error will be
+// returned if it fails to read from the file, or the data is invalid.
+func loadProfile(filename, profile string) (credentials.Value, error) {
+	config, err := ini.Load(filename)
+	if err != nil {
+		return credentials.Value{}, errors.Wrap(err, "failed to load shared credentials file")
+	}
+	iniProfile, err := config.GetSection(profile)
+	if err != nil {
+		return credentials.Value{}, errors.Wrap(err, "failed to get profile")
+	}
+
+	id, err := iniProfile.GetKey("aws_access_key_id")
+	if err != nil {
+		return credentials.Value{}, errors.Wrapf(err, "shared credentials %s in %s did not contain aws_access_key_id", profile, filename)
+	}
+
+	secret, err := iniProfile.GetKey("aws_secret_access_key")
+	if err != nil {
+		return credentials.Value{}, errors.Wrapf(err, "shared credentials %s in %s did not contain aws_secret_access_key", profile, filename)
+	}
+
+	// Default to empty string if not found
+	token := iniProfile.Key("aws_session_token")
+
+	return credentials.Value{
+		AccessKeyID:     id.String(),
+		SecretAccessKey: secret.String(),
+		SessionToken:    token.String(),
+	}, nil
+}
+
+// filename returns the filename to use to read AWS shared credentials.
+//
+// Will return an error if the user's home directory path cannot be found.
+func (p *RefreshableSharedCredentialsProvider) filename() (string, error) {
+	if len(p.Filename) != 0 {
+		return p.Filename, nil
+	}
+
+	if p.Filename = os.Getenv("AWS_SHARED_CREDENTIALS_FILE"); len(p.Filename) != 0 {
+		return p.Filename, nil
+	}
+
+	homeDir := UserHomeDir()
+	if len(homeDir) == 0 {
+		// Backwards compatibility of home directly not found error being returned.
+		return "", errors.New("user home directory not found.")
+	}
+
+	// SDK's default file path
+	// - Linux/Unix: $HOME/.aws/credentials
+	p.Filename = SharedCredentialsFilename()
+
+	return p.Filename, nil
+}
+
+// profile returns the AWS shared credentials profile.  If empty will read
+// environment variable "AWS_PROFILE". If that is not set profile will
+// return "default".
+func (p *RefreshableSharedCredentialsProvider) profile() string {
+	if p.Profile == "" {
+		p.Profile = os.Getenv("AWS_PROFILE")
+	}
+	if p.Profile == "" {
+		p.Profile = "default"
+	}
+
+	return p.Profile
+}

--- a/cmd/desync/credentials_test.go
+++ b/cmd/desync/credentials_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var now = time.Now
+
+func TestNewRefreshableSharedCredentials(t *testing.T) {
+	currentTime := time.Now()
+	mockNow := func() time.Time {
+		return currentTime.Add(time.Minute * 2)
+	}
+
+	c := NewRefreshableSharedCredentials("example.ini", "", mockNow)
+
+	assert.True(t, c.IsExpired(), "Expect creds to be expired before retrieve")
+
+	_, err := c.Get()
+	assert.Nil(t, err, "Expect no error")
+
+	assert.False(t, c.IsExpired(), "Expect creds to not be expired after retrieve")
+}
+
+func TestRefreshableSharedCredentialsProvider(t *testing.T) {
+	os.Clearenv()
+
+	p := RefreshableSharedCredentialsProvider{Filename: "example.ini", Profile: "", exp: now().Add(time.Minute), now: now}
+	creds, err := p.Retrieve()
+	assert.Nil(t, err, "Expect no error")
+
+	assert.Equal(t, "accessKey", creds.AccessKeyID, "Expect access key ID to match")
+	assert.Equal(t, "secret", creds.SecretAccessKey, "Expect secret access key to match")
+	assert.Equal(t, "token", creds.SessionToken, "Expect session token to match")
+}
+
+func TestRefreshableSharedCredentialsProviderIsExpired(t *testing.T) {
+	os.Clearenv()
+	currentTime := time.Now()
+	mockNow := func() time.Time {
+		return currentTime.Add(time.Minute * 2)
+	}
+
+	p := RefreshableSharedCredentialsProvider{Filename: "example.ini", Profile: "", exp: currentTime.Add(time.Minute), now: mockNow}
+
+	assert.True(t, p.IsExpired(), "Expect creds to be expired before retrieve")
+
+	_, err := p.Retrieve()
+	assert.Nil(t, err, "Expect no error")
+
+	assert.False(t, p.IsExpired(), "Expect creds to not be expired after retrieve")
+}
+
+func TestRefreshableSharedCredentialsProviderWithAWS_SHARED_CREDENTIALS_FILE(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", "example.ini")
+
+	p := RefreshableSharedCredentialsProvider{exp: now().Add(time.Minute), now: now}
+	creds, err := p.Retrieve()
+
+	assert.Nil(t, err, "Expect no error")
+
+	assert.Equal(t, "accessKey", creds.AccessKeyID, "Expect access key ID to match")
+	assert.Equal(t, "secret", creds.SecretAccessKey, "Expect secret access key to match")
+	assert.Equal(t, "token", creds.SessionToken, "Expect session token to match")
+}
+
+func TestRefreshableSharedCredentialsProviderWithAWS_SHARED_CREDENTIALS_FILEAbsPath(t *testing.T) {
+	os.Clearenv()
+
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(wd, "example.ini"))
+	p := RefreshableSharedCredentialsProvider{exp: now().Add(time.Minute), now: now}
+	creds, err := p.Retrieve()
+	assert.Nil(t, err, "Expect no error")
+
+	assert.Equal(t, "accessKey", creds.AccessKeyID, "Expect access key ID to match")
+	assert.Equal(t, "secret", creds.SecretAccessKey, "Expect secret access key to match")
+	assert.Equal(t, "token", creds.SessionToken, "Expect session token to match")
+}
+
+func TestRefreshableSharedCredentialsProviderWithAWS_PROFILE(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("AWS_PROFILE", "no_token")
+
+	p := RefreshableSharedCredentialsProvider{Filename: "example.ini", Profile: "", exp: now().Add(time.Minute), now: now}
+	creds, err := p.Retrieve()
+	assert.Nil(t, err, "Expect no error")
+
+	assert.Equal(t, "accessKey", creds.AccessKeyID, "Expect access key ID to match")
+	assert.Equal(t, "secret", creds.SecretAccessKey, "Expect secret access key to match")
+	assert.Empty(t, creds.SessionToken, "Expect no token")
+}
+
+func TestRefreshableSharedCredentialsProviderWithoutTokenFromProfile(t *testing.T) {
+	os.Clearenv()
+
+	p := RefreshableSharedCredentialsProvider{Filename: "example.ini", Profile: "no_token", exp: now().Add(time.Minute), now: now}
+	creds, err := p.Retrieve()
+	assert.Nil(t, err, "Expect no error")
+
+	assert.Equal(t, "accessKey", creds.AccessKeyID, "Expect access key ID to match")
+	assert.Equal(t, "secret", creds.SecretAccessKey, "Expect secret access key to match")
+	assert.Empty(t, creds.SessionToken, "Expect no token")
+}
+
+func TestRefreshableSharedCredentialsProviderColonInCredFile(t *testing.T) {
+	os.Clearenv()
+
+	p := RefreshableSharedCredentialsProvider{Filename: "example.ini", Profile: "with_colon", exp: now().Add(time.Minute), now: now}
+	creds, err := p.Retrieve()
+	assert.Nil(t, err, "Expect no error")
+
+	assert.Equal(t, "accessKey", creds.AccessKeyID, "Expect access key ID to match")
+	assert.Equal(t, "secret", creds.SecretAccessKey, "Expect secret access key to match")
+	assert.Empty(t, creds.SessionToken, "Expect no token")
+}
+
+func TestRefreshableSharedCredentialsProvider_DefaultFilename(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("USERPROFILE", "profile_dir")
+	os.Setenv("HOME", "home_dir")
+
+	// default filename and profile
+	p := RefreshableSharedCredentialsProvider{exp: now().Add(time.Minute), now: now}
+
+	filename, err := p.filename()
+
+	if err != nil {
+		t.Fatalf("expect no error, got %v", err)
+	}
+
+	if e, a := SharedCredentialsFilename(), filename; e != a {
+		t.Errorf("expect %q filename, got %q", e, a)
+	}
+}

--- a/cmd/desync/example.ini
+++ b/cmd/desync/example.ini
@@ -1,0 +1,12 @@
+[default]
+aws_access_key_id = accessKey
+aws_secret_access_key = secret
+aws_session_token = token
+
+[no_token]
+aws_access_key_id = accessKey
+aws_secret_access_key = secret
+
+[with_colon]
+aws_access_key_id: accessKey
+aws_secret_access_key: secret

--- a/cmd/desync/store.go
+++ b/cmd/desync/store.go
@@ -108,8 +108,8 @@ func storeFromLocation(location string, opts storeOptions) (desync.Store, error)
 		h.SetErrorRetry(cfg.HTTPErrorRetry)
 		s = h
 	case "s3+http", "s3+https":
-		accesskey, secretkey := cfg.GetS3CredentialsFor(loc)
-		s, err = desync.NewS3Store(location, accesskey, secretkey)
+		s3Creds, region := cfg.GetS3CredentialsFor(loc)
+		s, err = desync.NewS3Store(location, s3Creds, region)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/desync/upgrade-s3.go
+++ b/cmd/desync/upgrade-s3.go
@@ -43,8 +43,8 @@ func upgradeS3(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	accesskey, secretkey := cfg.GetS3CredentialsFor(loc)
-	s, err := desync.NewS3Store(storeLocation, accesskey, secretkey)
+	s3Creds, region := cfg.GetS3CredentialsFor(loc)
+	s, err := desync.NewS3Store(storeLocation, s3Creds, region)
 	if err != nil {
 		return err
 	}

--- a/s3.go
+++ b/s3.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	minio "github.com/minio/minio-go"
+	"github.com/minio/minio-go/pkg/credentials"
 	"github.com/pkg/errors"
 )
 
@@ -24,7 +25,7 @@ type S3Store struct {
 // should be provided like this: s3+http://host:port/bucket
 // Credentials are passed in via the environment variables S3_ACCESS_KEY
 // and S3S3_SECRET_KEY.
-func NewS3Store(location, accessKey, secretKey string) (S3Store, error) {
+func NewS3Store(location string, s3Creds *credentials.Credentials, region string) (S3Store, error) {
 	s := S3Store{Location: location}
 	u, err := url.Parse(location)
 	if err != nil {
@@ -50,7 +51,7 @@ func NewS3Store(location, accessKey, secretKey string) (S3Store, error) {
 		s.prefix += "/"
 	}
 
-	s.client, err = minio.New(u.Host, accessKey, secretKey, useSSL)
+	s.client, err = minio.NewWithCredentials(u.Host, s3Creds, useSSL, region)
 	if err != nil {
 		return s, errors.Wrap(err, location)
 	}


### PR DESCRIPTION
## What is being added?
We need to access S3 stores using [aws temporary credentials ](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html) as opposed to static  access and secret keys. Temp credentials are a more secure way of handling access to S3 since credentials are valid for a short window of time and they need to be refreshed periodically by other services (i.e. [AWS STS assume role](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) or [AWS SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/automation-permissions.html)).

Temp credentials are read from a [standard aws credentials file](https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html) which is specified desync's config file. 

This change is backwards compatible, so the users now have the option to specify their credentials directly in the config file or point to a specific profile inside the aws creds file. If a profile is not specified, the [default] profile is used.

Additionally, users can now specify an aws region explicitly. Providing the region explicitly to minio improves its performance, according to [minio's documentation](https://github.com/minio/minio-go/blob/b72bb4bde10032d4e9d3e3175b79ddcdc3efdd85/api.go#L174). If the region is not specified, an empty string is passed downstream (current behavior).

Lastly, the precedence for credential resolution is: first, env variables, then access-key/secret-key in the config file, and aws-credentials-file last. 

example:

~/.config/desync/config.json
```
{
  "http-timeout": 60000000000,
  "http-error-retry": 0,
  "s3-credentials": {
       "http://localhost": {
           "access-key": "MYACCESSKEY",
           "secret-key": "MYSECRETKEY"
       },
       "https://127.0.0.1:9000": {
           "aws-credentials-file": "/Users/user/.aws/credentials",
       },
       "https://127.0.0.1:8000": {
           "aws-credentials-file": "/Users/user/.aws/credentials",
           "aws-profile": "profile_static"
       },
       "https://s3.us-west-2.amazonaws.com": {
           "aws-credentials-file": "/Users/user/.aws/credentials",
           "aws-region": "us-west-2",
           "aws-profile": "profile_refreshable"
       }
  }
}
```

~/.aws/credentials
```
[default]
aws_access_key_id = DEFAULT_PROFILE_KEY
aws_secret_access_key = DEFAULT_PROFILE_SECRET

[profile_static]
aws_access_key_id = OTHERACCESSKEY
aws_secret_access_key = OTHERSECRETKEY

[profile_refreshable]
aws_access_key_id = PROFILE_REFRESHABLE_KEY
aws_secret_access_key = PROFILE_REFRESHABLE_SECRET
aws_session_token = PROFILE_REFRESHABLE_TOKEN
```

## Testing done 
* Added unit tests for new code
* Tested for backwards compatibility 
* Tested new feature with refreshable credentials

## TODO
* When credentials are invalid, the error returned is that the chunk doesn't exist. Ideally we want to see that the chunk could not be retrieved due to credentials being invalid. Will submit that as a bug fix in a separate PR at some other point.