### PR TITLE
S3: allow user to specify lookup type

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,18 @@ This is a store running on the local machine on port 9000 without SSL.
 s3+http://127.0.0.1:9000/store
 ```
 
+#### Setting S3 bucket addressing style for other services
+
+desync uses [minio](https://github.com/minio/minio-go) as an S3 client library. It has an auto-detection mechanism for determining the addressing style of the buckets which should work for Amazon and Google S3 services but could potentially fail for your custom implementation. You can manually specify the addressing style by appending the "lookup" query parameter to the URL.
+
+By default, the value of "?lookup=auto" is implied.
+
+```text
+s3+http://127.0.0.1:9000/bucket/prefix?lookup=path
+s3+https://s3.internal.company/bucket/prefix?lookup=dns
+s3+https://example.com/bucket/prefix?lookup=auto
+```
+
 ### Compressed vs Uncompressed chunk stores
 
 By default, desync reads and writes chunks in compressed form to all supported stores. This is in line with upstream casync's goal of storing in the most efficient way. It is however possible to change this behavior by providing desync with a config file (see Configuration section below). Disabling compression and store chunks uncompressed may reduce latency in some use-cases and improve performance. desync supports reading and writing uncompressed chunks to SFTP, S3, HTTP and local stores and caches. If more than one store is used, each of those can be configured independently, for example it's possible to read compressed chunks from S3 while using a local uncompressed cache for best performance. However, care needs to be taken when using the `chunk-server` command and building chains of chunk store proxies to avoid shifting the decompression load onto the server (it's possible this is actually desirable).

--- a/s3index.go
+++ b/s3index.go
@@ -21,8 +21,8 @@ type S3IndexStore struct {
 // should be provided like this: s3+http://host:port/bucket
 // Credentials are passed in via the environment variables S3_ACCESS_KEY
 // and S3S3_SECRET_KEY, or via the desync config file.
-func NewS3IndexStore(location *url.URL, s3Creds *credentials.Credentials, region string, opt StoreOptions) (s S3IndexStore, e error) {
-	b, err := NewS3StoreBase(location, s3Creds, region, opt)
+func NewS3IndexStore(location *url.URL, s3Creds *credentials.Credentials, region string, opt StoreOptions, lookupType minio.BucketLookupType) (s S3IndexStore, e error) {
+	b, err := NewS3StoreBase(location, s3Creds, region, opt, lookupType)
 	if err != nil {
 		return s, err
 	}


### PR DESCRIPTION
minio supports two ways to address S3 buckets: DNS- and path-style lookups (http://bucket.s3endpoint.org vs http://s3endpoint.org/bucket).
Desync does not have a way to specify the type of bucket addressing, like boto3's addressing_style configuration key, and minio falls back to the autodetection method (which actually works only for Google and Amazon, not for private installations).
This patchset gives the user a way to specify the method by appending "?lookup=dns", "?lookup=path" or "?lookup=auto" to the S3 path.