### PR TITLE
Use a BST for the list of Goodye items

### DIFF
--- a/format.go
+++ b/format.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"os"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 )
@@ -622,4 +623,45 @@ func (e *FormatEncoder) Encode(v interface{}) (int64, error) {
 	default:
 		return 0, fmt.Errorf("unsupported format element '%s'", reflect.TypeOf(v))
 	}
+}
+
+// Create a balanced BST of goodbye items in catar. Modifies the input slice.
+func makeGoodbyeBST(in []FormatGoodbyeItem) []FormatGoodbyeItem {
+	// Sort the list by hash (primary) and offset (secondary)
+	sort.Slice(in, func(i, j int) bool {
+		switch {
+		case in[i].Hash < in[j].Hash:
+			return true
+		case in[i].Hash > in[j].Hash:
+			return false
+		default:
+			return in[i].Offset < in[j].Offset
+		}
+	})
+
+	// Convert the sorted array into a complete BST in array representation
+	out := make([]FormatGoodbyeItem, len(in))
+	e := uint(math.Log2(float64(len(in))) + 1)
+	bst(in, out, 0, e)
+	return out
+}
+
+func bst(in, out []FormatGoodbyeItem, i int, e uint) {
+	if len(in) == 0 {
+		return
+	}
+	p := 1 << (e - 1)
+	q := p << 1
+
+	var k int
+	if len(in) >= p-1+p/2 {
+		k = (q - 2) / 2
+	} else {
+		v := p - 1 + p/2 - len(in)
+		k = (q-2)/2 - v
+	}
+
+	out[i] = in[k]
+	bst(in[:k], out, 2*i+1, e-1)
+	bst(in[k+1:], out, 2*i+2, e-1)
 }

--- a/format_test.go
+++ b/format_test.go
@@ -156,3 +156,51 @@ func TestEncoder(t *testing.T) {
 		}
 	}
 }
+
+// Goodbye items in a catar are a complete BST in array form. Test the sorting algorithm
+// for those. The key in the BST is the hash.
+func TestGoodbyeBST(t *testing.T) {
+	in := []FormatGoodbyeItem{
+		{Offset: 0x0, Hash: 0xb4bedf9e7796b4d},
+		{Offset: 0x1, Hash: 0x218f89516a601c9c},
+		{Offset: 0x2, Hash: 0x28b19de616c15f21},
+		{Offset: 0x3, Hash: 0x490c091d8b45918f},
+		{Offset: 0x4, Hash: 0x51ba5a19e058c7ad},
+		{Offset: 0x5, Hash: 0x61cffdbff93ec8e0},
+		{Offset: 0x6, Hash: 0x6b38ee3f1236bc32},
+		{Offset: 0x7, Hash: 0x6ec111ca376a466e},
+		{Offset: 0x8, Hash: 0x7d411df513f323cf},
+		{Offset: 0x9, Hash: 0x9007695395e7df8f},
+		{Offset: 0xa, Hash: 0x99a552eadd2d1199},
+		{Offset: 0xb, Hash: 0x9e09fb7343978b70},
+		{Offset: 0xc, Hash: 0xa1a7aeca9969d80a},
+		{Offset: 0xd, Hash: 0xbcbe4464f8e3043b},
+		{Offset: 0xe, Hash: 0xc01a4819ff41b89c},
+		{Offset: 0xf, Hash: 0xc7bb588a3af1fb89},
+	}
+
+	expected := []FormatGoodbyeItem{
+		{Offset: 0x8, Hash: 0x7d411df513f323cf},
+		{Offset: 0x4, Hash: 0x51ba5a19e058c7ad},
+		{Offset: 0xc, Hash: 0xa1a7aeca9969d80a},
+		{Offset: 0x2, Hash: 0x28b19de616c15f21},
+		{Offset: 0x6, Hash: 0x6b38ee3f1236bc32},
+		{Offset: 0xa, Hash: 0x99a552eadd2d1199},
+		{Offset: 0xe, Hash: 0xc01a4819ff41b89c},
+		{Offset: 0x1, Hash: 0x218f89516a601c9c},
+		{Offset: 0x3, Hash: 0x490c091d8b45918f},
+		{Offset: 0x5, Hash: 0x61cffdbff93ec8e0},
+		{Offset: 0x7, Hash: 0x6ec111ca376a466e},
+		{Offset: 0x9, Hash: 0x9007695395e7df8f},
+		{Offset: 0xb, Hash: 0x9e09fb7343978b70},
+		{Offset: 0xd, Hash: 0xbcbe4464f8e3043b},
+		{Offset: 0xf, Hash: 0xc7bb588a3af1fb89},
+		{Offset: 0x0, Hash: 0xb4bedf9e7796b4d},
+	}
+
+	out := makeGoodbyeBST(in)
+
+	if !reflect.DeepEqual(out, expected) {
+		t.Fatal("BST doesn't match expected")
+	}
+}

--- a/tar.go
+++ b/tar.go
@@ -163,10 +163,13 @@ func tar(ctx context.Context, enc FormatEncoder, path string, info os.FileInfo, 
 		}
 
 		// Fix the offsets in the item list, it needs to be the offset (backwards)
-		// from the start of the goodbye element, not offset from the start of the stream
+		// from the start of FormatGoodbye
 		for i := range items {
 			items[i].Offset = uint64(n) - items[i].Offset
 		}
+
+		// Turn the list of Goodbye items into a complete BST
+		items = makeGoodbyeBST(items)
 
 		// Append the tail marker
 		items = append(items, FormatGoodbyeItem{


### PR DESCRIPTION
As per #113, desync until now did not use the same order of the Goodbye items in catar archives preventing casync from FUSE-mounting such archives. This PR implements the BST algorithm casync uses.

Closes #113