### PR TITLE
Improve parallel chunking when dealing with large sparse files

### DIFF
--- a/chunker.go
+++ b/chunker.go
@@ -222,9 +222,9 @@ func (c *Chunker) split(i int, err error) (uint64, []byte, error) {
 func (c *Chunker) Advance(n int) error {
 	// We might still have bytes in the buffer. These count towards the move forward.
 	// It's possible the advance stays within the buffer and doesn't impact the reader.
+	c.start += uint64(n)
 	if n <= len(c.buf) {
 		c.buf = c.buf[n:]
-		c.start += uint64(n)
 		return nil
 	}
 	readerN := int64(n - len(c.buf))
@@ -234,7 +234,6 @@ func (c *Chunker) Advance(n int) error {
 		_, err := rs.Seek(readerN, io.SeekCurrent)
 		return err
 	}
-
 	_, err := io.CopyN(ioutil.Discard, c.r, readerN)
 	return err
 }

--- a/chunker.go
+++ b/chunker.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math/bits"
 )
 
@@ -212,6 +213,30 @@ func (c *Chunker) split(i int, err error) (uint64, []byte, error) {
 	c.hIdx = 0
 	c.hValue = 0
 	return start, b, err
+}
+
+// Advance n bytes without producing chunks. This can be used if the content of the next
+// section in the file is known (i.e. it is known that there are a number of null chunks
+// coming). This resets everything in the chunker and behaves as if the streams starts
+// at (current position+n).
+func (c *Chunker) Advance(n int) error {
+	// We might still have bytes in the buffer. These count towards the move forward.
+	// It's possible the advance stays within the buffer and doesn't impact the reader.
+	if n <= len(c.buf) {
+		c.buf = c.buf[n:]
+		c.start += uint64(n)
+		return nil
+	}
+	readerN := int64(n - len(c.buf))
+	c.buf = nil
+	rs, ok := c.r.(io.Seeker)
+	if ok {
+		_, err := rs.Seek(readerN, io.SeekCurrent)
+		return err
+	}
+
+	_, err := io.CopyN(ioutil.Discard, c.r, readerN)
+	return err
 }
 
 // Min returns the minimum chunk size

