### PR TITLE
Support infinite HTTP client timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Available configuration values:
 - `http-error-retry` *DEPRECATED, see `store-options.<Location>.error-retry` - Number of times to retry failed chunk requests from HTTP stores
 - `s3-credentials` - Defines credentials for use with S3 stores. Especially useful if more than one S3 store is used. The key in the config needs to be the URL scheme and host used for the store, excluding the path, but including the port number if used in the store URL. It is also possible to use a [standard aws credentials file](https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html) in order to store s3 credentials.
 - `store-options` - Allows customization of chunk and index stores, for example comression settings, timeouts, retry behavior and keys. Not all options are applicable to every store, some of these like `timeout` are ignored for local stores. Some of these options, such as the client certificates are overwritten with any values set in the command line. Note that the store location used in the command line needs to match the key under `store-options` exactly for these options to be used. Watch out for trailing `/` in URLs.
-  - `timeout` - Time limit for chunk read or write operation in nanoseconds. Default: 1 minute.
+  - `timeout` - Time limit for chunk read or write operation in nanoseconds. Default: 1 minute. If set to a negative value, timeout is infinite.
   - `error-retry` - Number of times to retry failed chunk requests. Default: 0.
   - `client-cert` - Cerificate file to be used for stores where the server requires mutual SSL.
   - `client-key` - Key file to be used for stores where the server requires mutual SSL.

--- a/remotehttp.go
+++ b/remotehttp.go
@@ -73,9 +73,13 @@ func NewRemoteHTTPStoreBase(location *url.URL, opt StoreOptions) (*RemoteHTTPBas
 		TLSClientConfig:     tlsConfig,
 	}
 
+	// If no timeout was given in config (set to 0), then use 1 minute. If timeout is negative, use 0 to
+	// set an infinite timeout.
 	timeout := opt.Timeout
 	if timeout == 0 {
 		timeout = time.Minute
+	} else if timeout < 0 {
+		timeout = 0
 	}
 	client := &http.Client{Transport: tr, Timeout: timeout}
 


### PR DESCRIPTION
Allows negative values for the store timeout which makes the timeout infinite.