### PR TITLE
Support mutual TLS on chunk and index server

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,26 @@ desync chunk-server -s /path/to/store --key server.key --cert server.crt -l :844
 desync extract --ca-cert ca.crt -s https://hostname:8443/ image.iso.caibx image.iso
 ```
 
+HTTPS chunk server with client authentication (mutual-TLS).
+
+```text
+# Building the CA, server and client certficates
+openssl genrsa -out ca.key 4096
+openssl req -x509 -new -nodes -key ca.key -sha256 -days 3650 -out ca.crt
+openssl genrsa -out server.key 2048
+openssl req -new -key server.key -out server.csr (Common Name should be the server name)
+openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 3650 -sha256
+openssl genrsa -out client.key 2048
+openssl req -new -key client.key -out client.csr
+openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out client.crt -days 3650 -sha256
+
+# Chunk server
+desync chunk-server -s /path/to/store --key server.key --cert server.crt --mutual-tls --client-ca ca.crt -l :8443
+
+# Client
+desync extract --client-key client.key --client-cert client.crt --ca-cert ca.crt -s https://hostname:8443/ image.iso.caibx image.iso
+```
+
 ## Links
 
 - casync - [https://github.com/systemd/casync](https://github.com/systemd/casync)

--- a/cmd/desync/options.go
+++ b/cmd/desync/options.go
@@ -48,11 +48,34 @@ func (o cmdStoreOptions) validate() error {
 	return nil
 }
 
-// Add common store option flags to command flagset.
+// Add common store option flags to a command flagset.
 func addStoreOptions(o *cmdStoreOptions, f *pflag.FlagSet) {
 	f.IntVarP(&o.n, "concurrency", "n", 10, "number of concurrent goroutines")
 	f.StringVar(&o.clientCert, "client-cert", "", "path to client certificate for TLS authentication")
 	f.StringVar(&o.clientKey, "client-key", "", "path to client key for TLS authentication")
 	f.StringVar(&o.caCert, "ca-cert", "", "trust authorities in this file, instead of OS trust store")
 	f.BoolVarP(&o.trustInsecure, "trust-insecure", "t", false, "trust invalid certificates")
+}
+
+// cmdServerOptions hold command line options used in HTTP servers.
+type cmdServerOptions struct {
+	cert      string
+	key       string
+	mutualTLS bool
+	clientCA  string
+}
+
+func (o cmdServerOptions) validate() error {
+	if (o.key == "") != (o.cert == "") {
+		return errors.New("--key and --cert options need to be provided together")
+	}
+	return nil
+}
+
+// Add common HTTP server options to a command flagset.
+func addServerOptions(o *cmdServerOptions, f *pflag.FlagSet) {
+	f.StringVar(&o.cert, "cert", "", "cert file in PEM format, requires --key")
+	f.StringVar(&o.key, "key", "", "key file in PEM format, requires --cert")
+	f.BoolVar(&o.mutualTLS, "mutual-tls", false, "require valid client certficate")
+	f.StringVar(&o.clientCA, "client-ca", "", "acceptable client certificate or CA")
 }


### PR DESCRIPTION
Expands server options to enforce client authentication via certificates with new options: `--mutual-tls` and `--client-ca`.