--- a/chunker_test.go
+++ b/chunker_test.go
@@ -191,9 +191,7 @@ func TestChunkerAdvance(t *testing.T) {
 	nullChunk := NewNullChunk(ChunkSizeMaxDefault)
 
 	// Build the input slice consisting of Null+dataA+Null+dataB
-	input := append(nullChunk.Data, dataA...)
-	input = append(input, nullChunk.Data...)
-	input = append(input, dataB...)
+	input := join(nullChunk.Data, dataA, nullChunk.Data, dataB)
 
 	c, err := NewChunker(bytes.NewReader(input), ChunkSizeMinDefault, ChunkSizeAvgDefault, ChunkSizeMaxDefault)
 	if err != nil {

--- a/make.go
+++ b/make.go
@@ -74,6 +74,11 @@ func IndexFromFile(ctx context.Context,
 		defer pb.Finish()
 	}
 
+	// Null chunks is produced when a large section of null bytes is chunked. There are no
+	// split points in those sections so it's always of max chunk size. Used for optimizations
+	// when chunking files with large empty sections.
+	nullChunk := NewNullChunk(max)
+
 	// Create/initialize the workers
 	worker := make([]*pChunker, n)
 	for i := 0; i < n; i++ {
@@ -96,11 +101,12 @@ func IndexFromFile(ctx context.Context,
 			return index, stats, err
 		}
 		p := &pChunker{
-			chunker: c,
-			results: make(chan IndexChunk, mChunks),
-			done:    make(chan struct{}),
-			offset:  start,
-			stats:   &stats,
+			chunker:   c,
+			results:   make(chan IndexChunk, mChunks),
+			done:      make(chan struct{}),
+			offset:    start,
+			stats:     &stats,
+			nullChunk: nullChunk,
 		}
 		worker[i] = p
 	}
@@ -163,6 +169,9 @@ type pChunker struct {
 	eof   bool
 	sync  IndexChunk
 	stats *ChunkingStats
+
+	// Null chunk for optimizing chunking sparse files
+	nullChunk *NullChunk
 }
 
 func (c *pChunker) start(ctx context.Context) {
@@ -200,8 +209,24 @@ func (c *pChunker) start(ctx context.Context) {
 
 		// Check if the next worker already has this chunk, at which point we stop
 		// here and let the next continue
-		if c.next != nil && c.next.syncWith(chunk) {
-			return
+		if c.next != nil {
+			inSync, zeroes := c.next.syncWith(chunk)
+			if inSync {
+				return
+			}
+			numNullChunks := int(int(zeroes) / len(c.nullChunk.Data))
+			if numNullChunks > 0 {
+				if err := c.chunker.Advance(numNullChunks * len(c.nullChunk.Data)); err != nil {
+					c.err = err
+					return
+				}
+				nc := chunk
+				for i := 0; i < numNullChunks; i++ {
+					nc = IndexChunk{Start: nc.Start + nc.Size, Size: uint64(len(c.nullChunk.Data)), ID: c.nullChunk.ID}
+					c.results <- nc
+					zeroes -= uint64(len(c.nullChunk.Data))
+				}
+			}
 		}
 
 		// If the next worker has stopped and has no more chunks in its bucket,
@@ -225,24 +250,59 @@ func (c *pChunker) active() bool {
 	}
 }
 
-// Returns true if the given chunk lines up with one in the current bucket
-func (c *pChunker) syncWith(chunk IndexChunk) bool {
+// Returns true if the given chunk lines up with one in the current bucket. Also returns
+// the number of zero bytes this chunker has found from 'chunk'. This helps the previous
+// chunker to skip chunking over those areas and put a null-chunks (always max size) in
+// place instead.
+func (c *pChunker) syncWith(chunk IndexChunk) (bool, uint64) {
 	// Read from our bucket until we're past (or match) where the previous worker
 	// currently is
+	var prev IndexChunk
 	for chunk.Start > c.sync.Start {
+		prev = c.sync
 		var ok bool
 		select {
 		case c.sync, ok = <-c.results:
 			if !ok {
-				return false
+				return false, 0
 			}
 		default: // Nothing in my bucket? Move on
-			return false
+			return false, 0
 		}
 	}
-	// Did we find a match with the previous worker. If so the previous worker
+
+	// Did we find a match with the previous worker? If so, the previous worker
 	// should stop and this one will keep going
-	return chunk.Start == c.sync.Start && chunk.Size == c.sync.Size
+	if chunk.Start == c.sync.Start && chunk.Size == c.sync.Size {
+		return true, 0
+	}
+
+	// The previous chunker didn't sync up with this one, but perhaps we're in a large area
+	// of nulls (chunk split points are unlikely to line up). If so we can tell the previous
+	// chunker how many nulls are coming so it doesn't need to do all the work again and can
+	// skip ahead, producing null-chunks of max size.
+	if c.sync.ID == c.nullChunk.ID && prev.ID == c.nullChunk.ID {
+		// We know there're at least some null chunks in front of the previous chunker. Let's
+		// see if there are more in our bucket so we can tell the previous chunker how far to
+		// skip ahead.
+		n := prev.Start + prev.Size - chunk.Start
+		for {
+			var ok bool
+			select {
+			case c.sync, ok = <-c.results:
+				if !ok {
+					return false, n
+				}
+			default: // Nothing more in my bucket? Move on
+				return false, n
+			}
+			if c.sync.ID != c.nullChunk.ID { // Hit the end of the null chunks, stop here
+				break
+			}
+			n += uint64(len(c.nullChunk.Data))
+		}
+	}
+	return false, 0
 }
 
 // ChunkingStats is used to report statistics of a parallel chunking operation.

--- a/make.go
+++ b/make.go
@@ -281,11 +281,12 @@ func (c *pChunker) syncWith(chunk IndexChunk) (bool, uint64) {
 	// of nulls (chunk split points are unlikely to line up). If so we can tell the previous
 	// chunker how many nulls are coming so it doesn't need to do all the work again and can
 	// skip ahead, producing null-chunks of max size.
+	var n uint64
 	if c.sync.ID == c.nullChunk.ID && prev.ID == c.nullChunk.ID {
 		// We know there're at least some null chunks in front of the previous chunker. Let's
 		// see if there are more in our bucket so we can tell the previous chunker how far to
 		// skip ahead.
-		n := prev.Start + prev.Size - chunk.Start
+		n = prev.Start + prev.Size - chunk.Start
 		for {
 			var ok bool
 			select {
@@ -302,7 +303,7 @@ func (c *pChunker) syncWith(chunk IndexChunk) (bool, uint64) {
 			n += uint64(len(c.nullChunk.Data))
 		}
 	}
-	return false, 0
+	return false, n
 }
 
 // ChunkingStats is used to report statistics of a parallel chunking operation.

--- a/make_test.go
+++ b/make_test.go
@@ -20,10 +20,11 @@ func TestParallelChunking(t *testing.T) {
 	rand.Read(rand2)
 
 	tests := map[string][][]byte{
-		"random input":  {rand1, rand2, rand1, rand2, rand1},
-		"leading null":  {null, null, null, null, rand1, rand2},
-		"trailing null": {rand1, rand2, null, null, null, null},
-		"middle null":   {rand1, null, null, null, null, rand2},
+		"random input":    {rand1, rand2, rand1, rand2, rand1},
+		"leading null":    {null, null, null, null, rand1, rand2},
+		"trailing null":   {rand1, rand2, null, null, null, null},
+		"middle null":     {rand1, null, null, null, null, rand2},
+		"spread out null": {rand1, null, null, null, rand1, null, null, null, rand2},
 	}
 
 	for name, input := range tests {

--- a/make_test.go
+++ b/make_test.go
@@ -1,86 +1,85 @@
 package desync
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha512"
 	"fmt"
-	"io/ioutil"
+	"math/rand"
 	"os"
-	"reflect"
 	"testing"
+
+	"github.com/folbricht/tempfile"
 )
 
 func TestParallelChunking(t *testing.T) {
-	blank, err := ioutil.TempFile("", "blank")
-	if err != nil {
-		t.Fatal(err)
-	}
-	blank.Close()
-	defer os.RemoveAll(blank.Name())
+	null := make([]byte, 4*ChunkSizeMaxDefault)
+	rand1 := make([]byte, 4*ChunkSizeMaxDefault)
+	rand.Read(rand1)
+	rand2 := make([]byte, 4*ChunkSizeMaxDefault)
+	rand.Read(rand2)
 
-	// Create a file full of zeroes to test behaviour of the chunker when no
-	// boundaries can be found (the rolling hash will not produce boundaries
-	// for files full of nil bytes)
-	zeroes, err := ioutil.TempFile("", "zeroes")
-	if err != nil {
-		t.Fatal(err)
-	}
-	zeroes.Close()
-	defer os.RemoveAll(zeroes.Name())
-	if err = ioutil.WriteFile(zeroes.Name(), make([]byte, 1024*1024), 0644); err != nil {
-		t.Fatal(err)
-	}
-	// Make an array of files we want to test the chunker with
-	testFiles := []string{
-		"testdata/chunker.input",
-		zeroes.Name(),
-		blank.Name(),
+	tests := map[string][][]byte{
+		"random input":  {rand1, rand2, rand1, rand2, rand1},
+		"leading null":  {null, null, null, null, rand1, rand2},
+		"trailing null": {rand1, rand2, null, null, null, null},
+		"middle null":   {rand1, null, null, null, null, rand2},
 	}
 
-	// Split each file with different values for n (number of goroutes)
-	for _, name := range testFiles {
-		// Chunk the file single stream first to use the results as reference for
-		// the parallel chunking
-		f, err := os.Open(name)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer f.Close()
-		c, err := NewChunker(f, ChunkSizeMinDefault, ChunkSizeAvgDefault, ChunkSizeMaxDefault)
-		if err != nil {
-			t.Fatal(err)
-		}
-		var expected []IndexChunk
-		for {
-			start, buf, err := c.Next()
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Put the input data into a file for chunking
+			f, err := tempfile.New("", "")
 			if err != nil {
 				t.Fatal(err)
 			}
-			if len(buf) == 0 {
-				break
+			defer os.Remove(f.Name())
+			b := join(input...)
+			if _, err := f.Write(b); err != nil {
+				t.Fatal(err)
 			}
-			id := ChunkID(sha512.Sum512_256(buf))
-			expected = append(expected, IndexChunk{Start: start, Size: uint64(len(buf)), ID: id})
-		}
+			f.Close()
 
-		for n := 2; n < 3; n++ {
-			t.Run(fmt.Sprintf("%s, n=%d", name, n), func(t *testing.T) {
-				// Split it up in parallel
-				index, _, err := IndexFromFile(
-					context.Background(),
-					name,
-					n,
-					ChunkSizeMinDefault, ChunkSizeAvgDefault, ChunkSizeMaxDefault,
-					nil,
-				)
+			// Chunk the file single stream first to use the results as reference for
+			// the parallel chunking
+			c, err := NewChunker(bytes.NewReader(b), ChunkSizeMinDefault, ChunkSizeAvgDefault, ChunkSizeMaxDefault)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var expected []IndexChunk
+			for {
+				start, buf, err := c.Next()
 				if err != nil {
 					t.Fatal(err)
 				}
-				// Compare the results of the single stream chunking to the parallel ones
-				if !reflect.DeepEqual(index.Chunks, expected) {
-					t.Fatal("chunks from parallel splitter don't match single stream chunks")
+				if len(buf) == 0 {
+					break
 				}
-			})
-		}
+				id := ChunkID(sha512.Sum512_256(buf))
+				expected = append(expected, IndexChunk{Start: start, Size: uint64(len(buf)), ID: id})
+			}
+
+			// Chunk the file with the parallel chunking algorithm and different degrees of concurrency
+			for n := 1; n <= 10; n++ {
+				t.Run(fmt.Sprintf("%s, n=%d", name, n), func(t *testing.T) {
+					index, _, err := IndexFromFile(
+						context.Background(),
+						f.Name(),
+						n,
+						ChunkSizeMinDefault, ChunkSizeAvgDefault, ChunkSizeMaxDefault,
+						nil,
+					)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					for i := range expected {
+						if expected[i] != index.Chunks[i] {
+							t.Fatal("chunks from parallel splitter don't match single stream chunks")
+						}
+					}
+				})
+			}
+		})
 	}
 }


### PR DESCRIPTION
As per https://github.com/folbricht/desync/issues/110, chunking large sparse files was being hampered by null bytes not producing split points, but rather producing chunks of max chunk size. That made parallel chunking inefficient since no sync-points between different goroutines could be found withing those null regions.

This PR handles null chunks better by not relying on sync-points between multiple concurrent chunkers, but by communicating the size of the null regions and not having chunk them more than once.

Closes https://github.com/folbricht/desync/issues/110