### PR TITLE
Support Windows paths for local stores and explicitly close temp files before rename

### DIFF
--- a/cmd/desync/store.go
+++ b/cmd/desync/store.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"path"
+	"path/filepath"
 
 	"github.com/folbricht/desync"
 	"github.com/pkg/errors"
@@ -116,13 +117,11 @@ func storeFromLocation(location string, opts storeOptions) (desync.Store, error)
 		if err != nil {
 			return nil, err
 		}
-	case "":
-		s, err = desync.NewLocalStore(loc.Path)
+	default:
+		s, err = desync.NewLocalStore(location)
 		if err != nil {
 			return nil, err
 		}
-	default:
-		return nil, fmt.Errorf("Unsupported store access scheme %s", loc.Scheme)
 	}
 	return s, nil
 }
@@ -197,17 +196,16 @@ func indexStoreFromLocation(location string, opts storeOptions) (desync.IndexSto
 		if err != nil {
 			return nil, "", err
 		}
-	case "":
+	default:
 		if location == "-" {
 			s, _ = desync.NewConsoleIndexStore()
 		} else {
-			s, err = desync.NewLocalIndexStore(p.String())
+			s, err = desync.NewLocalIndexStore(filepath.Dir(location))
 			if err != nil {
 				return nil, "", err
 			}
+			indexName = filepath.Base(location)
 		}
-	default:
-		return nil, "", fmt.Errorf("Unsupported store access scheme %s", loc.Scheme)
 	}
 	return s, indexName, nil
 }

--- a/local.go
+++ b/local.go
@@ -72,11 +72,12 @@ func (s LocalStore) StoreChunk(id ChunkID, b []byte) error {
 	if err != nil {
 		return err
 	}
-	defer tmp.Close()
-	defer os.Remove(tmp.Name()) // in case we don't get to the rename, clean up
 	if _, err = tmp.Write(b); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name()) // clean up
 		return err
 	}
+	tmp.Close() // Windows can't rename open files, close explicitly
 	p := filepath.Join(d, sID) + chunkFileExt
 	return os.Rename(tmp.Name(), p)
 }


### PR DESCRIPTION
This allows path names on windows with backslashes or drive letters like `c:\path\somewhere.caibx`. These would previously be parsed as URLs with a scheme of `c` which is not what we want.