### PR TITLE
Fixes issue with 32 bit builds of desync

### DIFF
--- a/extractstats.go
+++ b/extractstats.go
@@ -7,15 +7,15 @@ import (
 // ExtractStats contains detailed statistics about a file extract operation, such
 // as if data chunks were copied from seeds or cloned.
 type ExtractStats struct {
-	ChunksTotal     int    `json:"chunks-total"`
 	ChunksFromSeeds uint64 `json:"chunks-from-seeds"`
 	ChunksFromStore uint64 `json:"chunks-from-store"`
 	ChunksInPlace   uint64 `json:"chunks-in-place"`
-	BytesTotal      int64  `json:"bytes-total"`
 	BytesCopied     uint64 `json:"bytes-copied-from-seeds"`
 	BytesCloned     uint64 `json:"bytes-cloned-from-seeds"`
-	Seeds           int    `json:"seeds"`
 	Blocksize       uint64 `json:"blocksize"`
+	BytesTotal      int64  `json:"bytes-total"`
+	ChunksTotal     int    `json:"chunks-total"`
+	Seeds           int    `json:"seeds"`
 }
 
 func (s *ExtractStats) incChunksFromStore() {


### PR DESCRIPTION
Alignment issues with 64 bit fields in the struct causes 32 bit builds of desync to not work (panic in sync/atomic package).
Re-arranging the members of the struct fixes this problem
Based on suggestions found at https://github.com/golang/go/issues/599 and https://github.com/golang/go/issues/23345.