### PR TITLE
Improve how store paths are compared against configuration values as …

### DIFF
--- a/cmd/desync/config_test.go
+++ b/cmd/desync/config_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigFile(t *testing.T) {
+	cfgFileContent := []byte(`{"store-options": {"/path/to/store/":{"uncompressed": true}}}`)
+	f, err := ioutil.TempFile("", "")
+	require.NoError(t, err)
+	f.Close()
+	defer os.Remove(f.Name())
+	require.NoError(t, ioutil.WriteFile(f.Name(), cfgFileContent, 0644))
+
+	// Set the global config file name
+	cfgFile = f.Name()
+
+	// Call init, this should use the custom config file and global "cfg" should contain the
+	// values
+	initConfig()
+
+	// If everything worked, the options should be set according to the config file created above
+	opt := cfg.GetStoreOptionsFor("/path/to/store")
+	require.True(t, opt.Uncompressed)
+
+	// The options for a non-matching store should be default
+	opt = cfg.GetStoreOptionsFor("/path/other-store")
+	require.False(t, opt.Uncompressed)
+}

--- a/cmd/desync/location.go
+++ b/cmd/desync/location.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"net/url"
+	"path"
+	"path/filepath"
+)
+
+// Returns true if the two locations are equal. Locations can be URLs or local file paths.
+// It can handle Unix as well as Windows paths. Example
+// http://host/path/ is equal http://host/path (no trailing /) and /tmp/path is
+// equal \tmp\path on Windows.
+func locationMatch(loc1, loc2 string) bool {
+	// First lets see if they're both URLs
+	u1, _ := url.Parse(loc1)
+	u2, _ := url.Parse(loc2)
+	if u1.Scheme != "" || u2.Scheme != "" { // At lease one URL
+		if u1.Scheme != u2.Scheme || u1.Host != u2.Host {
+			return false
+		}
+		// URL paths should only use /, use path (not filepath) package to clean them
+		// before comparing
+		return path.Clean(u1.Path) == path.Clean(u2.Path)
+	}
+
+	// We're dealing with two paths.
+	p1, err := filepath.Abs(loc1)
+	if err != nil {
+		return false
+	}
+	p2, err := filepath.Abs(loc2)
+	if err != nil {
+		return false
+	}
+	return p1 == p2
+}

--- a/cmd/desync/location.go
+++ b/cmd/desync/location.go
@@ -11,10 +11,11 @@ import (
 // http://host/path/ is equal http://host/path (no trailing /) and /tmp/path is
 // equal \tmp\path on Windows.
 func locationMatch(loc1, loc2 string) bool {
-	// First lets see if they're both URLs
 	u1, _ := url.Parse(loc1)
 	u2, _ := url.Parse(loc2)
-	if u1.Scheme != "" || u2.Scheme != "" { // At lease one URL
+	// See if we have at least one URL, Windows drive letters come out as single-letter
+	// scheme so we need more here.
+	if len(u1.Scheme) > 1 || len(u2.Scheme) > 1 {
 		if u1.Scheme != u2.Scheme || u1.Host != u2.Host {
 			return false
 		}

--- a/cmd/desync/location_test.go
+++ b/cmd/desync/location_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocationEquality(t *testing.T) {
+	// Equal URLs
+	require.True(t, locationMatch("http://host/path", "http://host/path"))
+	require.True(t, locationMatch("http://host/path/", "http://host/path/"))
+	require.True(t, locationMatch("http://host/path", "http://host/path/"))
+
+	// Not equal URLs
+	require.False(t, locationMatch("http://host:8080/path", "http://host/path"))
+	require.False(t, locationMatch("http://host/path1", "http://host/path"))
+	require.False(t, locationMatch("http://host/path1", "http://host/path/"))
+	require.False(t, locationMatch("http://host1/path", "http://host2/path"))
+	require.False(t, locationMatch("sftp://host/path", "http://host/path"))
+	require.False(t, locationMatch("ssh://host/path", "/path"))
+
+	// Equal paths
+	require.True(t, locationMatch("/path", "/path/../path"))
+	require.True(t, locationMatch("//path", "//path"))
+	require.True(t, locationMatch("./path", "./path"))
+	require.True(t, locationMatch("path", "path/"))
+	require.True(t, locationMatch("path/..", "."))
+	if runtime.GOOS == "windows" {
+		require.True(t, locationMatch("c:\\path\\to\\somewhere", "c:\\path\\to\\somewhere\\"))
+		require.True(t, locationMatch("/path/to/somewhere", "\\path\\to\\somewhere\\"))
+	}
+
+	// Not equal paths
+	require.False(t, locationMatch("/path", "path"))
+	require.False(t, locationMatch("/path/to", "path/to"))
+	require.False(t, locationMatch("/path/to", "/path/to/.."))
+
+}

--- a/cmd/desync/location_test.go
+++ b/cmd/desync/location_test.go
@@ -36,5 +36,7 @@ func TestLocationEquality(t *testing.T) {
 	require.False(t, locationMatch("/path", "path"))
 	require.False(t, locationMatch("/path/to", "path/to"))
 	require.False(t, locationMatch("/path/to", "/path/to/.."))
-
+	if runtime.GOOS == "windows" {
+		require.False(t, locationMatch("c:\\path1", "c:\\path2"))
+	}
 }

--- a/cmd/desync/main.go
+++ b/cmd/desync/main.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/spf13/cobra"
 )
 
 // Define writers for STDOUT and STDERR that are used in the commands.
@@ -29,6 +31,10 @@ func main() {
 		cancel()
 	}()
 
+	// Read config early
+	cobra.OnInitialize(initConfig)
+
+	// Register the sub-commands under root
 	rootCmd := newRootCommand()
 	rootCmd.AddCommand(
 		newConfigCommand(ctx),

--- a/cmd/desync/root.go
+++ b/cmd/desync/root.go
@@ -12,7 +12,3 @@ func newRootCommand() *cobra.Command {
 	cmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default $HOME/.config/desync/config.json)")
 	return cmd
 }
-
-func init() {
-	cobra.OnInitialize(initConfig)
-}


### PR DESCRIPTION
…per #66 

Implements a better way to compare paths against store config. It no longer does a simple string compare where trailing whitespace mattered. Also supports comparing paths with / and \ on Windows.