### PR TITLE
Open SFTP connections sequentially

### DIFF
--- a/sftp.go
+++ b/sftp.go
@@ -74,6 +74,13 @@ func newSFTPStoreBase(location *url.URL, opt StoreOptions) (*SFTPStoreBase, erro
 		cancel()
 		return nil, err
 	}
+	// The stat has really two jobs. Confirm that the path actually exists on the
+	// server, and also make sure the handshake has happened successfully. SSH
+	// may fail if multiple instances access the SSH agent concurrently.
+	if _, err = client.Stat(path); err != nil {
+		cancel()
+		return nil, errors.Wrapf(err, "failed to stat '%s'", path)
+	}
 	return &SFTPStoreBase{location, path, client, cancel, opt}, nil
 }
 


### PR DESCRIPTION
This ensures that SFTP sessions are opened sequentially as to avoid issues with SSH agent access being limited to one instance at a time (and failing additional requests). As a positive side-effect, this will also confirm the remote SFTP path actually exists early on.