### PR TITLE
Report correct error messages when S3 credentials are invalid

### DIFF
--- a/s3.go
+++ b/s3.go
@@ -72,8 +72,10 @@ func (s S3Store) GetChunk(id ChunkID) ([]byte, error) {
 		switch e.Code {
 		case "NoSuchBucket":
 			err = fmt.Errorf("bucket '%s' does not exist", s.bucket)
-		default: // Without ListBucket perms in AWS, we get Permission Denied for a missing chunk, not 404
+		case "NoSuchKey":
 			err = ChunkMissing{ID: id}
+		default: // Without ListBucket perms in AWS, we get Permission Denied for a missing chunk, not 404
+			err = errors.Wrap(err, fmt.Sprintf("chunk %s could not be retrieved from s3 store", id))
 		}
 	}
 	return b, err


### PR DESCRIPTION
This fixes [#43](https://github.com/folbricht/desync/issues/43).