### PR TITLE
Allow indexes to be read/written to STDIN/STDOUT. Implements #52

### DIFF
--- a/cmd/desync/cache.go
+++ b/cmd/desync/cache.go
@@ -15,7 +15,7 @@ const cacheUsage = `desync cache [options] <index> [<index>...]
 Read chunk IDs from caibx or caidx files from one or more stores without
 writing to disk. Can be used (with -c) to populate a store with desired chunks
 either to be used as cache, or to populate a store with chunks referenced in an
-index file.`
+index file. Use '-' to read (a single) index from STDIN.`
 
 func cache(ctx context.Context, args []string) error {
 	var (

--- a/cmd/desync/cat.go
+++ b/cmd/desync/cat.go
@@ -12,16 +12,18 @@ import (
 	"github.com/folbricht/desync"
 )
 
-const catUsage = `desync cat [options] <caibx> [<outputfile>]
+const catUsage = `desync cat [options] <index> [<outputfile>]
 
-Stream a caibx to stdout or a file-like object, optionally seeking and limiting
+Stream a blob to stdout or a file-like object, optionally seeking and limiting
 the read length.
 
 Unlike extract, this supports output to FIFOs, named pipes, and other
 non-seekable destinations.
 
 This is inherently slower than extract as while multiple chunks can be
-retrieved concurrently, writing to stdout cannot be parallelized.`
+retrieved concurrently, writing to stdout cannot be parallelized.
+
+Use '-' to read the index from STDIN.`
 
 func cat(ctx context.Context, args []string) error {
 	var (

--- a/cmd/desync/chop.go
+++ b/cmd/desync/chop.go
@@ -10,10 +10,10 @@ import (
 	"github.com/folbricht/desync"
 )
 
-const chopUsage = `desync chop [options] <caibx> <file>
+const chopUsage = `desync chop [options] <index> <file>
 
-Reads the index file and extracts all referenced chunks from the file
-into a local or S3 store.`
+Reads the index and extracts all referenced chunks from the file into a store,
+local or remote. Use '-' to read the index from STDIN.`
 
 func chop(ctx context.Context, args []string) error {
 	var (

--- a/cmd/desync/extract.go
+++ b/cmd/desync/extract.go
@@ -12,12 +12,13 @@ import (
 	"github.com/folbricht/tempfile"
 )
 
-const extractUsage = `desync extract [options] <caibx> <output>
+const extractUsage = `desync extract [options] <index> <output>
 
-Read a caibx and build a blob reading chunks from one or more casync stores.
+Reads an index and builds a blob reading chunks from one or more chunk stores.
 When using -k, the blob will be extracted in-place utilizing existing data and
 the target file will not be deleted on error. This can be used to restart a
-failed prior extraction without having to retrieve completed chunks again.
+failed prior extraction without having to retrieve completed chunks again. Use
+'-' to read the index from STDIN.
 `
 
 func extract(ctx context.Context, args []string) error {

--- a/cmd/desync/info.go
+++ b/cmd/desync/info.go
@@ -17,7 +17,7 @@ const infoUsage = `desync info [-s <store>] <index>
 
 Displays information about the provided index, such as number of chunks. If a
 store is provided, it'll also show how many of the chunks are present in the
-store.`
+store. Use '-' to read the index from STDIN.`
 
 func info(ctx context.Context, args []string) error {
 	var (

--- a/cmd/desync/list.go
+++ b/cmd/desync/list.go
@@ -8,9 +8,10 @@ import (
 	"os"
 )
 
-const listUsage = `desync list-chunks <caibx>
+const listUsage = `desync list-chunks <index>
 
-Reads the index file and prints the list of chunk IDs in it.`
+Reads the index file and prints the list of chunk IDs in it. Use '-' to read
+the index from STDIN.`
 
 func list(ctx context.Context, args []string) error {
 	var (

--- a/cmd/desync/make.go
+++ b/cmd/desync/make.go
@@ -15,8 +15,9 @@ import (
 const makeUsage = `desync make [options] <index> <file>
 
 Creates chunks from the input file and builds an index. If a chunk store is
-provided with -s, such as a local directory or S3 store, it split the input
-file according to the index and stores the chunks.`
+provided with -s, such as a local directory or S3 store, it splits the input
+file according to the index and stores the chunks. Use '-' to write the index
+from STDOUT.`
 
 func makeCmd(ctx context.Context, args []string) error {
 	var (
@@ -97,8 +98,8 @@ func makeCmd(ctx context.Context, args []string) error {
 		ps.Stop()
 	}
 
-	fmt.Println("Chunks produced:", stats.ChunksAccepted)
-	fmt.Println("Overhead:", stats.ChunksProduced-stats.ChunksAccepted)
+	fmt.Fprintln(os.Stderr, "Chunks produced:", stats.ChunksAccepted)
+	fmt.Fprintln(os.Stderr, "Overhead:", stats.ChunksProduced-stats.ChunksAccepted)
 
 	return storeCaibxFile(index, indexFile, sOpts)
 }

--- a/cmd/desync/mount-index.go
+++ b/cmd/desync/mount-index.go
@@ -16,7 +16,8 @@ const mountIdxUsage = `desync mount-index [options] <index> <mountpoint>
 
 FUSE mount of the blob in the index file. It makes the (single) file in
 the index available for read access. Use 'extract' if the goal is to
-assemble the whole blob locally as that is more efficient.
+assemble the whole blob locally as that is more efficient. Use '-' to read
+the index from STDIN.
 `
 
 func mountIdx(ctx context.Context, args []string) error {

--- a/cmd/desync/progressbar.go
+++ b/cmd/desync/progressbar.go
@@ -89,7 +89,7 @@ func (p *ConsoleProgressBar) draw() {
 	if progress < 0 || blank < 0 { // No need to panic if anything's off
 		return
 	}
-	fmt.Printf("\r%s|%s%s|", p.prefix, strings.Repeat("=", progress), strings.Repeat(" ", blank))
+	fmt.Fprintf(os.Stderr, "\r%s|%s%s|", p.prefix, strings.Repeat("=", progress), strings.Repeat(" ", blank))
 }
 
 type NullProgressBar struct{}

--- a/cmd/desync/prune.go
+++ b/cmd/desync/prune.go
@@ -13,7 +13,8 @@ import (
 const pruneUsage = `desync prune [options] <index> [<index>..]
 
 Read chunk IDs in from index files and delete any chunks from a local (or s3)
-store that are not referenced in the index files.`
+store that are not referenced in the index files. Use '-' to read a single index
+from STDIN.`
 
 func prune(ctx context.Context, args []string) error {
 	var (

--- a/cmd/desync/store.go
+++ b/cmd/desync/store.go
@@ -157,7 +157,7 @@ func writableIndexStore(location string, opts storeOptions) (desync.IndexWriteSt
 	}
 	store, ok := s.(desync.IndexWriteStore)
 	if !ok {
-		return nil, indexName, fmt.Errorf("store '%s' does not support writing", location)
+		return nil, indexName, fmt.Errorf("index store '%s' does not support writing", location)
 	}
 	return store, indexName, nil
 }
@@ -198,10 +198,13 @@ func indexStoreFromLocation(location string, opts storeOptions) (desync.IndexSto
 			return nil, "", err
 		}
 	case "":
-
-		s, err = desync.NewLocaIndexlStore(p.String())
-		if err != nil {
-			return nil, "", err
+		if location == "-" {
+			s, _ = desync.NewConsoleIndexStore()
+		} else {
+			s, err = desync.NewLocaIndexStore(p.String())
+			if err != nil {
+				return nil, "", err
+			}
 		}
 	default:
 		return nil, "", fmt.Errorf("Unsupported store access scheme %s", loc.Scheme)

--- a/cmd/desync/untar.go
+++ b/cmd/desync/untar.go
@@ -12,9 +12,10 @@ import (
 	"github.com/folbricht/desync"
 )
 
-const untarUsage = `desync untar <catar|caidx> <target>
+const untarUsage = `desync untar <catar|index> <target>
 
-Extracts a directory tree from a catar file or an index file.`
+Extracts a directory tree from a catar file or an index. Use '-' to read the
+index from STDIN.`
 
 func untar(ctx context.Context, args []string) error {
 	var (

--- a/cmd/desync/verifyindex.go
+++ b/cmd/desync/verifyindex.go
@@ -10,9 +10,10 @@ import (
 	"github.com/folbricht/desync"
 )
 
-const verifyIndexUsage = `desync verify-index [options] <caibx> <file>
+const verifyIndexUsage = `desync verify-index [options] <index> <file>
 
-Verifies an index file matches the content of a blob.
+Verifies an index file matches the content of a blob. Use '-' to read the index
+from STDIN.
 `
 
 func verifyIndex(ctx context.Context, args []string) error {

--- a/consoleindex.go
+++ b/consoleindex.go
@@ -1,0 +1,39 @@
+package desync
+
+import (
+	"io/ioutil"
+	"os"
+
+	"io"
+)
+
+// ConsoleIndexStore is used for writing/reading indexes from STDOUT/STDIN
+type ConsoleIndexStore struct{}
+
+// NewConsoleStore creates an instance of an indexStore that reads/writes to and
+// from console
+func NewConsoleIndexStore() (ConsoleIndexStore, error) {
+	return ConsoleIndexStore{}, nil
+}
+
+// GetIndexReader returns a reader from STDIN
+func (s ConsoleIndexStore) GetIndexReader(string) (io.ReadCloser, error) {
+	return ioutil.NopCloser(os.Stdin), nil
+}
+
+// GetIndex reads an index from STDIN and returns it.
+func (s ConsoleIndexStore) GetIndex(string) (i Index, e error) {
+	return IndexFromReader(os.Stdin)
+}
+
+// StoreIndex writes the provided indes to STDOUT. The name is ignored.
+func (s ConsoleIndexStore) StoreIndex(name string, idx Index) error {
+	_, err := idx.WriteTo(os.Stdout)
+	return err
+}
+
+func (r ConsoleIndexStore) String() string {
+	return "-"
+}
+
+func (s ConsoleIndexStore) Close() error { return nil }

--- a/localindex.go
+++ b/localindex.go
@@ -1,24 +1,22 @@
 package desync
 
 import (
+	"fmt"
+	"io"
 	"os"
 	"strings"
-
-	"fmt"
-
-	"io"
 
 	"github.com/pkg/errors"
 )
 
-// LocalStore index store
+// LocalIndexStore is used to read/write index files on local disk
 type LocalIndexStore struct {
 	Path string
 }
 
 // NewLocalStore creates an instance of a local castore, it only checks presence
 // of the store
-func NewLocaIndexlStore(path string) (LocalIndexStore, error) {
+func NewLocaIndexStore(path string) (LocalIndexStore, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return LocalIndexStore{}, err
@@ -32,7 +30,8 @@ func NewLocaIndexlStore(path string) (LocalIndexStore, error) {
 	return LocalIndexStore{Path: path}, nil
 }
 
-// Get and Index Reader from a local store, returns an error if the specified index file does not exist.
+// GetIndexReader returns a reader of an index file in the store or an error if
+// the specified index file does not exist.
 func (s LocalIndexStore) GetIndexReader(name string) (rdr io.ReadCloser, e error) {
 	return os.Open(s.Path + name)
 }
@@ -51,7 +50,7 @@ func (s LocalIndexStore) GetIndex(name string) (i Index, e error) {
 	return idx, err
 }
 
-// GetIndex returns an Index structure from the store
+// StoreIndex stores an index in the index store with the given name.
 func (s LocalIndexStore) StoreIndex(name string, idx Index) error {
 	// Write the index to file
 	i, err := os.Create(s.Path + name)


### PR DESCRIPTION
Implements #52 by adding support for reading/writing indexes from/to STDIN/STDOUT. Also adds documentation for remote indexes and moves the progressbar to STDERR (where it should have been all along).