### PR TITLE
Option to zero timestamps in tar archives

### DIFF
--- a/cmd/desync/tar.go
+++ b/cmd/desync/tar.go
@@ -49,6 +49,7 @@ the input can be a tar file or stream to STDIN with '-'.
 	flags.BoolVarP(&opt.createIndex, "index", "i", false, "create index file (caidx), not catar")
 	flags.BoolVarP(&opt.OneFileSystem, "one-file-system", "x", false, "don't cross filesystem boundaries")
 	flags.StringVar(&opt.inFormat, "input-format", "disk", "input format, 'disk' or 'tar'")
+	flags.BoolVarP(&opt.NoTime, "no-time", "", false, "set file timestamps to zero in the archive")
 	addStoreOptions(&opt.cmdStoreOptions, flags)
 	return cmd
 }

--- a/localfs.go
+++ b/localfs.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/pkg/xattr"
@@ -37,6 +38,9 @@ type LocalFSOptions struct {
 
 	// Ignore the incoming permissions when writing files. Use the current default instead.
 	NoSamePermissions bool
+
+	// Reads all timestamps as zero. Used in tar operations to avoid unneccessary changes.
+	NoTime bool
 }
 
 var _ FilesystemWriter = &LocalFS{}
@@ -85,6 +89,9 @@ func (fs *LocalFS) CreateDir(n NodeDirectory) error {
 			return err
 		}
 	}
+	if n.MTime == time.Unix(0, 0) {
+		return nil
+	}
 	return os.Chtimes(dst, n.MTime, n.MTime)
 }
 
@@ -116,6 +123,9 @@ func (fs *LocalFS) CreateFile(n NodeFile) error {
 		if err := syscall.Chmod(dst, FilemodeToStatMode(n.Mode)); err != nil {
 			return err
 		}
+	}
+	if n.MTime == time.Unix(0, 0) {
+		return nil
 	}
 	return os.Chtimes(dst, n.MTime, n.MTime)
 }
@@ -175,6 +185,9 @@ func (fs *LocalFS) CreateDevice(n NodeDevice) error {
 		if err := syscall.Chmod(dst, FilemodeToStatMode(n.Mode)); err != nil {
 			return errors.Wrapf(err, "chmod %s", dst)
 		}
+	}
+	if n.MTime == time.Unix(0, 0) {
+		return nil
 	}
 	return os.Chtimes(dst, n.MTime, n.MTime)
 }
@@ -255,11 +268,16 @@ func (fs *LocalFS) Next() (*File, error) {
 		}
 	}
 
+	mtime := entry.info.ModTime()
+	if fs.opts.NoTime {
+		mtime = time.Unix(0, 0)
+	}
+
 	f := &File{
 		Name:       entry.info.Name(),
 		Path:       path.Clean(entry.path),
 		Mode:       entry.info.Mode(),
-		ModTime:    entry.info.ModTime(),
+		ModTime:    mtime,
 		Size:       uint64(entry.info.Size()),
 		LinkTarget: linkTarget,
 		Uid:        uid,


### PR DESCRIPTION
Adds a new `--no-time` option to the tar command which will zero all timestamps in the archive to avoid unnecessary changes in the data stream. When extracting an archive with zero timestamps, untar will not set an mtime on the created files.

Closes #124 