### PR TITLE
Allow ignoring chunks from existing indexes when chopping blobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,12 @@ to populate a local cache from a possibly large blob that already exists on the 
 desync chop -s /some/local/store somefile.tar.caibx somefile.tar
 ```
 
+Chop a blob according to an existing index, while ignoring any chunks that are referenced in another index. This can be used to improve performance when it is known that all chunks referenced in `image-v1.caibx` are already present in the target store and can be ignored when chopping `image-v2.iso`.
+
+```text
+desync chop -s /some/local/store --ignore image-v1.iso.caibx image-v2.iso.caibx image-v2.iso
+```
+
 Pack a directory tree into a catar file.
 
 ```text

--- a/cmd/desync/chop_test.go
+++ b/cmd/desync/chop_test.go
@@ -11,23 +11,36 @@ import (
 )
 
 func TestChopCommand(t *testing.T) {
-	store, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(store)
+	for _, test := range []struct {
+		name string
+		args []string
+	}{
+		{"simple chop",
+			[]string{"testdata/blob1.caibx", "testdata/blob1"}},
+		{"chop with ignore",
+			[]string{"--ignore", "testdata/blob2.caibx", "testdata/blob1.caibx", "testdata/blob1"}},
+	} {
+		store, err := ioutil.TempDir("", "")
+		require.NoError(t, err)
+		defer os.RemoveAll(store)
 
-	cmd := newChopCommand(context.Background())
-	cmd.SetArgs([]string{"-s", store, "testdata/blob1.caibx", "testdata/blob1"})
+		args := []string{"-s", store}
+		args = append(args, test.args...)
 
-	// Redirect the command's output to turn off the progressbar and run it
-	stderr = ioutil.Discard
-	cmd.SetOutput(ioutil.Discard)
-	_, err = cmd.ExecuteC()
-	require.NoError(t, err)
+		cmd := newChopCommand(context.Background())
+		cmd.SetArgs(args)
 
-	// If the file was split right, we'll have chunks in the dir now
-	dirs, err := ioutil.ReadDir(store)
-	require.NoError(t, err)
-	require.NotEmpty(t, dirs)
+		// Redirect the command's output to turn off the progressbar and run it
+		stderr = ioutil.Discard
+		cmd.SetOutput(ioutil.Discard)
+		_, err = cmd.ExecuteC()
+		require.NoError(t, err)
+
+		// If the file was split right, we'll have chunks in the dir now
+		dirs, err := ioutil.ReadDir(store)
+		require.NoError(t, err)
+		require.NotEmpty(t, dirs)
+	}
 }
 
 func TestChopErrors(t *testing.T) {


### PR DESCRIPTION
This adds a new option `--ignore <index>` which allows specifying indexes whose chunks should be skipped during a `chop` operation to improve performance.

Useful to speed up a chop operation if it is known that the chunks of previously chunked (similar) files are already in the target store. These chunks will be skipped entirely:
- The chunk won't be read from the input file
- The store will not be queried for the presence of the chunk (can be slow when using remote stores)
- The checksum of the file chunk will not be calculated or verified