### PR TITLE
Dedup in-flight requests for chunks in the HTTP chunk-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ Not all types of stores support all operations. The table below lists the suppor
 | Prune | yes | yes | no | yes | no |
 | Verify | yes | yes | no | no | no |
 
+### Store failover
+
+Given stores with identical content (same chunks in each), it is possible to group them in a way that provides resilience to failures. Store groups are specified in the command line using `|` as separator in the same `-s` option. For example using `-s http://server1/|http://server2`, requests will normally be sent to `server1`, but if a failure is encountered, all subsequent requests will be routed to `server2`. There is no automatic fail-back. A failure in `server2` will cause it to switch back to `server1`. Any number of stores can be grouped this way. Note that a missing chunk is treated as a failure immediately, no other servers will be tried, hence the need for all grouped stores to hold the same content.
+
 ### Remote indexes
 
 Indexes can be stored and retrieved from remote locations via SFTP, S3, and HTTP. Storing indexes remotely is optional and deliberately separate from chunk storage. While it's possible to store indexes in the same location as chunks in the case of SFTP and S3, this should only be done in secured environments. The built-in HTTP chunk store (`chunk-server` command) can not be used as index server. Use the `index-server` command instead to start an index server that serves indexes and can optionally store them as well (with `-w`).
@@ -300,12 +304,12 @@ Extract an image using several seeds present in a directory. Each of the `.caibx
 desync extract -s /local/store --seed-dir /path/to/images image-v3.qcow2.caibx image-v3.qcow2
 ```
 
-Mix and match remote stores and use a local cache store to improve performance.
+Mix and match remote stores and use a local cache store to improve performance. Also group two identical HTTP stores with `|` to provide failover in case of errors on one.
 
 ```text
 desync extract \
+       -s http://192.168.1.101/casync.store/|http://192.168.1.102/casync.store/ \
        -s ssh://192.168.1.1/path/to/casync.store/ \
-       -s http://192.168.1.2/casync.store/ \
        -s https://192.168.1.3/ssl.store/ \
        -c /path/to/cache \
        somefile.tar.caibx somefile.tar

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Among the distinguishing factors:
 - SHA512/256 is currently the only supported hash function.
 - Only chunk stores using zstd compression as well uncompressed are supported at this point.
 - Supports local stores as well as remote stores (as client) over SSH, SFTP and HTTP
-- Built-in HTTP(S) chunk server that can proxy multiple local or remote stores and also supports caching.
+- Built-in HTTP(S) chunk server that can proxy multiple local or remote stores and also supports caching and deduplication for concurrent requests.
 - Drop-in replacement for casync on SSH servers when serving chunks read-only
 - Support for catar files exists, but ignores SELinux and ACLs that may be present in existing catar files and those won't be present when creating a new catar with the `tar` command; FCAPs are supported only as a verbatim copy of "security.capability" XAttr.
 - Supports chunking with the same algorithm used by casync (see `make` command) but executed in parallel. Results are identical to what casync produces, same chunks and index files, but with significantly better performance. For example, up to 10x faster than casync if the chunks are already present in the store. If the chunks are new, it heavily depends on I/O, but it's still likely several times faster than casync.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Not all types of stores support all operations. The table below lists the suppor
 
 ### Store failover
 
-Given stores with identical content (same chunks in each), it is possible to group them in a way that provides resilience to failures. Store groups are specified in the command line using `|` as separator in the same `-s` option. For example using `-s http://server1/|http://server2`, requests will normally be sent to `server1`, but if a failure is encountered, all subsequent requests will be routed to `server2`. There is no automatic fail-back. A failure in `server2` will cause it to switch back to `server1`. Any number of stores can be grouped this way. Note that a missing chunk is treated as a failure immediately, no other servers will be tried, hence the need for all grouped stores to hold the same content.
+Given stores with identical content (same chunks in each), it is possible to group them in a way that provides resilience to failures. Store groups are specified in the command line using `|` as separator in the same `-s` option. For example using `-s "http://server1/|http://server2/"`, requests will normally be sent to `server1`, but if a failure is encountered, all subsequent requests will be routed to `server2`. There is no automatic fail-back. A failure in `server2` will cause it to switch back to `server1`. Any number of stores can be grouped this way. Note that a missing chunk is treated as a failure immediately, no other servers will be tried, hence the need for all grouped stores to hold the same content.
 
 ### Remote indexes
 
