### PR TITLE
Refactor code to use errgroup

### DIFF
--- a/assemble.go
+++ b/assemble.go
@@ -87,7 +87,6 @@ func AssembleFile(ctx context.Context, name string, idx Index, s Store, seeds []
 
 	// Start the workers, each having its own filehandle to write concurrently
 	for i := 0; i < n; i++ {
-		// wg.Add(1)
 		f, err := os.OpenFile(name, os.O_RDWR, 0666)
 		if err != nil {
 			return stats, fmt.Errorf("unable to open file %s, %s", name, err)

--- a/verifyindex.go
+++ b/verifyindex.go
@@ -6,20 +6,15 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"sync"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // VerifyIndex re-calculates the checksums of a blob comparing it to a given index.
 // Fails if the index does not match the blob.
 func VerifyIndex(ctx context.Context, name string, idx Index, n int, pb ProgressBar) error {
-	var (
-		wg   sync.WaitGroup
-		mu   sync.Mutex
-		pErr error
-		in   = make(chan IndexChunk)
-	)
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	in := make(chan IndexChunk)
+	g, ctx := errgroup.WithContext(ctx)
 
 	// Setup and start the progressbar if any
 	if pb != nil {
@@ -36,26 +31,14 @@ func VerifyIndex(ctx context.Context, name string, idx Index, n int, pb Progress
 		return fmt.Errorf("index size (%d) does not match file size (%d)", idx.Length(), stat.Size())
 	}
 
-	// Helper function to record and deal with any errors in the goroutines
-	recordError := func(err error) {
-		mu.Lock()
-		defer mu.Unlock()
-		if pErr == nil {
-			pErr = err
-		}
-		cancel()
-	}
-
 	// Start the workers, each having its own filehandle to read concurrently
 	for i := 0; i < n; i++ {
-		wg.Add(1)
 		f, err := os.Open(name)
 		if err != nil {
 			return fmt.Errorf("unable to open file %s, %s", name, err)
 		}
 		defer f.Close()
-		go func() {
-			var err error
+		g.Go(func() error {
 			for c := range in {
 				// Update progress bar if any
 				if pb != nil {
@@ -64,44 +47,37 @@ func VerifyIndex(ctx context.Context, name string, idx Index, n int, pb Progress
 
 				// Position the filehandle to the place where the chunk is meant to come
 				// from within the file
-				if _, err = f.Seek(int64(c.Start), io.SeekStart); err != nil {
-					recordError(err)
-					continue
+				if _, err := f.Seek(int64(c.Start), io.SeekStart); err != nil {
+					return err
 				}
 
 				// Read the whole (uncompressed) chunk into memory
 				b := make([]byte, c.Size)
-				if _, err = io.ReadFull(f, b); err != nil {
-					recordError(err)
-					continue
+				if _, err := io.ReadFull(f, b); err != nil {
+					return err
 				}
 
 				// Calculate this chunks checksum and compare to what it's supposed to be
 				// according to the index
 				sum := sha512.Sum512_256(b)
 				if sum != c.ID {
-					recordError(fmt.Errorf("checksum does not match chunk %s", c.ID))
-					continue
+					return fmt.Errorf("checksum does not match chunk %s", c.ID)
 				}
 			}
-			wg.Done()
-		}()
+			return nil
+		})
 	}
 
 	// Feed the workers, stop if there are any errors
 loop:
 	for _, c := range idx.Chunks {
-		// See if we're meant to stop
 		select {
 		case <-ctx.Done():
 			break loop
-		default:
+		case in <- c:
 		}
-		in <- c
 	}
 	close(in)
 
-	wg.Wait()
-
-	return pErr
+	return g.Wait()
 }


### PR DESCRIPTION
A lot of code is duplicated to implement a concurrent worker pattern that records errors in the worker go routines.

This PR replaces this code with https://godoc.org/golang.org/x/sync/errgroup which simplifies it significantly and de-dups the code as well.