### PR TITLE
Resolve #83: implement extended attributes (xattrs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Among the distinguishing factors:
 - Supports local stores as well as remote stores (as client) over SSH, SFTP and HTTP
 - Built-in HTTP(S) chunk server that can proxy multiple local or remote stores and also supports caching.
 - Drop-in replacement for casync on SSH servers when serving chunks read-only
-- Support for catar files exists, but ignores XAttr, SELinux, ACLs and FCAPs that may be present in existing catar files and those won't be present when creating a new catar with the `tar` command
+- Support for catar files exists, but ignores SELinux and ACLs that may be present in existing catar files and those won't be present when creating a new catar with the `tar` command; FCAPs are supported only as a verbatim copy of "security.capability" XAttr.
 - Supports chunking with the same algorithm used by casync (see `make` command) but executed in parallel. Results are identical to what casync produces, same chunks and index files, but with significantly better performance. For example, up to 10x faster than casync if the chunks are already present in the store. If the chunks are new, it heavily depends on I/O, but it's still likely several times faster than casync.
 - While casync supports very small min chunk sizes, optimizations in desync require min chunk sizes larger than the window size of the rolling hash used (currently 48 bytes). The tool's default chunk sizes match the defaults used in casync, min 16k, avg 64k, max 256k.
 - Allows FUSE mounting of blob indexes

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/mitchellh/go-homedir v1.0.0 // indirect
 	github.com/pkg/errors v0.8.0
 	github.com/pkg/sftp v1.8.2
+	github.com/pkg/xattr v0.4.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/smartystreets/assertions v0.0.0-20180820201707-7c9eb446e3cf // indirect
 	github.com/smartystreets/goconvey v0.0.0-20180222194500-ef6db91d284a // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.8.2 h1:3upwlsK5/USEeM5gzIe9eWdzU4sV+kG3gKKg3RLBuWE=
 github.com/pkg/sftp v1.8.2/go.mod h1:NxmoDg/QLVWluQDUYG7XBZTLUpKeFa8e3aMf1BfjyHk=
+github.com/pkg/xattr v0.4.0 h1:OacIpDCc4H+4b/bWpYBLOT5gXk7G/jwx5O1D8x8Zewo=
+github.com/pkg/xattr v0.4.0/go.mod h1:W2cGD0TBEus7MkUgv0tNZ9JutLtVO3cXu+IBRuHqnFs=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/smartystreets/assertions v0.0.0-20180820201707-7c9eb446e3cf h1:6V1qxN6Usn4jy8unvggSJz/NC790tefw8Zdy6OZS5co=
@@ -54,6 +56,8 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6Zh
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522 h1:Ve1ORMCxvRmSXBwJK+t3Oy+V2vRW2OetUQBq4rJIkZE=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20181021155630-eda9bb28ed51 h1:GNXpDwiINQORfoRpKYZBUNeIGY4giY2DonS5etRdlnE=
+golang.org/x/sys v0.0.0-20181021155630-eda9bb28ed51/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/cheggaaa/pb.v1 v1.0.25 h1:Ev7yu1/f6+d+b3pi5vPdRPc6nNtP1umSfcWiEfRqv6I=

--- a/untar.go
+++ b/untar.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pkg/errors"
+	"github.com/pkg/xattr"
 )
 
 // UntarOptions are used to influence the behaviour of untar
@@ -79,6 +80,14 @@ func makeDir(base string, n NodeDirectory, opts UntarOptions) error {
 		if err := os.Chown(dst, n.UID, n.GID); err != nil {
 			return err
 		}
+
+		if n.Xattrs != nil {
+			for key, value := range n.Xattrs {
+				if err := xattr.LSet(dst, key, []byte(value)); err != nil {
+					return err
+				}
+			}
+		}
 	}
 	if !opts.NoSamePermissions {
 		if err := syscall.Chmod(dst, uint32(n.Mode)); err != nil {
@@ -102,6 +111,14 @@ func makeFile(base string, n NodeFile, opts UntarOptions) error {
 	if !opts.NoSameOwner {
 		if err = f.Chown(n.UID, n.GID); err != nil {
 			return err
+		}
+
+		if n.Xattrs != nil {
+			for key, value := range n.Xattrs {
+				if err := xattr.LSet(dst, key, []byte(value)); err != nil {
+					return err
+				}
+			}
 		}
 	}
 	if !opts.NoSamePermissions {
@@ -129,6 +146,14 @@ func makeSymlink(base string, n NodeSymlink, opts UntarOptions) error {
 		if err := os.Lchown(dst, n.UID, n.GID); err != nil {
 			return err
 		}
+
+		if n.Xattrs != nil {
+			for key, value := range n.Xattrs {
+				if err := xattr.LSet(dst, key, []byte(value)); err != nil {
+					return err
+				}
+			}
+		}
 	}
 	return nil
 }
@@ -145,6 +170,14 @@ func makeDevice(base string, n NodeDevice, opts UntarOptions) error {
 	if !opts.NoSameOwner {
 		if err := os.Chown(dst, n.UID, n.GID); err != nil {
 			return err
+		}
+
+		if n.Xattrs != nil {
+			for key, value := range n.Xattrs {
+				if err := xattr.LSet(dst, key, []byte(value)); err != nil {
+					return err
+				}
+			}
 		}
 	}
 	if !opts.NoSamePermissions {


### PR DESCRIPTION
Most POSIX filesystems allow extended attributes to be assigned to inodes.
Currently desync does not support extended attributes.
This patch implements extended attributes in an casync-compatible way.

