### PR TITLE
Add support to store and retrieve index files from remote (and local)…

### DIFF
--- a/cmd/desync/cache.go
+++ b/cmd/desync/cache.go
@@ -55,10 +55,17 @@ func cache(ctx context.Context, args []string) error {
 		return errors.New("-clientKey and -clientCert options need to be provided together.")
 	}
 
+	// Parse the store locations, open the stores and add a cache is requested
+	opts := storeOptions{
+		n:          n,
+		clientCert: clientCert,
+		clientKey:  clientKey,
+	}
+
 	// Read the input files and merge all chunk IDs in a map to de-dup them
 	idm := make(map[desync.ChunkID]struct{})
 	for _, name := range flags.Args() {
-		c, err := readCaibxFile(name)
+		c, err := readCaibxFile(name, opts)
 		if err != nil {
 			return err
 		}
@@ -73,12 +80,6 @@ func cache(ctx context.Context, args []string) error {
 		ids = append(ids, id)
 	}
 
-	// Parse the store locations, open the stores and add a cache is requested
-	opts := storeOptions{
-		n:          n,
-		clientCert: clientCert,
-		clientKey:  clientKey,
-	}
 	s, err := multiStore(opts, storeLocations.list...)
 	if err != nil {
 		return err

--- a/cmd/desync/cat.go
+++ b/cmd/desync/cat.go
@@ -94,7 +94,7 @@ func cat(ctx context.Context, args []string) error {
 	defer s.Close()
 
 	// Read the input
-	c, err := readCaibxFile(inFile)
+	c, err := readCaibxFile(inFile, opts)
 	if err != nil {
 		return err
 	}

--- a/cmd/desync/chop.go
+++ b/cmd/desync/chop.go
@@ -19,6 +19,8 @@ func chop(ctx context.Context, args []string) error {
 	var (
 		storeLocation string
 		n             int
+		clientCert    string
+		clientKey     string
 	)
 	flags := flag.NewFlagSet("chop", flag.ExitOnError)
 	flags.Usage = func() {
@@ -27,6 +29,8 @@ func chop(ctx context.Context, args []string) error {
 	}
 	flags.StringVar(&storeLocation, "s", "", "Local casync store location")
 	flags.IntVar(&n, "n", 10, "number of goroutines")
+	flags.StringVar(&clientCert, "clientCert", "", "Path to Client Certificate for TLS authentication")
+	flags.StringVar(&clientKey, "clientKey", "", "Path to Client Key for TLS authentication")
 	flags.Parse(args)
 
 	if flags.NArg() < 2 {
@@ -35,18 +39,30 @@ func chop(ctx context.Context, args []string) error {
 	if flags.NArg() > 2 {
 		return errors.New("Too many arguments. See -h for help.")
 	}
+
+	if clientKey != "" && clientCert == "" || clientCert != "" && clientKey == "" {
+		return errors.New("-clientKey and -clientCert options need to be provided together.")
+	}
+
 	indexFile := flags.Arg(0)
 	dataFile := flags.Arg(1)
 
+	// Parse the store locations, open the stores and add a cache is requested
+	opts := storeOptions{
+		n:          n,
+		clientCert: clientCert,
+		clientKey:  clientKey,
+	}
+
 	// Open the target store
-	s, err := WritableStore(storeLocation, storeOptions{n: n})
+	s, err := WritableStore(storeLocation, opts)
 	if err != nil {
 		return err
 	}
 	defer s.Close()
 
 	// Read the input
-	c, err := readCaibxFile(indexFile)
+	c, err := readCaibxFile(indexFile, opts)
 	if err != nil {
 		return err
 	}

--- a/cmd/desync/chunkserver.go
+++ b/cmd/desync/chunkserver.go
@@ -1,0 +1,7 @@
+package main
+
+import "context"
+
+func chunkServer(ctx context.Context, args []string) error {
+	return server(ctx, ChunkServer, args)
+}

--- a/cmd/desync/extract.go
+++ b/cmd/desync/extract.go
@@ -81,7 +81,7 @@ func extract(ctx context.Context, args []string) error {
 	defer s.Close()
 
 	// Read the input
-	idx, err := readCaibxFile(inFile)
+	idx, err := readCaibxFile(inFile, opts)
 	if err != nil {
 		return err
 	}

--- a/cmd/desync/indexserver.go
+++ b/cmd/desync/indexserver.go
@@ -1,0 +1,7 @@
+package main
+
+import "context"
+
+func indexServer(ctx context.Context, args []string) error {
+	return server(ctx, IndexServer, args)
+}

--- a/cmd/desync/info.go
+++ b/cmd/desync/info.go
@@ -22,6 +22,8 @@ store.`
 func info(ctx context.Context, args []string) error {
 	var (
 		n              int
+		clientCert     string
+		clientKey      string
 		storeLocations = new(multiArg)
 		showJSON       bool
 		results        struct {
@@ -38,6 +40,8 @@ func info(ctx context.Context, args []string) error {
 	}
 	flags.Var(storeLocations, "s", "store location, can be multiples")
 	flags.IntVar(&n, "n", 10, "number of goroutines")
+	flags.StringVar(&clientCert, "clientCert", "", "Path to Client Certificate for TLS authentication")
+	flags.StringVar(&clientKey, "clientKey", "", "Path to Client Key for TLS authentication")
 	flags.BoolVar(&showJSON, "j", false, "show information in JSON format")
 	flags.Parse(args)
 
@@ -48,8 +52,18 @@ func info(ctx context.Context, args []string) error {
 		return errors.New("Too many arguments. See -h for help.")
 	}
 
+	if clientKey != "" && clientCert == "" || clientCert != "" && clientKey == "" {
+		return errors.New("-clientKey and -clientCert options need to be provided together.")
+	}
+
+	opts := storeOptions{
+		n:          n,
+		clientCert: clientCert,
+		clientKey:  clientKey,
+	}
+
 	// Read the index
-	c, err := readCaibxFile(flags.Arg(0))
+	c, err := readCaibxFile(flags.Arg(0), opts)
 	if err != nil {
 		return err
 	}

--- a/cmd/desync/list.go
+++ b/cmd/desync/list.go
@@ -10,14 +10,21 @@ import (
 
 const listUsage = `desync list-chunks <caibx>
 
-Reads the index file from disk and prints the list of chunk IDs in it.`
+Reads the index file and prints the list of chunk IDs in it.`
 
 func list(ctx context.Context, args []string) error {
+	var (
+		clientCert string
+		clientKey  string
+	)
+
 	flags := flag.NewFlagSet("list-chunks", flag.ExitOnError)
 	flags.Usage = func() {
 		fmt.Fprintln(os.Stderr, listUsage)
 		flags.PrintDefaults()
 	}
+	flags.StringVar(&clientCert, "clientCert", "", "Path to Client Certificate for TLS authentication")
+	flags.StringVar(&clientKey, "clientKey", "", "Path to Client Key for TLS authentication")
 	flags.Parse(args)
 
 	if flags.NArg() < 1 {
@@ -27,8 +34,18 @@ func list(ctx context.Context, args []string) error {
 		return errors.New("Too many arguments. See -h for help.")
 	}
 
+	if clientKey != "" && clientCert == "" || clientCert != "" && clientKey == "" {
+		return errors.New("-clientKey and -clientCert options need to be provided together.")
+	}
+
+	// Parse the store locations, open the stores and add a cache is requested
+	opts := storeOptions{
+		clientCert: clientCert,
+		clientKey:  clientKey,
+	}
+
 	// Read the input
-	c, err := readCaibxFile(flags.Arg(0))
+	c, err := readCaibxFile(flags.Arg(0), opts)
 	if err != nil {
 		return err
 	}

--- a/cmd/desync/main.go
+++ b/cmd/desync/main.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-
-	"github.com/folbricht/desync"
 )
 
 const usage = `desync <command> [options]
@@ -76,7 +74,8 @@ func main() {
 		"tar":          tar,
 		"untar":        untar,
 		"prune":        prune,
-		"chunk-server": server,
+		"chunk-server": chunkServer,
+		"index-server": indexServer,
 		"chunk":        chunkCmd,
 		"make":         makeCmd,
 		"mount-index":  mountIdx,
@@ -99,15 +98,6 @@ func help(ctx context.Context, args []string) error {
 	flag.Usage()
 	os.Exit(1)
 	return nil
-}
-
-func readCaibxFile(name string) (c desync.Index, err error) {
-	f, err := os.Open(name)
-	if err != nil {
-		return
-	}
-	defer f.Close()
-	return desync.IndexFromReader(f)
 }
 
 func die(err error) {

--- a/cmd/desync/mount-index.go
+++ b/cmd/desync/mount-index.go
@@ -75,7 +75,7 @@ func mountIdx(ctx context.Context, args []string) error {
 	defer s.Close()
 
 	// Read the input
-	idx, err := readCaibxFile(indexFile)
+	idx, err := readCaibxFile(indexFile, opts)
 	if err != nil {
 		return err
 	}

--- a/cmd/desync/prune.go
+++ b/cmd/desync/prune.go
@@ -19,6 +19,8 @@ func prune(ctx context.Context, args []string) error {
 	var (
 		storeLocation string
 		accepted      bool
+		clientCert    string
+		clientKey     string
 	)
 	flags := flag.NewFlagSet("prune", flag.ExitOnError)
 	flags.Usage = func() {
@@ -28,6 +30,8 @@ func prune(ctx context.Context, args []string) error {
 
 	flags.StringVar(&storeLocation, "s", "", "local or s3 store")
 	flags.BoolVar(&accepted, "y", false, "do not ask for confirmation")
+	flags.StringVar(&clientCert, "clientCert", "", "Path to Client Certificate for TLS authentication")
+	flags.StringVar(&clientKey, "clientKey", "", "Path to Client Key for TLS authentication")
 	flags.Parse(args)
 
 	if flags.NArg() < 1 {
@@ -36,6 +40,16 @@ func prune(ctx context.Context, args []string) error {
 
 	if storeLocation == "" {
 		return errors.New("No store provided.")
+	}
+
+	if clientKey != "" && clientCert == "" || clientCert != "" && clientKey == "" {
+		return errors.New("-clientKey and -clientCert options need to be provided together.")
+	}
+
+	// Parse the store locations, open the stores and add a cache is requested
+	opts := storeOptions{
+		clientCert: clientCert,
+		clientKey:  clientKey,
 	}
 
 	// Open the target store
@@ -54,7 +68,7 @@ func prune(ctx context.Context, args []string) error {
 	// Read the input files and merge all chunk IDs in a map to de-dup them
 	ids := make(map[desync.ChunkID]struct{})
 	for _, name := range flags.Args() {
-		c, err := readCaibxFile(name)
+		c, err := readCaibxFile(name, opts)
 		if err != nil {
 			return err
 		}

--- a/cmd/desync/server.go
+++ b/cmd/desync/server.go
@@ -29,7 +29,7 @@ reading from multiple local or remote stores as well as a local cache. If
 enables writing to this store, but this is only allowed when just one upstream
 chunk store is provided.`
 
-	indexServerUsage = `desync chunk-server [options]
+	indexServerUsage = `desync index-server [options]
 
 Starts an HTTP index server that can be used as remote store. It supports
 reading from a single local or remote store.

--- a/cmd/desync/server.go
+++ b/cmd/desync/server.go
@@ -11,7 +11,15 @@ import (
 	"github.com/folbricht/desync"
 )
 
-const serverUsage = `desync chunk-server [options]
+type ServerType int
+
+const (
+	IndexServer = iota
+	ChunkServer
+)
+
+const (
+	chunkServerUsage = `desync chunk-server [options]
 
 Starts an HTTP chunk server that can be used as remote store. It supports
 reading from multiple local or remote stores as well as a local cache. If
@@ -19,7 +27,15 @@ reading from multiple local or remote stores as well as a local cache. If
 enables writing to this store, but this is only allowed when just one upstream
 chunk store is provided.`
 
-func server(ctx context.Context, args []string) error {
+	indexServerUsage = `desync chunk-server [options]
+
+Starts an HTTP index server that can be used as remote store. It supports
+reading from a single local or remote store.
+If -cert and -key are provided, the server will serve over HTTPS. The -w option
+enables writing to this store.`
+)
+
+func server(ctx context.Context, serverType ServerType, args []string) error {
 	var (
 		cacheLocation   string
 		n               int
@@ -32,12 +48,25 @@ func server(ctx context.Context, args []string) error {
 	)
 	flags := flag.NewFlagSet("server", flag.ExitOnError)
 	flags.Usage = func() {
-		fmt.Fprintln(os.Stderr, serverUsage)
+		if serverType == ChunkServer {
+			fmt.Fprintln(os.Stderr, chunkServerUsage)
+		}
+
+		if serverType == IndexServer {
+			fmt.Fprintln(os.Stderr, indexServerUsage)
+		}
 		flags.PrintDefaults()
 	}
 
-	flags.Var(storeLocations, "s", "casync store location, can be multiples")
-	flags.StringVar(&cacheLocation, "c", "", "use local store as cache")
+	if serverType == ChunkServer {
+		flags.Var(storeLocations, "s", "casync store location, can be multiples")
+		flags.StringVar(&cacheLocation, "c", "", "use local store as cache")
+	}
+
+	if serverType == IndexServer {
+		flags.Var(storeLocations, "s", "index store location")
+	}
+
 	flags.IntVar(&n, "n", 10, "number of goroutines, only used for remote SSH stores")
 	flags.BoolVar(&desync.TrustInsecure, "t", false, "trust invalid certificates")
 	flags.Var(listenAddresses, "l", "listen address, can be multiples (default :http)")
@@ -66,7 +95,7 @@ func server(ctx context.Context, args []string) error {
 
 	// Checkout the store
 	if len(storeLocations.list) == 0 {
-		return errors.New("No casync store provided. See -h for help.")
+		return errors.New("No store provided. See -h for help.")
 	}
 
 	// When supporting writing, only one upstream store is possible
@@ -76,25 +105,28 @@ func server(ctx context.Context, args []string) error {
 
 	// Parse the store locations, open the stores and add a cache is requested
 	var (
-		s    desync.Store
-		err  error
 		opts = storeOptions{
 			n:          n,
 			clientCert: clientCert,
 			clientKey:  clientKey,
 		}
 	)
-	if writable {
-		s, err = WritableStore(storeLocations.list[0], opts)
-	} else {
-		s, err = MultiStoreWithCache(opts, cacheLocation, storeLocations.list...)
-	}
-	if err != nil {
-		return err
-	}
-	defer s.Close()
 
-	http.Handle("/", desync.NewHTTPHandler(s, writable))
+	if serverType == ChunkServer {
+		s, err := handleChunkStore(writable, storeLocations, opts, cacheLocation)
+		if err != nil {
+			return err
+		}
+		defer s.Close()
+	}
+
+	if serverType == IndexServer {
+		is, err := handleIndexStore(writable, storeLocations, opts, cacheLocation)
+		if err != nil {
+			return err
+		}
+		defer is.Close()
+	}
 
 	// Run the server(s) in a goroutine, and use the main goroutine to wait for
 	// a signal or a failing server (ctx gets cancelled in that case)
@@ -117,4 +149,40 @@ func server(ctx context.Context, args []string) error {
 	// wait for either INT/TERM or an issue with the server
 	<-ctx.Done()
 	return nil
+}
+
+func handleChunkStore(writable bool, storeLocations *multiArg, opts storeOptions, cacheLocation string) (desync.Store, error) {
+	var (
+		s   desync.Store
+		err error
+	)
+	if writable {
+		s, err = WritableStore(storeLocations.list[0], opts)
+	} else {
+		s, err = MultiStoreWithCache(opts, cacheLocation, storeLocations.list...)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	http.Handle("/", desync.NewHTTPHandler(s, writable))
+	return s, err
+}
+
+func handleIndexStore(writable bool, storeLocations *multiArg, opts storeOptions, cacheLocation string) (desync.IndexStore, error) {
+	var (
+		s   desync.IndexStore
+		err error
+	)
+	if writable {
+		s, _, err = writableIndexStore(storeLocations.list[0], opts)
+	} else {
+		s, _, err = indexStoreFromLocation(storeLocations.list[0], opts)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	http.Handle("/", desync.NewHTTPIndexHandler(s, writable))
+	return s, err
 }

--- a/cmd/desync/server.go
+++ b/cmd/desync/server.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"os"
 
+	"strings"
+
 	"github.com/folbricht/desync"
 )
 
@@ -174,10 +176,17 @@ func handleIndexStore(writable bool, storeLocations *multiArg, opts storeOptions
 		s   desync.IndexStore
 		err error
 	)
+
+	// Making sure we have a "/" at the end
+	loc := storeLocations.list[0]
+	if !strings.HasSuffix(loc, "/") {
+		loc = loc + "/"
+	}
+
 	if writable {
-		s, _, err = writableIndexStore(storeLocations.list[0], opts)
+		s, _, err = writableIndexStore(loc, opts)
 	} else {
-		s, _, err = indexStoreFromLocation(storeLocations.list[0], opts)
+		s, _, err = indexStoreFromLocation(loc, opts)
 	}
 	if err != nil {
 		return nil, err

--- a/cmd/desync/store.go
+++ b/cmd/desync/store.go
@@ -134,11 +134,7 @@ func readCaibxFile(location string, opts storeOptions) (c desync.Index, err erro
 	}
 	defer is.Close()
 
-	c, err = is.GetIndex(indexName)
-	if err != nil {
-		return c, err
-	}
-	return c, err
+	return is.GetIndex(indexName)
 }
 
 func storeCaibxFile(idx desync.Index, location string, opts storeOptions) error {

--- a/cmd/desync/store.go
+++ b/cmd/desync/store.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"net/url"
 
+	"path"
+
 	"github.com/folbricht/desync"
+	"github.com/pkg/errors"
 )
 
 // storeOptions are used to pass additional options to store initalization
@@ -109,7 +112,7 @@ func storeFromLocation(location string, opts storeOptions) (desync.Store, error)
 		s = h
 	case "s3+http", "s3+https":
 		s3Creds, region := cfg.GetS3CredentialsFor(loc)
-		s, err = desync.NewS3Store(location, s3Creds, region)
+		s, err = desync.NewS3Store(loc, s3Creds, region)
 		if err != nil {
 			return nil, err
 		}
@@ -122,4 +125,90 @@ func storeFromLocation(location string, opts storeOptions) (desync.Store, error)
 		return nil, fmt.Errorf("Unsupported store access scheme %s", loc.Scheme)
 	}
 	return s, nil
+}
+
+func readCaibxFile(location string, opts storeOptions) (c desync.Index, err error) {
+	is, indexName, err := indexStoreFromLocation(location, opts)
+	if err != nil {
+		return c, err
+	}
+	defer is.Close()
+
+	c, err = is.GetIndex(indexName)
+	if err != nil {
+		return c, err
+	}
+	return c, err
+}
+
+func storeCaibxFile(idx desync.Index, location string, opts storeOptions) error {
+	is, indexName, err := writableIndexStore(location, opts)
+	if err != nil {
+		return err
+	}
+	defer is.Close()
+	return is.StoreIndex(indexName, idx)
+}
+
+// WritableIndexStore is used to parse a store location from the command line for
+// commands that expect to write indexes, such as make or tar. It determines
+// which type of writable store is needed, instantiates and returns a
+// single desync.IndexWriteStore.
+func writableIndexStore(location string, opts storeOptions) (desync.IndexWriteStore, string, error) {
+	s, indexName, err := indexStoreFromLocation(location, opts)
+	if err != nil {
+		return nil, indexName, err
+	}
+	store, ok := s.(desync.IndexWriteStore)
+	if !ok {
+		return nil, indexName, fmt.Errorf("store '%s' does not support writing", location)
+	}
+	return store, indexName, nil
+}
+
+// Parse a single store URL or path and return an initialized instance of it
+func indexStoreFromLocation(location string, opts storeOptions) (desync.IndexStore, string, error) {
+	loc, err := url.Parse(location)
+	if err != nil {
+		return nil, "", fmt.Errorf("Unable to parse store location %s : %s", location, err)
+	}
+
+	indexName := path.Base(loc.Path)
+	// Remove file name from url path
+	p := *loc
+	p.Path = path.Dir(p.Path)
+
+	var s desync.IndexStore
+	switch loc.Scheme {
+	case "ssh":
+		return nil, "", errors.New("Index storage is not supported by ssh remote stores")
+	case "sftp":
+		s, err = desync.NewSFTPIndexStore(loc)
+		if err != nil {
+			return nil, "", err
+		}
+	case "http", "https":
+		h, err := desync.NewRemoteHTTPIndexStore(&p, opts.n, opts.clientCert, opts.clientKey)
+		if err != nil {
+			return nil, "", err
+		}
+		h.SetTimeout(cfg.HTTPTimeout)
+		h.SetErrorRetry(cfg.HTTPErrorRetry)
+		s = h
+	case "s3+http", "s3+https":
+		s3Creds, region := cfg.GetS3CredentialsFor(&p)
+		s, err = desync.NewS3IndexStore(&p, s3Creds, region)
+		if err != nil {
+			return nil, "", err
+		}
+	case "":
+
+		s, err = desync.NewLocaIndexlStore(p.String())
+		if err != nil {
+			return nil, "", err
+		}
+	default:
+		return nil, "", fmt.Errorf("Unsupported store access scheme %s", loc.Scheme)
+	}
+	return s, indexName, nil
 }

--- a/cmd/desync/tar.go
+++ b/cmd/desync/tar.go
@@ -22,6 +22,8 @@ func tar(ctx context.Context, args []string) error {
 	var (
 		makeIndex     bool
 		n             int
+		clientCert    string
+		clientKey     string
 		storeLocation string
 		chunkSize     string
 	)
@@ -33,6 +35,8 @@ func tar(ctx context.Context, args []string) error {
 	flags.BoolVar(&makeIndex, "i", false, "Create index file (caidx), not catar")
 	flags.StringVar(&storeLocation, "s", "", "Local or S3 casync store location (with -i)")
 	flags.IntVar(&n, "n", 10, "number of goroutines (with -i)")
+	flags.StringVar(&clientCert, "clientCert", "", "Path to Client Certificate for TLS authentication")
+	flags.StringVar(&clientKey, "clientKey", "", "Path to Client Key for TLS authentication")
 	flags.StringVar(&chunkSize, "m", "16:64:256", "Min/Avg/Max chunk size in kb (with -i)")
 	flags.Parse(args)
 
@@ -45,19 +49,27 @@ func tar(ctx context.Context, args []string) error {
 	if makeIndex && storeLocation == "" {
 		return errors.New("-i requires a store (-s <location>)")
 	}
+	if clientKey != "" && clientCert == "" || clientCert != "" && clientKey == "" {
+		return errors.New("-clientKey and -clientCert options need to be provided together.")
+	}
 
 	output := flags.Arg(0)
 	sourceDir := flags.Arg(1)
 
-	f, err := os.Create(output)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
 	// Just make the catar and stop if that's all that was required
 	if !makeIndex {
+		f, err := os.Create(output)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
 		return desync.Tar(ctx, f, sourceDir)
+	}
+
+	sOpts := storeOptions{
+		n:          n,
+		clientCert: clientCert,
+		clientKey:  clientKey,
 	}
 
 	// An index is requested, so stream the output of the tar command directly
@@ -65,7 +77,7 @@ func tar(ctx context.Context, args []string) error {
 	r, w := io.Pipe()
 
 	// Open the target store
-	s, err := WritableStore(storeLocation, storeOptions{n: n})
+	s, err := WritableStore(storeLocation, sOpts)
 	if err != nil {
 		return err
 	}
@@ -100,12 +112,6 @@ func tar(ctx context.Context, args []string) error {
 		return tarErr
 	}
 
-	// Write the index to file
-	i, err := os.Create(output)
-	if err != nil {
-		return err
-	}
-	defer i.Close()
-	_, err = index.WriteTo(i)
-	return err
+	// Write the index
+	return storeCaibxFile(index, output, sOpts)
 }

--- a/cmd/desync/untar.go
+++ b/cmd/desync/untar.go
@@ -58,24 +58,16 @@ func untar(ctx context.Context, args []string) error {
 	input := flags.Arg(0)
 	targetDir := flags.Arg(1)
 
-	f, err := os.Open(input)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
 	// If we got a catar file unpack that and exit
 	if !readIndex {
+		f, err := os.Open(input)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
 		return desync.UnTar(ctx, f, targetDir, opts)
 	}
 
-	// Apparently the input must be an index, read it whole
-	index, err := desync.IndexFromReader(f)
-	if err != nil {
-		return err
-	}
-
-	// Parse the store locations, open the stores and add a cache is requested
 	sOpts := storeOptions{
 		n:          n,
 		clientCert: clientCert,
@@ -86,6 +78,12 @@ func untar(ctx context.Context, args []string) error {
 		return err
 	}
 	defer s.Close()
+
+	// Apparently the input must be an index, read it whole
+	index, err := readCaibxFile(input, sOpts)
+	if err != nil {
+		return err
+	}
 
 	return desync.UnTarIndex(ctx, targetDir, index, s, n, opts)
 }

--- a/cmd/desync/upgrade-s3.go
+++ b/cmd/desync/upgrade-s3.go
@@ -44,7 +44,7 @@ func upgradeS3(ctx context.Context, args []string) error {
 		return err
 	}
 	s3Creds, region := cfg.GetS3CredentialsFor(loc)
-	s, err := desync.NewS3Store(storeLocation, s3Creds, region)
+	s, err := desync.NewS3Store(loc, s3Creds, region)
 	if err != nil {
 		return err
 	}

--- a/cmd/desync/verifyindex.go
+++ b/cmd/desync/verifyindex.go
@@ -17,7 +17,9 @@ Verifies an index file matches the content of a blob.
 
 func verifyIndex(ctx context.Context, args []string) error {
 	var (
-		n int
+		n          int
+		clientCert string
+		clientKey  string
 	)
 	flags := flag.NewFlagSet("verify-index", flag.ExitOnError)
 	flags.Usage = func() {
@@ -25,6 +27,8 @@ func verifyIndex(ctx context.Context, args []string) error {
 		flags.PrintDefaults()
 	}
 	flags.IntVar(&n, "n", 10, "number of goroutines")
+	flags.StringVar(&clientCert, "clientCert", "", "Path to Client Certificate for TLS authentication")
+	flags.StringVar(&clientKey, "clientKey", "", "Path to Client Key for TLS authentication")
 	flags.Parse(args)
 
 	if flags.NArg() < 2 {
@@ -36,8 +40,15 @@ func verifyIndex(ctx context.Context, args []string) error {
 	indexFile := flags.Arg(0)
 	dataFile := flags.Arg(1)
 
+	// Parse the store locations, open the stores and add a cache is requested
+	opts := storeOptions{
+		n:          n,
+		clientCert: clientCert,
+		clientKey:  clientKey,
+	}
+
 	// Read the input
-	idx, err := readCaibxFile(indexFile)
+	idx, err := readCaibxFile(indexFile, opts)
 	if err != nil {
 		return err
 	}

--- a/errors.go
+++ b/errors.go
@@ -7,8 +7,17 @@ type ChunkMissing struct {
 	ID ChunkID
 }
 
+// NoSuchObject is returned by a store that can't find a requested object
+type NoSuchObject struct {
+	location string
+}
+
 func (e ChunkMissing) Error() string {
 	return fmt.Sprintf("chunk %s missing from store", e.ID)
+}
+
+func (e NoSuchObject) Error() string {
+	return fmt.Sprintf("object %s missing from store", e.location)
 }
 
 // ChunkInvalid means the hash of the chunk content doesn't match its ID

--- a/httphandler.go
+++ b/httphandler.go
@@ -40,7 +40,7 @@ func (h HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.put(sid, w, r)
 	default:
 		w.WriteHeader(http.StatusMethodNotAllowed)
-		w.Write([]byte("only GET is supported"))
+		w.Write([]byte("only GET, PUT and HEAD are supported"))
 	}
 }
 

--- a/httphandler.go
+++ b/httphandler.go
@@ -11,24 +11,16 @@ import (
 )
 
 type HTTPHandler struct {
-	s        Store
-	writable bool
+	HTTPHandlerBase
+	s Store
 }
 
 func NewHTTPHandler(s Store, writable bool) http.Handler {
-	return HTTPHandler{s, writable}
+	return HTTPHandler{HTTPHandlerBase{"chunk", writable}, s}
 }
 
 func (h HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	sid := strings.TrimSuffix(filepath.Base(r.URL.Path), ".cacnk")
-
-	// Parse the ID and verify the format
-	id, err := ChunkIDFromString(sid)
-	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte("invalid chunk id"))
-		return
-	}
 
 	// We only really need the ID, but to maintain compatibility with stores
 	// that are simply shared with HTTP, we expect /prefix/chunkID. Make sure
@@ -41,49 +33,60 @@ func (h HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case "GET":
-		h.get(id, w)
+		h.get(sid, w)
 	case "HEAD":
-		h.head(id, w)
+		h.head(sid, w)
 	case "PUT":
-		h.put(id, w, r)
+		h.put(sid, w, r)
 	default:
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		w.Write([]byte("only GET is supported"))
 	}
 }
 
-func (h HTTPHandler) get(id ChunkID, w http.ResponseWriter) {
-	b, err := h.s.GetChunk(id)
-	switch err.(type) {
-	case nil:
-		w.WriteHeader(http.StatusOK)
-		w.Write(b)
-	case ChunkMissing:
-		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprintf(w, "chunk %s not found", id)
-	default:
-		w.WriteHeader(http.StatusInternalServerError)
-		msg := fmt.Sprintf("failed to retrieve chunk %s:%s", id, err)
-		fmt.Fprintln(w, msg)
-		fmt.Fprintln(os.Stderr, msg)
+func (h HTTPHandler) parseChunkId(sid string, w http.ResponseWriter) (ChunkID, error) {
+	// Parse the ID and verify the format
+	cid, err := ChunkIDFromString(sid)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("invalid chunk id"))
+		return ChunkID{}, err
 	}
+	return cid, err
 }
 
-func (h HTTPHandler) head(id ChunkID, w http.ResponseWriter) {
-	if h.s.HasChunk(id) {
+func (h HTTPHandler) get(sid string, w http.ResponseWriter) {
+	cid, err := h.parseChunkId(sid, w)
+	if err != nil {
+		return
+	}
+	b, err := h.s.GetChunk(cid)
+	h.HTTPHandlerBase.get(sid, b, err, w)
+}
+
+func (h HTTPHandler) head(sid string, w http.ResponseWriter) {
+	cid, err := h.parseChunkId(sid, w)
+	if err != nil {
+		return
+	}
+	if h.s.HasChunk(cid) {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
 	w.WriteHeader(http.StatusNotFound)
 }
 
-func (h HTTPHandler) put(id ChunkID, w http.ResponseWriter, r *http.Request) {
-	// Make sure writing was enabled for this server
-	if !h.writable {
-		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(w, "writing to upstream chunk store '%s' is not enabled\n", h.s)
+func (h HTTPHandler) put(sid string, w http.ResponseWriter, r *http.Request) {
+	err := h.HTTPHandlerBase.validateWritable(h.s.String(), w, r)
+	if err != nil {
 		return
 	}
+
+	cid, err := h.parseChunkId(sid, w)
+	if err != nil {
+		return
+	}
+
 	// The upstream store needs to support writing as well
 	s, ok := h.s.(WriteStore)
 	if !ok {
@@ -91,6 +94,7 @@ func (h HTTPHandler) put(id ChunkID, w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "upstream chunk store '%s' does not support writing\n", h.s)
 		return
 	}
+
 	// Read the chunk into memory
 	b := new(bytes.Buffer)
 	if _, err := io.Copy(b, r.Body); err != nil {
@@ -98,8 +102,9 @@ func (h HTTPHandler) put(id ChunkID, w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, err)
 		return
 	}
+
 	// Store it upstream
-	if err := s.StoreChunk(id, b.Bytes()); err != nil {
+	if err := s.StoreChunk(cid, b.Bytes()); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintln(w, err)
 		return

--- a/httphandlerbase.go
+++ b/httphandlerbase.go
@@ -1,0 +1,42 @@
+package desync
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+type HTTPHandlerBase struct {
+	handlerType string
+	writable    bool
+}
+
+func (h HTTPHandlerBase) get(id string, b []byte, err error, w http.ResponseWriter) {
+	switch err.(type) {
+	case nil:
+		w.WriteHeader(http.StatusOK)
+		w.Write(b)
+	case ChunkMissing:
+	case NoSuchObject:
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprintf(w, "%s %s not found", h.handlerType, id)
+	default:
+		w.WriteHeader(http.StatusInternalServerError)
+		msg := fmt.Sprintf("failed to retrieve %s %s:%s", h.handlerType, id, err)
+		fmt.Fprintln(w, msg)
+		fmt.Fprintln(os.Stderr, msg)
+	}
+}
+
+func (h HTTPHandlerBase) validateWritable(storeName string, w http.ResponseWriter, r *http.Request) error {
+	// Make sure writing was enabled for this server
+	if !h.writable {
+		w.WriteHeader(http.StatusBadRequest)
+		msg := fmt.Sprintf("writing to upstream %s store '%s' is not enabled", h.handlerType, storeName)
+		fmt.Fprintln(w, msg)
+		return errors.New(msg)
+	}
+	return nil
+}

--- a/httpindexhandler.go
+++ b/httpindexhandler.go
@@ -29,7 +29,7 @@ func (h HTTPIndexHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.put(indexName, w, r)
 	default:
 		w.WriteHeader(http.StatusMethodNotAllowed)
-		w.Write([]byte("only GET is supported"))
+		w.Write([]byte("only GET, PUT and HEAD are supported"))
 	}
 }
 
@@ -47,7 +47,7 @@ func (h HTTPIndexHandler) get(indexName string, w http.ResponseWriter) {
 	b := new(bytes.Buffer)
 	_, err = b.ReadFrom(ir)
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
+		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintln(w, err)
 		return
 	}
@@ -82,6 +82,7 @@ func (h HTTPIndexHandler) put(indexName string, w http.ResponseWriter, r *http.R
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintln(w, err)
+		return
 	}
 
 	// Store it upstream

--- a/httpindexhandler.go
+++ b/httpindexhandler.go
@@ -1,0 +1,94 @@
+package desync
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+type HTTPIndexHandler struct {
+	HTTPHandlerBase
+	s IndexStore
+}
+
+func NewHTTPIndexHandler(s IndexStore, writable bool) http.Handler {
+	return HTTPIndexHandler{HTTPHandlerBase{"index", writable}, s}
+}
+
+func (h HTTPIndexHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	indexName := filepath.Base(r.URL.Path)
+
+	switch r.Method {
+	case "GET":
+		h.get(indexName, w)
+	case "HEAD":
+		h.head(indexName, w)
+	case "PUT":
+		h.put(indexName, w, r)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		w.Write([]byte("only GET is supported"))
+	}
+}
+
+func (h HTTPIndexHandler) get(indexName string, w http.ResponseWriter) {
+	ir, err := h.s.GetIndexReader(indexName)
+	if err != nil {
+		if os.IsNotExist(err) {
+			w.WriteHeader(http.StatusNotFound)
+		} else {
+			w.WriteHeader(http.StatusBadRequest)
+		}
+		fmt.Fprintln(w, err)
+		return
+	}
+	b := new(bytes.Buffer)
+	_, err = b.ReadFrom(ir)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintln(w, err)
+		return
+	}
+	h.HTTPHandlerBase.get(indexName, b.Bytes(), err, w)
+}
+
+func (h HTTPIndexHandler) head(indexName string, w http.ResponseWriter) {
+	_, err := h.s.GetIndexReader(indexName)
+	if err != nil {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	w.WriteHeader(http.StatusNotFound)
+}
+
+func (h HTTPIndexHandler) put(indexName string, w http.ResponseWriter, r *http.Request) {
+	err := h.HTTPHandlerBase.validateWritable(h.s.String(), w, r)
+	if err != nil {
+		return
+	}
+
+	// The upstream store needs to support writing as well
+	s, ok := h.s.(IndexWriteStore)
+	if !ok {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "upstream index store '%s' does not support writing\n", h.s)
+		return
+	}
+
+	// Read the chunk into memory
+	idx, err := IndexFromReader(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintln(w, err)
+	}
+
+	// Store it upstream
+	if err := s.StoreIndex(indexName, idx); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintln(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/index.go
+++ b/index.go
@@ -75,6 +75,10 @@ func IndexFromReader(r io.Reader) (c Index, err error) {
 	return
 }
 
+func (i *Index) Store(path string) (int64, error) {
+	return 0, nil
+}
+
 // WriteTo writes the index and chunk table into a stream
 func (i *Index) WriteTo(w io.Writer) (int64, error) {
 	index := FormatIndex{

--- a/localindex.go
+++ b/localindex.go
@@ -34,11 +34,7 @@ func NewLocaIndexlStore(path string) (LocalIndexStore, error) {
 
 // Get and Index Reader from a local store, returns an error if the specified index file does not exist.
 func (s LocalIndexStore) GetIndexReader(name string) (rdr io.ReadCloser, e error) {
-	f, err := os.Open(s.Path + name)
-	if err != nil {
-		return nil, err
-	}
-	return f, nil
+	return os.Open(s.Path + name)
 }
 
 // GetIndex returns an Index structure from the store

--- a/localindex.go
+++ b/localindex.go
@@ -1,0 +1,74 @@
+package desync
+
+import (
+	"os"
+	"strings"
+
+	"fmt"
+
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+// LocalStore index store
+type LocalIndexStore struct {
+	Path string
+}
+
+// NewLocalStore creates an instance of a local castore, it only checks presence
+// of the store
+func NewLocaIndexlStore(path string) (LocalIndexStore, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return LocalIndexStore{}, err
+	}
+	if !info.IsDir() {
+		return LocalIndexStore{}, fmt.Errorf("%s is not a directory", path)
+	}
+	if !strings.HasSuffix(path, "/") {
+		path = path + "/"
+	}
+	return LocalIndexStore{Path: path}, nil
+}
+
+// Get and Index Reader from a local store, returns an error if the specified index file does not exist.
+func (s LocalIndexStore) GetIndexReader(name string) (rdr io.ReadCloser, e error) {
+	f, err := os.Open(s.Path + name)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+// GetIndex returns an Index structure from the store
+func (s LocalIndexStore) GetIndex(name string) (i Index, e error) {
+	f, err := s.GetIndexReader(name)
+	if err != nil {
+		return i, nil
+	}
+	defer f.Close()
+	idx, err := IndexFromReader(f)
+	if os.IsNotExist(err) {
+		err = errors.Errorf("Index file does not exist: %v", err)
+	}
+	return idx, err
+}
+
+// GetIndex returns an Index structure from the store
+func (s LocalIndexStore) StoreIndex(name string, idx Index) error {
+	// Write the index to file
+	i, err := os.Create(s.Path + name)
+	if err != nil {
+		return err
+	}
+	defer i.Close()
+	_, err = idx.WriteTo(i)
+	return err
+}
+
+func (r LocalIndexStore) String() string {
+	return r.Path
+}
+
+func (s LocalIndexStore) Close() error { return nil }

--- a/remotehttpindex.go
+++ b/remotehttpindex.go
@@ -1,0 +1,52 @@
+package desync
+
+import (
+	"bytes"
+	"io"
+	"net/url"
+)
+
+// RemoteHTTP is a remote index store accessed via HTTP.
+type RemoteHTTPIndex struct {
+	*RemoteHTTPBase
+}
+
+// NewRemoteHTTPStore initializes a new store that pulls the specified index file via HTTP(S) from
+// a remote web server.
+func NewRemoteHTTPIndexStore(location *url.URL, n int, cert string, key string) (*RemoteHTTPIndex, error) {
+	b, err := NewRemoteHTTPStoreBase(location, n, cert, key)
+	if err != nil {
+		return nil, err
+	}
+	return &RemoteHTTPIndex{b}, nil
+}
+
+// Get and Index Reader from an HTTP store, returns an error if the specified index file does not exist.
+func (r RemoteHTTPIndex) GetIndexReader(name string) (rdr io.ReadCloser, e error) {
+	b, err := r.GetObject(name)
+	if err != nil {
+		return rdr, err
+	}
+	rc := &ClosingByteReader{bytes.NewReader(b)}
+	return rc, nil
+}
+
+// GetIndex returns an Index structure from the store
+func (r *RemoteHTTPIndex) GetIndex(name string) (i Index, e error) {
+	ir, err := r.GetIndexReader(name)
+	if err != nil {
+		return i, err
+	}
+	return IndexFromReader(ir)
+}
+
+// StoreChunk adds a new chunk to the store
+func (r *RemoteHTTPIndex) StoreIndex(name string, idx Index) error {
+	rdr, w := io.Pipe()
+
+	go func() {
+		defer w.Close()
+		idx.WriteTo(w)
+	}()
+	return r.StoreObject(name, rdr)
+}

--- a/remotehttpindex.go
+++ b/remotehttpindex.go
@@ -3,6 +3,7 @@ package desync
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 	"net/url"
 )
 
@@ -27,7 +28,7 @@ func (r RemoteHTTPIndex) GetIndexReader(name string) (rdr io.ReadCloser, e error
 	if err != nil {
 		return rdr, err
 	}
-	rc := &ClosingByteReader{bytes.NewReader(b)}
+	rc := ioutil.NopCloser(bytes.NewReader(b))
 	return rc, nil
 }
 

--- a/s3index.go
+++ b/s3index.go
@@ -1,0 +1,63 @@
+package desync
+
+import (
+	"io"
+
+	"path"
+
+	"net/url"
+
+	"github.com/minio/minio-go"
+	"github.com/minio/minio-go/pkg/credentials"
+	"github.com/pkg/errors"
+)
+
+// S3Store is a read-write store with S3 backing
+type S3IndexStore struct {
+	S3StoreBase
+}
+
+// NewS3Store creates an index store with S3 backing. The URL
+// should be provided like this: s3+http://host:port/bucket
+// Credentials are passed in via the environment variables S3_ACCESS_KEY
+// and S3S3_SECRET_KEY, or via the desync config file.
+func NewS3IndexStore(location *url.URL, s3Creds *credentials.Credentials, region string) (s S3IndexStore, e error) {
+	b, err := NewS3StoreBase(location, s3Creds, region)
+	if err != nil {
+		return s, err
+	}
+	return S3IndexStore{b}, nil
+}
+
+// Get and Index Reader from an S3 store, returns an error if the specified index file does not exist.
+func (s S3IndexStore) GetIndexReader(name string) (r io.ReadCloser, e error) {
+	obj, err := s.client.GetObject(s.bucket, s.prefix+name, minio.GetObjectOptions{})
+	if err != nil {
+		return r, errors.Wrap(err, s.String())
+	}
+	return obj, nil
+}
+
+// GetIndex returns an Index structure from the store
+func (s S3IndexStore) GetIndex(name string) (i Index, e error) {
+	obj, err := s.GetIndexReader(name)
+	if err != nil {
+		return i, err
+	}
+	defer obj.Close()
+	return IndexFromReader(obj)
+}
+
+// StoreIndex writes the index file to the S3 store
+func (s S3IndexStore) StoreIndex(name string, idx Index) error {
+	contentType := "application/octet-stream"
+	r, w := io.Pipe()
+
+	go func() {
+		defer w.Close()
+		idx.WriteTo(w)
+	}()
+
+	_, err := s.client.PutObject(s.bucket, s.prefix+name, r, -1, minio.PutObjectOptions{ContentType: contentType})
+	return errors.Wrap(err, path.Base(s.Location))
+}

--- a/sftp.go
+++ b/sftp.go
@@ -13,20 +13,26 @@ import (
 	"strconv"
 	"strings"
 
+	"path"
+
 	"github.com/pkg/errors"
 	"github.com/pkg/sftp"
 )
 
 // SFTPStore is a remote store that uses SFTP over SSH to access chunks
-type SFTPStore struct {
+type SFTPStoreBase struct {
 	location *url.URL
-	client   *sftp.Client
 	path     string
+	client   *sftp.Client
 	cancel   context.CancelFunc
 }
 
-// NewRemoteSSHStore establishes up to n connections with a casync chunk server
-func NewSFTPStore(location *url.URL) (*SFTPStore, error) {
+type SFTPStore struct {
+	*SFTPStoreBase
+}
+
+// Creates a base sftp client
+func newSFTPStoreBase(location *url.URL) (*SFTPStoreBase, error) {
 	sshCmd := os.Getenv("CASYNC_SSH_PATH")
 	if sshCmd == "" {
 		sshCmd = "ssh"
@@ -58,7 +64,60 @@ func NewSFTPStore(location *url.URL) (*SFTPStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &SFTPStore{location, client, path, cancel}, nil
+	return &SFTPStoreBase{location, path, client, cancel}, nil
+}
+
+// StoreChunk adds a new chunk to the store
+func (s *SFTPStore) StoreObject(name string, r io.Reader) error {
+	// Write to a tempfile on the remote server. This is not 100% guaranteed to not
+	// conflict between gorouties, there's no tempfile() function for remote servers.
+	// Use a large enough random number instead to build a tempfile
+	tmpfile := name + strconv.Itoa(rand.Int())
+	d := path.Dir(name)
+	var errCount int
+retry:
+	f, err := s.client.Create(tmpfile)
+	if err != nil {
+		// It's possible the parent dir doesn't yet exist. Create it while ignoring
+		// errors since that could be racy and fail if another goroutine does the
+		// same.
+		if errCount < 1 {
+			s.client.Mkdir(d)
+			errCount++
+			goto retry
+		}
+		return errors.Wrap(err, "sftp:create "+tmpfile)
+	}
+
+	if _, err := io.Copy(f, r); err != nil {
+		s.client.Remove(tmpfile)
+		return errors.Wrap(err, "sftp:copying chunk data to "+tmpfile)
+	}
+	if err = f.Close(); err != nil {
+		return errors.Wrap(err, "sftp:closing "+tmpfile)
+	}
+	return errors.Wrap(s.client.PosixRename(tmpfile, name), "sftp:renaming "+tmpfile+" to "+name)
+}
+
+// Close terminates all client connections
+func (s *SFTPStoreBase) Close() error {
+	if s.cancel != nil {
+		defer s.cancel()
+	}
+	return s.client.Close()
+}
+
+func (s *SFTPStoreBase) String() string {
+	return s.location.String()
+}
+
+// NewRemoteSSHStore establishes up to n connections with a casync chunk server
+func NewSFTPStore(location *url.URL) (*SFTPStore, error) {
+	b, err := newSFTPStoreBase(location)
+	if err != nil {
+		return nil, err
+	}
+	return &SFTPStore{b}, nil
 }
 
 // Get a chunk from an SFTP store, returns ChunkMissing if the file does not exist
@@ -87,45 +146,7 @@ func (s *SFTPStore) RemoveChunk(id ChunkID) error {
 
 // StoreChunk adds a new chunk to the store
 func (s *SFTPStore) StoreChunk(id ChunkID, b []byte) error {
-	name := s.nameFromID(id)
-	sID := id.String()
-	d := s.path + sID[0:4]
-
-	// Write to a tempfile on the remote server. This is not 100% guaranteed to not
-	// conflict between gorouties, there's no tempfile() function for remote servers.
-	// Use a large enough random number instead to build a tempfile
-	tmpfile := d + "/." + sID + chunkFileExt + strconv.Itoa(rand.Int())
-	var errCount int
-retry:
-	f, err := s.client.Create(tmpfile)
-	if err != nil {
-		// It's possible the parent dir doesn't yet exist. Create it while ignoring
-		// errors since that could be racy and fail if another goroutine does the
-		// same.
-		if errCount < 1 {
-			s.client.Mkdir(d)
-			errCount++
-			goto retry
-		}
-		return errors.Wrap(err, "sftp:create "+tmpfile)
-	}
-
-	if _, err := io.Copy(f, bytes.NewReader(b)); err != nil {
-		s.client.Remove(tmpfile)
-		return errors.Wrap(err, "sftp:copying chunk data to "+tmpfile)
-	}
-	if err = f.Close(); err != nil {
-		return errors.Wrap(err, "sftp:closing "+tmpfile)
-	}
-	return errors.Wrap(s.client.PosixRename(tmpfile, name), "sftp:renaming "+tmpfile+" to "+name)
-}
-
-// Close terminates all client connections
-func (s *SFTPStore) Close() error {
-	if s.cancel != nil {
-		defer s.cancel()
-	}
-	return s.client.Close()
+	return s.StoreObject(s.nameFromID(id), bytes.NewReader(b))
 }
 
 // HasChunk returns true if the chunk is in the store
@@ -173,10 +194,6 @@ func (s *SFTPStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 		}
 	}
 	return nil
-}
-
-func (s *SFTPStore) String() string {
-	return s.location.String()
 }
 
 func (s *SFTPStore) nameFromID(id ChunkID) string {

--- a/sftp.go
+++ b/sftp.go
@@ -68,7 +68,7 @@ func newSFTPStoreBase(location *url.URL) (*SFTPStoreBase, error) {
 }
 
 // StoreChunk adds a new chunk to the store
-func (s *SFTPStore) StoreObject(name string, r io.Reader) error {
+func (s *SFTPStoreBase) StoreObject(name string, r io.Reader) error {
 	// Write to a tempfile on the remote server. This is not 100% guaranteed to not
 	// conflict between gorouties, there's no tempfile() function for remote servers.
 	// Use a large enough random number instead to build a tempfile

--- a/sftpindex.go
+++ b/sftpindex.go
@@ -1,0 +1,56 @@
+package desync
+
+import (
+	"net/url"
+	"os"
+
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+type SFTPIndexStore struct {
+	*SFTPStoreBase
+}
+
+// NewSFTPIndexStore establishes up to n connections with a casync index server
+func NewSFTPIndexStore(location *url.URL) (*SFTPIndexStore, error) {
+	b, err := newSFTPStoreBase(location)
+	if err != nil {
+		return nil, err
+	}
+	return &SFTPIndexStore{b}, nil
+}
+
+// Get and Index Reader from  an SFTP store, returns an error if the specified index file does not exist.
+func (s *SFTPIndexStore) GetIndexReader(name string) (r io.ReadCloser, e error) {
+	f, err := s.client.Open(name)
+	if err != nil {
+		if os.IsNotExist(err) {
+			err = errors.Errorf("Index file does not exist: %v", err)
+		}
+		return r, err
+	}
+	return f, nil
+}
+
+// Get and Index from  an SFTP store, returns an error if the specified index file does not exist.
+func (s *SFTPIndexStore) GetIndex(name string) (i Index, e error) {
+	f, err := s.GetIndexReader(name)
+	if err != nil {
+		return i, err
+	}
+	defer f.Close()
+	return IndexFromReader(f)
+}
+
+// StoreChunk adds a new chunk to the store
+func (s *SFTPStore) StoreIndex(name string, idx Index) error {
+	r, w := io.Pipe()
+
+	go func() {
+		defer w.Close()
+		idx.WriteTo(w)
+	}()
+	return s.StoreObject(name, r)
+}

--- a/sftpindex.go
+++ b/sftpindex.go
@@ -45,7 +45,7 @@ func (s *SFTPIndexStore) GetIndex(name string) (i Index, e error) {
 }
 
 // StoreChunk adds a new chunk to the store
-func (s *SFTPStore) StoreIndex(name string, idx Index) error {
+func (s *SFTPIndexStore) StoreIndex(name string, idx Index) error {
 	r, w := io.Pipe()
 
 	go func() {

--- a/store.go
+++ b/store.go
@@ -3,6 +3,7 @@ package desync
 import (
 	"context"
 	"fmt"
+	"io"
 )
 
 // Store is a generic interface implemented by read-only stores, like SSH or
@@ -10,7 +11,7 @@ import (
 type Store interface {
 	GetChunk(id ChunkID) ([]byte, error)
 	HasChunk(id ChunkID) bool
-	Close() error
+	io.Closer
 	fmt.Stringer
 }
 
@@ -25,4 +26,16 @@ type WriteStore interface {
 type PruneStore interface {
 	WriteStore
 	Prune(ctx context.Context, ids map[ChunkID]struct{}) error
+}
+
+type IndexStore interface {
+	GetIndexReader(name string) (io.ReadCloser, error)
+	GetIndex(name string) (Index, error)
+	io.Closer
+	fmt.Stringer
+}
+
+type IndexWriteStore interface {
+	IndexStore
+	StoreIndex(name string, idx Index) error
 }

--- a/types.go
+++ b/types.go
@@ -3,6 +3,8 @@ package desync
 import (
 	"encoding/hex"
 
+	"io"
+
 	"github.com/pkg/errors"
 )
 
@@ -32,3 +34,9 @@ func ChunkIDFromString(id string) (ChunkID, error) {
 func (c ChunkID) String() string {
 	return hex.EncodeToString(c[:])
 }
+
+type ClosingByteReader struct {
+	io.Reader
+}
+
+func (c *ClosingByteReader) Close() error { return nil }

--- a/types.go
+++ b/types.go
@@ -3,8 +3,6 @@ package desync
 import (
 	"encoding/hex"
 
-	"io"
-
 	"github.com/pkg/errors"
 )
 
@@ -34,9 +32,3 @@ func ChunkIDFromString(id string) (ChunkID, error) {
 func (c ChunkID) String() string {
 	return hex.EncodeToString(c[:])
 }
-
-type ClosingByteReader struct {
-	io.Reader
-}
-
-func (c *ClosingByteReader) Close() error { return nil }


### PR DESCRIPTION
This PR implements https://github.com/folbricht/desync/issues/49.

I tested all commands with the new remote index feature and everything seems to work fine. Most of the code for index-server was reused from the chunk server, so there should be low risk of bugs introduced in that area which is good.

This touches a lot of code and I think some regression testing is needed. I did some regression testing myself but **I didn't do any sftp or https testing.** Do you have some scripts to help with this tests? 

## Testing done
### HTTP remote index
I tested the new feature with local, http, and S3 stores.

first started an index server:
`desync index-server -s /Users/user/store/ -l :8080 -w`

Then tested a make + extract:

`desync make  -s ./make-feature  http://localhost:8080/make-feature.caidx  /path/to/blob`

`desync extract  -s ./make-feature  http://localhost:8080/make-feature.caidx  ./assembly/blob`

### S3 remote index

`desync make  -s ./make-feature s3+https://s3.us-west-2.amazonaws.com/make-feature.caidx  /path/to/blob`

`desync extract  -s ./make-feature s3+https://s3.us-west-2.amazonaws.com/make-feature.caidx  ./assembly/blob`