### PR TITLE
Add CaFormatExcludeFile flag to catar archives

### DIFF
--- a/const.go
+++ b/const.go
@@ -71,6 +71,7 @@ const (
 	CaFormatWithSELinux = 0x40000000
 	CaFormatWithFcaps   = 0x80000000
 
+	CaFormatExcludeFile      = 0x1000000000000000
 	CaFormatSHA512256        = 0x2000000000000000
 	CaFormatExcludeSubmounts = 0x4000000000000000
 	CaFormatExcludeNoDump    = 0x8000000000000000

--- a/tar.go
+++ b/tar.go
@@ -27,7 +27,8 @@ const TarFeatureFlags uint64 = CaFormatWith32BitUIDs |
 	CaFormatWithSockets |
 	CaFormatWithXattrs |
 	CaFormatSHA512256 |
-	CaFormatExcludeNoDump
+	CaFormatExcludeNoDump |
+	CaFormatExcludeFile
 
 // Tar implements the tar command which recursively parses a directory tree,
 // and produces a stream of encoded casync format elements (catar file).


### PR DESCRIPTION
This adds CaFormatExcludeFile to feature flags as per #114. The catar flags produced for both are now: `0xb000000010001f22`.