@@ -308,7 +308,7 @@ Mix and match remote stores and use a local cache store to improve performance. 
 
 ```text
 desync extract \
-       -s http://192.168.1.101/casync.store/|http://192.168.1.102/casync.store/ \
+       -s "http://192.168.1.101/casync.store/|http://192.168.1.102/casync.store/" \
        -s ssh://192.168.1.1/path/to/casync.store/ \
        -s https://192.168.1.3/ssl.store/ \
        -c /path/to/cache \

--- a/cache.go
+++ b/cache.go
@@ -45,11 +45,11 @@ func (c Cache) GetChunk(id ChunkID) (*Chunk, error) {
 }
 
 // HasChunk first checks the cache for the chunk, then the store.
-func (c Cache) HasChunk(id ChunkID) bool {
-	if c.l.HasChunk(id) || c.s.HasChunk(id) {
-		return true
+func (c Cache) HasChunk(id ChunkID) (bool, error) {
+	if hasChunk, err := c.l.HasChunk(id); err != nil || hasChunk {
+		return hasChunk, err
 	}
-	return false
+	return c.s.HasChunk(id)
 }
 
 func (c Cache) String() string {

--- a/chunkstorage.go
+++ b/chunkstorage.go
@@ -51,8 +51,8 @@ func (s *ChunkStorage) StoreChunk(chunk *Chunk) (err error) {
 	}
 
 	// Skip this chunk if the store already has it
-	if s.ws.HasChunk(chunk.ID()) {
-		return nil
+	if hasChunk, err := s.ws.HasChunk(chunk.ID()); err != nil || hasChunk {
+		return err
 	}
 
 	// The chunk was marked as "processed" above. If there's a problem to actually

--- a/cmd/desync/cache.go
+++ b/cmd/desync/cache.go
@@ -67,7 +67,7 @@ func runCache(ctx context.Context, opt cacheOptions, args []string) error {
 		ids = append(ids, id)
 	}
 
-	s, err := multiStore(opt.cmdStoreOptions, opt.stores...)
+	s, err := multiStoreWithRouter(opt.cmdStoreOptions, opt.stores...)
 	if err != nil {
 		return err
 	}

--- a/cmd/desync/chunkserver.go
+++ b/cmd/desync/chunkserver.go
@@ -94,11 +94,17 @@ func runChunkServer(ctx context.Context, opt chunkServerOptions, args []string) 
 	)
 	if opt.writable {
 		s, err = WritableStore(opt.stores[0], opt.cmdStoreOptions)
+		if err != nil {
+			return err
+		}
 	} else {
 		s, err = MultiStoreWithCache(opt.cmdStoreOptions, opt.cache, opt.stores...)
-	}
-	if err != nil {
-		return err
+		if err != nil {
+			return err
+		}
+		// We want to take the edge of a large number of requests coming in for the same chunk. No need
+		// to hit the (potentially slow) upstream stores for duplicated requests.
+		s = desync.NewDedupQueue(s)
 	}
 	defer s.Close()
 

--- a/cmd/desync/info.go
+++ b/cmd/desync/info.go
@@ -97,7 +97,7 @@ func runInfo(ctx context.Context, opt infoOptions, args []string) error {
 			wg.Add(1)
 			go func() {
 				for id := range ids {
-					if store.HasChunk(id) {
+					if hasChunk, err := store.HasChunk(id); err != nil && hasChunk {
 						atomic.AddUint64(&results.InStore, 1)
 					}
 				}

--- a/cmd/desync/info.go
+++ b/cmd/desync/info.go
@@ -97,7 +97,7 @@ func runInfo(ctx context.Context, opt infoOptions, args []string) error {
 			wg.Add(1)
 			go func() {
 				for id := range ids {
-					if hasChunk, err := store.HasChunk(id); err != nil && hasChunk {
+					if hasChunk, err := store.HasChunk(id); err == nil && hasChunk {
 						atomic.AddUint64(&results.InStore, 1)
 					}
 				}

--- a/cmd/desync/info.go
+++ b/cmd/desync/info.go
@@ -85,7 +85,7 @@ func runInfo(ctx context.Context, opt infoOptions, args []string) error {
 	results.Unique = len(deduped)
 
 	if len(opt.stores) > 0 {
-		store, err := multiStore(cmdStoreOptions{n: opt.n}, opt.stores...)
+		store, err := multiStoreWithRouter(cmdStoreOptions{n: opt.n}, opt.stores...)
 		if err != nil {
 			return err
 		}

--- a/cmd/desync/info_test.go
+++ b/cmd/desync/info_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInfoCommand(t *testing.T) {
+	expectedOutput := []byte(`{
+		"total": 161,
+		"unique": 131,
+		"in-store": 131,
+		"size": 2097152,
+		"chunk-size-min": 2048,
+		"chunk-size-avg": 8192,
+		"chunk-size-max": 32768
+	}`)
+	exp := make(map[string]interface{})
+	err := json.Unmarshal(expectedOutput, &exp)
+	require.NoError(t, err)
+
+	cmd := newInfoCommand(context.Background())
+	cmd.SetArgs([]string{"-s", "testdata/blob1.store", "testdata/blob1.caibx"})
+	b := new(bytes.Buffer)
+
+	// Redirect the command's output
+	stdout = b
+	cmd.SetOutput(ioutil.Discard)
+	_, err = cmd.ExecuteC()
+	require.NoError(t, err)
+
+	// Decode the output and compare to what's expected
+	got := make(map[string]interface{})
+	err = json.Unmarshal(b.Bytes(), &got)
+	require.NoError(t, err)
+	require.Equal(t, exp, got)
+}

--- a/copy.go
+++ b/copy.go
@@ -28,7 +28,11 @@ func Copy(ctx context.Context, ids []ChunkID, src Store, dst WriteStore, n int, 
 				if pb != nil {
 					pb.Increment()
 				}
-				if dst.HasChunk(id) {
+				hasChunk, err := dst.HasChunk(id)
+				if err != nil {
+					return err
+				}
+				if hasChunk {
 					continue
 				}
 				chunk, err := src.GetChunk(id)

--- a/dedupqueue.go
+++ b/dedupqueue.go
@@ -1,0 +1,133 @@
+package desync
+
+import (
+	"fmt"
+	"sync"
+)
+
+var _ Store = &DedupQueue{}
+
+// DedupQueue wraps a store and provides deduplication of incoming chunk requests. This is useful when
+// a burst of requests for the same chunk is received and the chunk store serving those is slow. With
+// the DedupQueue wrapper, concurrent requests for the same chunk will result in just one request to the
+// upstread store. Implements the Store interface.
+type DedupQueue struct {
+	store         Store
+	mu            sync.Mutex
+	getChunkQueue *queue
+	hasChunkQueue *queue
+}
+
+// NewDedupQueue initializes a new instance of the wrapper.
+func NewDedupQueue(store Store) *DedupQueue {
+	return &DedupQueue{
+		store:         store,
+		getChunkQueue: newQueue(),
+		hasChunkQueue: newQueue(),
+	}
+}
+
+func (q *DedupQueue) GetChunk(id ChunkID) (*Chunk, error) {
+	req, isInFlight := q.getChunkQueue.loadOrStore(id)
+
+	if isInFlight { // The request is already in-flight, wait for it to come back
+		data, err := req.wait()
+		switch b := data.(type) {
+		case nil:
+			return nil, err
+		case *Chunk:
+			return b, err
+		default:
+			return nil, fmt.Errorf("internal error: unexpected type %T", data)
+		}
+	}
+
+	// This request is the first one for this chunk, execute as normal
+	b, err := q.store.GetChunk(id)
+
+	// Signal to any others that wait for us that we're done, they'll use our data
+	// and don't need to hit the store themselves
+	req.markDone(b, err)
+
+	// We're done, drop the request from the queue to avoid keeping all the chunk data
+	// in memory after the request is done
+	q.getChunkQueue.delete(id)
+	return b, err
+}
+
+func (q *DedupQueue) HasChunk(id ChunkID) (bool, error) {
+	req, isInFlight := q.getChunkQueue.loadOrStore(id)
+
+	if isInFlight { // The request is already in-flight, wait for it to come back
+		data, err := req.wait()
+		return data.(bool), err
+	}
+
+	// This request is the first one for this chunk, execute as normal
+	hasChunk, err := q.store.HasChunk(id)
+
+	// Signal to any others that wait for us that we're done, they'll use our data
+	// and don't need to hit the store themselves
+	req.markDone(hasChunk, err)
+
+	// We're done, drop the request from the queue to avoid keeping all in memory
+	q.getChunkQueue.delete(id)
+	return hasChunk, err
+}
+
+func (q *DedupQueue) String() string { return q.store.String() }
+
+func (q *DedupQueue) Close() error { return q.store.Close() }
+
+// queue manages the in-flight requests
+type queue struct {
+	requests map[ChunkID]*request
+	mu       sync.Mutex
+}
+
+func newQueue() *queue {
+	return &queue{requests: make(map[ChunkID]*request)}
+}
+
+// Returns either a new request, or an existing one from the queue.
+func (q *queue) loadOrStore(id ChunkID) (*request, bool) {
+	q.mu.Lock()
+	req, isInFlight := q.requests[id]
+	if !isInFlight {
+		req = newRequest()
+		q.requests[id] = req
+	}
+	q.mu.Unlock()
+	return req, isInFlight
+}
+
+func (q *queue) delete(id ChunkID) {
+	q.mu.Lock()
+	delete(q.requests, id)
+	q.mu.Unlock()
+}
+
+// queueRequests is used to dedup requests for GetChunk() or HasChunk() with the data
+// being either the chunk itself or a bool in case of HasChunk().
+type request struct {
+	data interface{}
+	err  error
+	done chan struct{}
+}
+
+func newRequest() *request {
+	return &request{done: make(chan struct{})}
+}
+
+// Wait for the request to complete. Returns the data as well as the error from the request.
+func (r request) wait() (interface{}, error) {
+	<-r.done
+	return r.data, r.err
+}
+
+// Set the result data and marks this request as comlete.
+func (r request) markDone(data interface{}, err error) {
+	r.data = data
+	r.err = err
+	close(r.done)
+}

--- a/dedupqueue_test.go
+++ b/dedupqueue_test.go
@@ -1,0 +1,91 @@
+package desync
+
+import (
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestDedupQueueSimple(t *testing.T) {
+	// var requests int64
+	// store := &TestStore{
+	// 	GetChunkFunc: func(ChunkID) (*Chunk, error) {
+	// 		atomic.AddInt64(&requests, 1)
+	// 		return NewChunkFromUncompressed([]byte{0}), nil
+	// 	},
+	// }
+	exists := ChunkID{0}
+	notExists := ChunkID{1}
+	store := &TestStore{
+		Chunks: map[ChunkID][]byte{
+			exists: {0, 1, 2, 3},
+		},
+	}
+	q := NewDedupQueue(store)
+
+	// First compare we're getting the expected data in the positive case
+	bExpected, err := store.GetChunk(exists)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bActual, err := q.GetChunk(exists)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(bActual, bExpected) {
+		t.Fatalf("got %v; want %v", bExpected, bActual)
+	}
+
+	// Now make sure errors too are passed correctly
+	_, err = q.GetChunk(notExists)
+	if _, ok := err.(ChunkMissing); !ok {
+		t.Fatalf("got '%v'; want chunk missing error", err)
+	}
+
+	// Check HasChunk() as well
+	hasChunk, err := q.HasChunk(exists)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasChunk {
+		t.Fatalf("HasChunk() = false; want true")
+	}
+}
+
+func TestDedupQueueParallel(t *testing.T) {
+	// Make a store that counts the requests to it
+	var requests int64
+	store := &TestStore{
+		GetChunkFunc: func(ChunkID) (*Chunk, error) {
+			time.Sleep(time.Millisecond) // make it artificially slow to not complete too early
+			atomic.AddInt64(&requests, 1)
+			return NewChunkFromUncompressed([]byte{0}), nil
+		},
+	}
+	q := NewDedupQueue(store)
+
+	var (
+		wg    sync.WaitGroup
+		start = make(chan struct{})
+	)
+
+	// Start several goroutines all asking for the same chunk from the store
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			<-start
+			q.GetChunk(ChunkID{0})
+			wg.Done()
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	// There should ideally be just one requests that was done on the upstream store
+	if requests > 1 {
+		t.Fatalf("%d requests to the store; want 1", requests)
+	}
+}

--- a/failover.go
+++ b/failover.go
@@ -1,0 +1,105 @@
+package desync
+
+import (
+	"strings"
+	"sync"
+)
+
+var _ Store = &FailoverGroup{}
+
+// FailoverGroup wraps multiple stores to provide failover when one or more stores in the group fail.
+// Only one of the stores in the group is considered "active" at a time. If an unexpected error is returned
+// from the active store, the next store in the group becomes the active one and the request retried.
+// When all stores returned a failure, the group will pass up the failure to the caller. The active store
+// rotates through all available stores. All stores in the group are expected to contain the same chunks,
+// there is no failover for missing chunks. Implements the Store interface.
+type FailoverGroup struct {
+	stores []Store
+	active int
+	mu     sync.RWMutex
+}
+
+// NewFailoverGroup initializes and returns a store wraps multiple stores to form a group that can fail over
+// between them on failure from one.
+func NewFailoverGroup(stores ...Store) *FailoverGroup {
+	return &FailoverGroup{stores: stores}
+}
+
+func (g *FailoverGroup) GetChunk(id ChunkID) (*Chunk, error) {
+	var gErr error
+	for i := 0; i < len(g.stores); i++ {
+		s, active := g.current()
+		b, err := s.GetChunk(id)
+		if err == nil { // return right away on success
+			return b, err
+		}
+
+		// All stores are meant to hold the same chunks, fail on the first missing chunk
+		if _, ok := err.(ChunkMissing); ok {
+			return b, err
+		}
+
+		// Record the error to be returned when all requests fail
+		gErr = err
+
+		// Fail over to the next store
+		g.errorFrom(active)
+	}
+	return nil, gErr
+}
+
+func (g *FailoverGroup) HasChunk(id ChunkID) (bool, error) {
+	var gErr error
+	for i := 0; i < len(g.stores); i++ {
+		s, active := g.current()
+		hc, err := s.HasChunk(id)
+		if err == nil { // return right away on success
+			return hc, err
+		}
+
+		// Record the error to be returned when all requests fail
+		gErr = err
+
+		// Fail over to the next store
+		g.errorFrom(active)
+	}
+	return false, gErr
+}
+
+func (g *FailoverGroup) String() string {
+	var str []string
+	for _, s := range g.stores {
+		str = append(str, s.String())
+	}
+	return strings.Join(str, "|")
+}
+
+func (g *FailoverGroup) Close() error {
+	var closeErr error
+	for _, s := range g.stores {
+		if err := s.Close(); err != nil {
+			closeErr = err
+		}
+	}
+	return closeErr
+}
+
+// Thread-safe method to return the currently active store.
+func (g *FailoverGroup) current() (Store, int) {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	return g.stores[g.active], g.active
+}
+
+// Fail over to the next available store after recveiving an error from i (the active). We
+// need i to know which store returned the error as there could be failures from concurrent
+// requests. Another request could have initiated the failover already. So ignore if i is not
+// (no longer) the active store.
+func (g *FailoverGroup) errorFrom(i int) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if i != g.active {
+		return
+	}
+	g.active = (g.active + 1) % len(g.stores)
+}

--- a/failover_test.go
+++ b/failover_test.go
@@ -1,0 +1,124 @@
+package desync
+
+import (
+	"crypto/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func TestFailoverMissingChunk(t *testing.T) {
+	s := &TestStore{}
+	g := NewFailoverGroup(s)
+	_, err := g.GetChunk(ChunkID{0})
+	if _, ok := err.(ChunkMissing); !ok {
+		t.Fatalf("expected missing chunk error, got %T", err)
+	}
+}
+
+func TestFailoverAllError(t *testing.T) {
+	var failed = errors.New("failed")
+	storeFail := &TestStore{
+		GetChunkFunc: func(ChunkID) (*Chunk, error) { return nil, failed },
+	}
+	g := NewFailoverGroup(storeFail, storeFail)
+	if _, err := g.GetChunk(ChunkID{0}); err != failed {
+		t.Fatalf("expected error, got %T", err)
+	}
+}
+
+func TestFailoverSimple(t *testing.T) {
+	// Create two stores, one that always fails and one that works
+	storeFail := &TestStore{
+		GetChunkFunc: func(ChunkID) (*Chunk, error) { return nil, errors.New("failed") },
+	}
+	storeSucc := &TestStore{
+		GetChunkFunc: func(ChunkID) (*Chunk, error) { return nil, nil },
+	}
+
+	// Group the two stores together, the failing ones first
+	g := NewFailoverGroup(storeFail, storeFail, storeSucc)
+
+	// Request a chunk, should succeed
+	if _, err := g.GetChunk(ChunkID{0}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Look inside the group to confirm we failed over to the last one
+	if g.active != 2 {
+		t.Fatalf("expected g.active=1, but got %d", g.active)
+	}
+}
+
+func TestFailoverMutliple(t *testing.T) {
+	// Create two stores, one that fails when x is 1 and the other fails when x is 0
+	var x int64
+	storeA := &TestStore{
+		GetChunkFunc: func(id ChunkID) (*Chunk, error) {
+			if atomic.LoadInt64(&x) == 0 {
+				return nil, nil
+			}
+			return nil, errors.New("failed")
+		},
+	}
+	storeB := &TestStore{
+		GetChunkFunc: func(id ChunkID) (*Chunk, error) {
+			if atomic.LoadInt64(&x) == 1 {
+				return nil, nil
+			}
+			return nil, errors.New("failed")
+		},
+	}
+
+	// Group the two stores together, the failing ones first
+	g := NewFailoverGroup(storeA, storeB)
+
+	var (
+		wg       sync.WaitGroup
+		done     = make(chan struct{})
+		timeout  = time.After(time.Second)
+		failOver = time.Tick(10 * time.Millisecond)
+	)
+
+	// Run several goroutines querying the group in a tight loop
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			var id ChunkID
+			for {
+				time.Sleep(time.Millisecond)
+				select {
+				case <-done:
+					wg.Done()
+					return
+				default:
+					rand.Read(id[:])
+					if _, err := g.GetChunk(id); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+		}()
+	}
+
+	// Make the stores fail over every 10 ms
+	go func() {
+		wg.Add(1)
+		for {
+			select {
+			case <-timeout: // done running
+				close(done)
+				wg.Done()
+				return
+			case <-failOver: // switch over to the other store
+				newX := (x + 1) % 2
+				atomic.StoreInt64(&x, newX)
+			}
+		}
+	}()
+
+	wg.Wait()
+}

--- a/httphandler.go
+++ b/httphandler.go
@@ -61,7 +61,12 @@ func (h HTTPHandler) get(id ChunkID, w http.ResponseWriter) {
 }
 
 func (h HTTPHandler) head(id ChunkID, w http.ResponseWriter) {
-	if h.s.HasChunk(id) {
+	hasChunk, err := h.s.HasChunk(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if hasChunk {
 		w.WriteHeader(http.StatusOK)
 		return
 	}

--- a/httphandler_test.go
+++ b/httphandler_test.go
@@ -49,7 +49,11 @@ func TestHTTPHandlerReadWrite(t *testing.T) {
 	}
 
 	// Check it's in the store
-	if !rwStore.HasChunk(id) {
+	hashChunk, err := rwStore.HasChunk(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hashChunk {
 		t.Fatal("chunk not found in store")
 	}
 
@@ -111,12 +115,20 @@ func TestHTTPHandlerCompression(t *testing.T) {
 	}
 
 	// Check it's in the store when looking for compressed chunks
-	if !coStore.HasChunk(id) {
+	coExists, err := coStore.HasChunk(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !coExists {
 		t.Fatal("chunk not found in store")
 	}
 
 	// It's also visible when looking for uncompressed data
-	if !unStore.HasChunk(id) {
+	unExists, err := unStore.HasChunk(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !unExists {
 		t.Fatal("chunk not found in store")
 	}
 

--- a/index_test.go
+++ b/index_test.go
@@ -139,7 +139,11 @@ func TestIndexChunking(t *testing.T) {
 		if err != nil {
 			t.Fatal(id)
 		}
-		if !s.HasChunk(id) {
+		hasChunk, err := s.HasChunk(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !hasChunk {
 			t.Fatalf("store is missing chunk %s", id)
 		}
 	}

--- a/local.go
+++ b/local.go
@@ -13,6 +13,8 @@ import (
 	"github.com/folbricht/tempfile"
 )
 
+var _ WriteStore = LocalStore{}
+
 // LocalStore casync store
 type LocalStore struct {
 	Base string
@@ -216,10 +218,16 @@ func (s LocalStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 }
 
 // HasChunk returns true if the chunk is in the store
-func (s LocalStore) HasChunk(id ChunkID) bool {
+func (s LocalStore) HasChunk(id ChunkID) (bool, error) {
 	_, p := s.nameFromID(id)
 	_, err := os.Stat(p)
-	return err == nil
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
 }
 
 func (s LocalStore) String() string {

--- a/local_test.go
+++ b/local_test.go
@@ -31,7 +31,11 @@ func TestLocalStoreCompressed(t *testing.T) {
 	}
 
 	// Check it's in the store
-	if !s.HasChunk(id) {
+	hasChunk, err := s.HasChunk(id)
+	if err != nil {
+		t.Fatal((err))
+	}
+	if !hasChunk {
 		t.Fatal("chunk not found in store")
 	}
 
@@ -84,7 +88,11 @@ func TestLocalStoreUncompressed(t *testing.T) {
 	}
 
 	// Check it's in the store
-	if !s.HasChunk(id) {
+	hasChunk, err := s.HasChunk(id)
+	if err != nil {
+		t.Fatal((err))
+	}
+	if !hasChunk {
 		t.Fatal("chunk not found in store")
 	}
 

--- a/protocolserver_test.go
+++ b/protocolserver_test.go
@@ -18,8 +18,10 @@ func TestProtocolServer(t *testing.T) {
 	chunkIn := NewChunkFromUncompressed(uncompressed)
 	compressed, _ := chunkIn.Compressed()
 	id := chunkIn.ID()
-	store := TestStore{
-		id: compressed,
+	store := &TestStore{
+		Chunks: map[ChunkID][]byte{
+			id: compressed,
+		},
 	}
 	ps := NewProtocolServer(r2, w1, store)
 

--- a/remotessh.go
+++ b/remotessh.go
@@ -9,6 +9,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+var _ Store = &RemoteSSH{}
+
 // RemoteSSH is a remote casync store accessed via SSH. Supports running
 // multiple sessions to improve throughput.
 type RemoteSSH struct {
@@ -55,11 +57,11 @@ func (r *RemoteSSH) Close() error {
 // this way, pulling the whole chunk just to see if it's present, is very
 // inefficient. I'm not aware of a way to implement it with the casync protocol
 // any other way.
-func (r *RemoteSSH) HasChunk(id ChunkID) bool {
-	if _, err := r.GetChunk(id); err == nil {
-		return true
+func (r *RemoteSSH) HasChunk(id ChunkID) (bool, error) {
+	if _, err := r.GetChunk(id); err != nil {
+		return false, err
 	}
-	return false
+	return true, nil
 }
 
 func (r *RemoteSSH) String() string {

--- a/s3.go
+++ b/s3.go
@@ -13,6 +13,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+var _ WriteStore = S3Store{}
+
 // S3StoreBase is the base object for all chunk and index stores with S3 backing
 type S3StoreBase struct {
 	Location string
@@ -133,10 +135,10 @@ func (s S3Store) StoreChunk(chunk *Chunk) error {
 }
 
 // HasChunk returns true if the chunk is in the store
-func (s S3Store) HasChunk(id ChunkID) bool {
+func (s S3Store) HasChunk(id ChunkID) (bool, error) {
 	name := s.nameFromID(id)
 	_, err := s.client.StatObject(s.bucket, name, minio.StatObjectOptions{})
-	return err == nil
+	return err == nil, nil
 }
 
 // RemoveChunk deletes a chunk, typically an invalid one, from the filesystem.

--- a/sftp.go
+++ b/sftp.go
@@ -19,6 +19,8 @@ import (
 	"github.com/pkg/sftp"
 )
 
+var _ WriteStore = &SFTPStore{}
+
 // SFTPStoreBase is the base object for SFTP chunk and index stores.
 type SFTPStoreBase struct {
 	location *url.URL
@@ -200,12 +202,12 @@ func (s *SFTPStore) StoreChunk(chunk *Chunk) error {
 }
 
 // HasChunk returns true if the chunk is in the store
-func (s *SFTPStore) HasChunk(id ChunkID) bool {
+func (s *SFTPStore) HasChunk(id ChunkID) (bool, error) {
 	c := <-s.pool
 	defer func() { s.pool <- c }()
 	name := c.nameFromID(id)
 	_, err := c.client.Stat(name)
-	return err == nil
+	return err == nil, nil
 }
 
 // Prune removes any chunks from the store that are not contained in a list

--- a/store.go
+++ b/store.go
@@ -11,7 +11,7 @@ import (
 // HTTP remote stores currently.
 type Store interface {
 	GetChunk(id ChunkID) (*Chunk, error)
-	HasChunk(id ChunkID) bool
+	HasChunk(id ChunkID) (bool, error)
 	io.Closer
 	fmt.Stringer
 }

--- a/store_test.go
+++ b/store_test.go
@@ -1,22 +1,34 @@
 package desync
 
-var _ Store = TestStore{}
+var _ Store = &TestStore{}
 
-type TestStore map[ChunkID][]byte
+type TestStore struct {
+	Chunks map[ChunkID][]byte
 
-func (s TestStore) GetChunk(id ChunkID) (*Chunk, error) {
-	b, ok := s[id]
+	// Override the default behavior by setting these functions
+	GetChunkFunc func(ChunkID) (*Chunk, error)
+	HasChunkFunc func(ChunkID) (bool, error)
+}
+
+func (s *TestStore) GetChunk(id ChunkID) (*Chunk, error) {
+	if s.GetChunkFunc != nil {
+		return s.GetChunkFunc(id)
+	}
+	b, ok := s.Chunks[id]
 	if !ok {
 		return nil, ChunkMissing{id}
 	}
 	return &Chunk{compressed: b}, nil
 }
 
-func (s TestStore) HasChunk(id ChunkID) (bool, error) {
-	_, ok := s[id]
+func (s *TestStore) HasChunk(id ChunkID) (bool, error) {
+	if s.HasChunkFunc != nil {
+		return s.HasChunkFunc(id)
+	}
+	_, ok := s.Chunks[id]
 	return ok, nil
 }
 
-func (s TestStore) String() string { return "TestStore" }
+func (s *TestStore) String() string { return "TestStore" }
 
-func (s TestStore) Close() error { return nil }
+func (s *TestStore) Close() error { return nil }

--- a/store_test.go
+++ b/store_test.go
@@ -1,5 +1,7 @@
 package desync
 
+var _ Store = TestStore{}
+
 type TestStore map[ChunkID][]byte
 
 func (s TestStore) GetChunk(id ChunkID) (*Chunk, error) {
@@ -10,8 +12,9 @@ func (s TestStore) GetChunk(id ChunkID) (*Chunk, error) {
 	return &Chunk{compressed: b}, nil
 }
 
-func (s TestStore) HasChunk(id ChunkID) bool {
-	return false
+func (s TestStore) HasChunk(id ChunkID) (bool, error) {
+	_, ok := s[id]
+	return ok, nil
 }
 
 func (s TestStore) String() string { return "TestStore" }

--- a/storerouter.go
+++ b/storerouter.go
@@ -41,13 +41,17 @@ func (r StoreRouter) GetChunk(id ChunkID) (*Chunk, error) {
 
 // HasChunk returns true if one of the containing stores has the chunk. It
 // goes through the stores in order and returns as soon as the chunk is found.
-func (r StoreRouter) HasChunk(id ChunkID) bool {
+func (r StoreRouter) HasChunk(id ChunkID) (bool, error) {
 	for _, s := range r.Stores {
-		if s.HasChunk(id) {
-			return true
+		hasChunk, err := s.HasChunk(id)
+		if err != nil {
+			return false, err
+		}
+		if hasChunk {
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 func (r StoreRouter) String() string {


### PR DESCRIPTION
Closes #103 

When a large number of requests for the same chunk are made to a chunk-server concurrently and isn't found in the local cache (yet), all those requests are routed to the upstream store which may be remote/slow. To avoid these peaks of requests for the same chunk, this PR adds a dedup feature which will restrict the number of requests for the same chunk that is sent to upstream stores (or cache stores) to one. The first request will be handled as normal, subsequest requests are all waiting for the result of the first. 