### PR TITLE
Don't use filepath in HTTP handling since that breaks on windows as p…

### DIFF
--- a/httphandler.go
+++ b/httphandler.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -106,21 +106,21 @@ func (h HTTPHandler) put(id ChunkID, w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func (h HTTPHandler) idFromPath(path string) (ChunkID, error) {
+func (h HTTPHandler) idFromPath(p string) (ChunkID, error) {
 	ext := CompressedChunkExt
 	if h.Uncompressed {
-		if strings.HasSuffix(path, CompressedChunkExt) {
+		if strings.HasSuffix(p, CompressedChunkExt) {
 			return ChunkID{}, errors.New("compressed chunk requested from http chunk store serving uncompressed chunks")
 		}
 		ext = UncompressedChunkExt
 	}
-	sID := strings.TrimSuffix(filepath.Base(path), ext)
+	sID := strings.TrimSuffix(path.Base(p), ext)
 	if len(sID) < 4 {
 		return ChunkID{}, fmt.Errorf("expected format '/<prefix>/<chunkid>%s", ext)
 	}
 
 	// Make sure the prefix does match the first characters of the ID.
-	if path != filepath.Join("/", sID[0:4], sID+ext) {
+	if p != path.Join("/", sID[0:4], sID+ext) {
 		return ChunkID{}, fmt.Errorf("expected format '/<prefix>/<chunkid>%s", ext)
 	}
 	return ChunkIDFromString(sID)

--- a/httpindexhandler.go
+++ b/httpindexhandler.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"path/filepath"
+	"path"
 )
 
 // HTTPIndexHandler is the HTTP handler for index stores.
@@ -20,7 +20,7 @@ func NewHTTPIndexHandler(s IndexStore, writable bool) http.Handler {
 }
 
 func (h HTTPIndexHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	indexName := filepath.Base(r.URL.Path)
+	indexName := path.Base(r.URL.Path)
 
 	switch r.Method {
 	case "GET":

--- a/remotehttp.go
+++ b/remotehttp.go
@@ -8,7 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"path/filepath"
+	"path"
 	"strings"
 	"time"
 
@@ -235,7 +235,7 @@ func (r *RemoteHTTP) StoreChunk(chunk *Chunk) error {
 
 func (r *RemoteHTTP) nameFromID(id ChunkID) string {
 	sID := id.String()
-	name := filepath.Join(sID[0:4], sID)
+	name := path.Join(sID[0:4], sID)
 	if r.opt.Uncompressed {
 		name += UncompressedChunkExt
 	} else {


### PR DESCRIPTION
…er #70 

There's two fixes here:
- The HTTP client (store) should use the `path` library that only uses `/` as separator to avoid sending backslashes when running on Windows
- The HTTP handler should expect to receive all paths with `/` and also not use filepath since that would behave differently when the server runs on Windows.