### PR TITLE
Verbose logging for remotehttp

### DIFF
--- a/cmd/desync/config.go
+++ b/cmd/desync/config.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -172,5 +174,15 @@ func setDigestAlgorithm() {
 		desync.Digest = desync.SHA256{}
 	default:
 		die(fmt.Errorf("invalid digest algorithm '%s'", digestAlgorithm))
+	}
+}
+
+// Verbose mode
+var verbose bool
+
+func setVerbose() {
+	if !verbose {
+		log.SetFlags(0)
+		log.SetOutput(ioutil.Discard)
 	}
 }

--- a/cmd/desync/config.go
+++ b/cmd/desync/config.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
-	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -17,6 +15,7 @@ import (
 	"github.com/folbricht/desync"
 	"github.com/minio/minio-go/pkg/credentials"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -181,8 +180,12 @@ func setDigestAlgorithm() {
 var verbose bool
 
 func setVerbose() {
-	if !verbose {
-		log.SetFlags(0)
-		log.SetOutput(ioutil.Discard)
+	if verbose {
+		desync.Log = &logrus.Logger{
+			Out:       os.Stderr,
+			Formatter: new(logrus.TextFormatter),
+			// Hooks:     make(logrus.LevelHooks),
+			Level: logrus.DebugLevel,
+		}
 	}
 }

--- a/cmd/desync/main.go
+++ b/cmd/desync/main.go
@@ -38,7 +38,7 @@ func main() {
 	signal.Notify(sighup, syscall.SIGHUP)
 
 	// Read config early
-	cobra.OnInitialize(initConfig, setDigestAlgorithm)
+	cobra.OnInitialize(initConfig, setDigestAlgorithm, setVerbose)
 
 	// Register the sub-commands under root
 	rootCmd := newRootCommand()

--- a/cmd/desync/root.go
+++ b/cmd/desync/root.go
@@ -11,5 +11,6 @@ func newRootCommand() *cobra.Command {
 	}
 	cmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default $HOME/.config/desync/config.json)")
 	cmd.PersistentFlags().StringVar(&digestAlgorithm, "digest", "sha512-256", "digest algorithm, sha512-256 or sha256")
+	cmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "verbose mode")
 	return cmd
 }

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/pkg/sftp v1.8.2
 	github.com/pkg/xattr v0.4.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.5.0
 	github.com/smartystreets/assertions v0.0.0-20180820201707-7c9eb446e3cf // indirect
 	github.com/smartystreets/goconvey v0.0.0-20180222194500-ef6db91d284a // indirect
 	github.com/spf13/cobra v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/jtolds/gls v4.2.1+incompatible h1:fSuqC+Gmlu6l/ZYAoZzx2pyucC8Xza35fpR
 github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/klauspost/compress v1.10.3 h1:OP96hzwJVBIHYU52pVTI6CczrxPvrGfgqF9N5eTO0Q8=
 github.com/klauspost/compress v1.10.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3vkb4ax0b5D2DHbNAUsen0Gx5wZoq3lV4=
@@ -44,6 +46,8 @@ github.com/pkg/xattr v0.4.0 h1:OacIpDCc4H+4b/bWpYBLOT5gXk7G/jwx5O1D8x8Zewo=
 github.com/pkg/xattr v0.4.0/go.mod h1:W2cGD0TBEus7MkUgv0tNZ9JutLtVO3cXu+IBRuHqnFs=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.5.0 h1:1N5EYkVAPEywqZRJd7cwnRtCb6xJx7NH3T3WUTF980Q=
+github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s+Squfpo=
 github.com/smartystreets/assertions v0.0.0-20180820201707-7c9eb446e3cf h1:6V1qxN6Usn4jy8unvggSJz/NC790tefw8Zdy6OZS5co=
 github.com/smartystreets/assertions v0.0.0-20180820201707-7c9eb446e3cf/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20180222194500-ef6db91d284a h1:JSvGDIbmil4Ui/dDdFBExb7/cmkNjyX5F97oglmvCDo=
@@ -64,6 +68,8 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522 h1:Ve1ORMCxvRmSXBwJK+t3Oy+V2
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181021155630-eda9bb28ed51 h1:GNXpDwiINQORfoRpKYZBUNeIGY4giY2DonS5etRdlnE=
 golang.org/x/sys v0.0.0-20181021155630-eda9bb28ed51/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/cheggaaa/pb.v1 v1.0.25 h1:Ev7yu1/f6+d+b3pi5vPdRPc6nNtP1umSfcWiEfRqv6I=

--- a/log.go
+++ b/log.go
@@ -1,0 +1,13 @@
+package desync
+
+import (
+	"io/ioutil"
+
+	"github.com/sirupsen/logrus"
+)
+
+var Log = logrus.New()
+
+func init() {
+	Log.SetOutput(ioutil.Discard)
+}

--- a/remotehttp.go
+++ b/remotehttp.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 	"path"
@@ -110,13 +111,17 @@ retry:
 	if r.opt.HTTPAuth != "" {
 		req.Header.Set("Authorization", r.opt.HTTPAuth)
 	}
+	log.Printf("HTTP GET: %s: request sent\n", u.String())
 	resp, err = r.client.Do(req)
 	if err != nil {
 		if attempt >= r.opt.ErrorRetry {
+			log.Printf("HTTP GET: %s: error: %v -- %d attempts failed, giving up\n", u.String(), err, attempt)
 			return nil, errors.Wrap(err, u.String())
 		}
+		log.Printf("HTTP GET: %s: error: %v -- attempt %d failed, retrying\n", u.String(), err, attempt)
 		goto retry
 	}
+	log.Printf("HTTP GET: %s: response received: %s\n", u.String(), resp.Status)
 	defer resp.Body.Close()
 	switch resp.StatusCode {
 	case 200: // expected
@@ -128,8 +133,10 @@ retry:
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		if attempt >= r.opt.ErrorRetry {
+			log.Printf("HTTP GET: %s: error while reading response body: %v -- %d attempts failed, giving up\n", u.String(), err, attempt)
 			return nil, errors.Wrap(err, u.String())
 		}
+		log.Printf("HTTP GET: %s: error while reading response body: %v -- attempt %d failed, retrying\n", u.String(), err, attempt)
 		goto retry
 	}
 	return b, nil
@@ -153,13 +160,17 @@ retry:
 	if r.opt.HTTPAuth != "" {
 		req.Header.Set("Authorization", r.opt.HTTPAuth)
 	}
+	log.Printf("HTTP PUT: %s: request sent\n", u.String())
 	resp, err = r.client.Do(req)
 	if err != nil {
 		if attempt >= r.opt.ErrorRetry {
+			log.Printf("HTTP PUT: %s: error: %v -- %d attempts failed, giving up\n", u.String(), err, attempt)
 			return err
 		}
+		log.Printf("HTTP PUT: %s: error: %v -- attempt %d failed, retrying\n", u.String(), err, attempt)
 		goto retry
 	}
+	log.Printf("HTTP PUT: %s: response received: %s\n", u.String(), resp.Status)
 	defer resp.Body.Close()
 	msg, _ := ioutil.ReadAll(resp.Body)
 	if resp.StatusCode != 200 {
@@ -209,13 +220,17 @@ retry:
 	if r.opt.HTTPAuth != "" {
 		req.Header.Set("Authorization", r.opt.HTTPAuth)
 	}
+	log.Printf("HTTP HEAD: %s: request sent\n", u.String())
 	resp, err = r.client.Do(req)
 	if err != nil {
 		if attempt >= r.opt.ErrorRetry {
+			log.Printf("HTTP HEAD: %s: error: %v -- %d attempts failed, giving up\n", u.String(), err, attempt)
 			return false, err
 		}
+		log.Printf("HTTP HEAD: %s: error: %v -- attempt %d failed, retrying\n", u.String(), err, attempt)
 		goto retry
 	}
+	log.Printf("HTTP HEAD: %s: response received: %s\n", u.String(), resp.Status)
 	io.Copy(ioutil.Discard, resp.Body)
 	resp.Body.Close()
 	switch resp.StatusCode {

--- a/remotehttp.go
+++ b/remotehttp.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"path"
@@ -16,6 +15,7 @@ import (
 	"crypto/x509"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 var _ WriteStore = &RemoteHTTP{}
@@ -101,6 +101,10 @@ func (r *RemoteHTTPBase) GetObject(name string) ([]byte, error) {
 	var (
 		resp    *http.Response
 		attempt int
+		log     = Log.WithFields(logrus.Fields{
+			"method": "GET",
+			"url":    u.String(),
+		})
 	)
 retry:
 	attempt++
@@ -111,17 +115,17 @@ retry:
 	if r.opt.HTTPAuth != "" {
 		req.Header.Set("Authorization", r.opt.HTTPAuth)
 	}
-	log.Printf("HTTP GET: %s: request sent\n", u.String())
+	log.Debug("request sent")
 	resp, err = r.client.Do(req)
 	if err != nil {
 		if attempt >= r.opt.ErrorRetry {
-			log.Printf("HTTP GET: %s: error: %v -- %d attempts failed, giving up\n", u.String(), err, attempt)
+			log.WithField("attempt", attempt).WithError(err).Error("failed, giving up")
 			return nil, errors.Wrap(err, u.String())
 		}
-		log.Printf("HTTP GET: %s: error: %v -- attempt %d failed, retrying\n", u.String(), err, attempt)
+		log.WithField("attempt", attempt).WithError(err).Error("failed, retrying")
 		goto retry
 	}
-	log.Printf("HTTP GET: %s: response received: %s\n", u.String(), resp.Status)
+	log.WithField("status", resp.StatusCode).Debug("response received")
 	defer resp.Body.Close()
 	switch resp.StatusCode {
 	case 200: // expected
@@ -133,10 +137,10 @@ retry:
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		if attempt >= r.opt.ErrorRetry {
-			log.Printf("HTTP GET: %s: error while reading response body: %v -- %d attempts failed, giving up\n", u.String(), err, attempt)
+			log.WithField("attempt", attempt).WithError(err).Error("failed, giving up")
 			return nil, errors.Wrap(err, u.String())
 		}
-		log.Printf("HTTP GET: %s: error while reading response body: %v -- attempt %d failed, retrying\n", u.String(), err, attempt)
+		log.WithField("attempt", attempt).WithError(err).Error("failed, retrying")
 		goto retry
 	}
 	return b, nil
@@ -150,6 +154,10 @@ func (r *RemoteHTTPBase) StoreObject(name string, rdr io.Reader) error {
 		resp    *http.Response
 		err     error
 		attempt int
+		log     = Log.WithFields(logrus.Fields{
+			"method": "PUT",
+			"url":    u.String(),
+		})
 	)
 retry:
 	attempt++
@@ -160,17 +168,17 @@ retry:
 	if r.opt.HTTPAuth != "" {
 		req.Header.Set("Authorization", r.opt.HTTPAuth)
 	}
-	log.Printf("HTTP PUT: %s: request sent\n", u.String())
+	log.Debug("request sent")
 	resp, err = r.client.Do(req)
 	if err != nil {
 		if attempt >= r.opt.ErrorRetry {
-			log.Printf("HTTP PUT: %s: error: %v -- %d attempts failed, giving up\n", u.String(), err, attempt)
+			log.WithField("attempt", attempt).WithError(err).Error("failed, giving up")
 			return err
 		}
-		log.Printf("HTTP PUT: %s: error: %v -- attempt %d failed, retrying\n", u.String(), err, attempt)
+		log.WithField("attempt", attempt).WithError(err).Error("failed, retrying")
 		goto retry
 	}
-	log.Printf("HTTP PUT: %s: response received: %s\n", u.String(), resp.Status)
+	log.WithField("status", resp.StatusCode).Debug("response received")
 	defer resp.Body.Close()
 	msg, _ := ioutil.ReadAll(resp.Body)
 	if resp.StatusCode != 200 {
@@ -210,6 +218,10 @@ func (r *RemoteHTTP) HasChunk(id ChunkID) (bool, error) {
 		resp    *http.Response
 		err     error
 		attempt int
+		log     = Log.WithFields(logrus.Fields{
+			"method": "HEAD",
+			"url":    u.String(),
+		})
 	)
 retry:
 	attempt++
@@ -220,17 +232,17 @@ retry:
 	if r.opt.HTTPAuth != "" {
 		req.Header.Set("Authorization", r.opt.HTTPAuth)
 	}
-	log.Printf("HTTP HEAD: %s: request sent\n", u.String())
+	log.Debug("request sent")
 	resp, err = r.client.Do(req)
 	if err != nil {
 		if attempt >= r.opt.ErrorRetry {
-			log.Printf("HTTP HEAD: %s: error: %v -- %d attempts failed, giving up\n", u.String(), err, attempt)
+			log.WithField("attempt", attempt).WithError(err).Error("failed, giving up")
 			return false, err
 		}
-		log.Printf("HTTP HEAD: %s: error: %v -- attempt %d failed, retrying\n", u.String(), err, attempt)
+		log.WithField("attempt", attempt).WithError(err).Error("failed, retrying")
 		goto retry
 	}
-	log.Printf("HTTP HEAD: %s: response received: %s\n", u.String(), resp.Status)
+	log.WithField("status", resp.StatusCode).Debug("response received")
 	io.Copy(ioutil.Discard, resp.Body)
 	resp.Body.Close()
 	switch resp.StatusCode {


### PR DESCRIPTION
Related to #157 - this provides a "--verbose" commandline switch, and when active, it prints HTTP requests/responses done via the remotehttp module.

The output looks like this:
```
2020/04/22 22:33:06 HTTP HEAD: https://storage.googleapis.com/<bucketname>/8f3b/8f3b7cf12857a73edb96afe45f4dad05bc97695daceec3a54062ad26b5689715.cacnk: request sent
2020/04/22 22:33:06 HTTP HEAD: https://storage.googleapis.com/<bucketname>/8f6d/8f6d1389a95d165e1de44aef9183e0918df3695bc54dde347c08d082b41745f9.cacnk: request sent
2020/04/22 22:33:06 HTTP HEAD: https://storage.googleapis.com/<bucketname>/cc40/cc4065a576a9f79a1d7455e6fdae5dc056befffea3b178a5abd554eada58603d.cacnk: request sent
2020/04/22 22:33:06 HTTP PUT: https://storage.googleapis.com/<bucketname>/2e12/2e127eb6618a59962a8696875cabd9d8f7dde40360724fc6084a90b118583758.cacnk: response received: 200 OK
2020/04/22 22:33:06 HTTP HEAD: https://storage.googleapis.com/<bucketname>/3021/3021d108e13e9a63138f02aa57e2034a0ef1dde46993b086804e0c776154523f.cacnk: request sent
2020/04/22 22:33:06 HTTP HEAD: https://storage.googleapis.com/<bucketname>/5ecc/5ecc236603e745b008a7c66beb939d1e6b2361754878bdc2d2cafc9d3015e679.cacnk: response received: 404 Not Found
2020/04/22 22:33:06 HTTP PUT: https://storage.googleapis.com/<bucketname>/5ecc/5ecc236603e745b008a7c66beb939d1e6b2361754878bdc2d2cafc9d3015e679.cacnk: request sent
2020/04/22 22:33:06 HTTP PUT: https://storage.googleapis.com/<bucketname>/5ecc/5ecc236603e745b008a7c66beb939d1e6b2361754878bdc2d2cafc9d3015e679.cacnk: response received: 502 Bad Gateway
2020/04/22 22:33:06 HTTP PUT: https://storage.googleapis.com/<bucketname>/d440/d440a71089310cf27fda85164f4f21f8122ca2cafdbfff8657677af1ad8b0ac5.cacnk: response received: 200 OK
2020/04/22 22:33:06 HTTP HEAD: https://storage.googleapis.com/<bucketname>/132f/132faf4e6d4a79880bd93a1a83ea422b979bbdd852f091832b539f6d817c08d4.cacnk: response received: 404 Not Found
2020/04/22 22:33:06 HTTP PUT: https://storage.googleapis.com/<bucketname>/132f/132faf4e6d4a79880bd93a1a83ea422b979bbdd852f091832b539f6d817c08d4.cacnk: request sent
2020/04/22 22:33:06 HTTP HEAD: https://storage.googleapis.com/<bucketname>/67dd/67dd3bc3c481cb54784eae89a86553a022fa3f16f325d341580ebb5ffac89a1a.cacnk: response received: 404 Not Found
2020/04/22 22:33:06 HTTP PUT: https://storage.googleapis.com/<bucketname>/67dd/67dd3bc3c481cb54784eae89a86553a022fa3f16f325d341580ebb5ffac89a1a.cacnk: request sent
2020/04/22 22:33:06 HTTP HEAD: https://storage.googleapis.com/<bucketname>/8f6d/8f6d1389a95d165e1de44aef9183e0918df3695bc54dde347c08d082b41745f9.cacnk: response received: 404 Not Found
2020/04/22 22:33:06 HTTP PUT: https://storage.googleapis.com/<bucketname>/8f6d/8f6d1389a95d165e1de44aef9183e0918df3695bc54dde347c08d082b41745f9.cacnk: request sent
2020/04/22 22:33:06 HTTP HEAD: https://storage.googleapis.com/<bucketname>/cc40/cc4065a576a9f79a1d7455e6fdae5dc056befffea3b178a5abd554eada58603d.cacnk: response received: 404 Not Found
2020/04/22 22:33:06 HTTP PUT: https://storage.googleapis.com/<bucketname>/cc40/cc4065a576a9f79a1d7455e6fdae5dc056befffea3b178a5abd554eada58603d.cacnk: request sent
2020/04/22 22:33:06 HTTP HEAD: https://storage.googleapis.com/<bucketname>/3021/3021d108e13e9a63138f02aa57e2034a0ef1dde46993b086804e0c776154523f.cacnk: response received: 404 Not Found
2020/04/22 22:33:06 HTTP PUT: https://storage.googleapis.com/<bucketname>/3021/3021d108e13e9a63138f02aa57e2034a0ef1dde46993b086804e0c776154523f.cacnk: request sent
2020/04/22 22:33:06 HTTP HEAD: https://storage.googleapis.com/<bucketname>/f2ee/f2eef3c3450ad3e7f67008f04ff851eb390783d8372661d0dd97fb068360639b.cacnk: response received: 404 Not Found
2020/04/22 22:33:06 HTTP HEAD: https://storage.googleapis.com/<bucketname>/8f3b/8f3b7cf12857a73edb96afe45f4dad05bc97695daceec3a54062ad26b5689715.cacnk: response received: 404 Not Found
2020/04/22 22:33:06 HTTP PUT: https://storage.googleapis.com/<bucketname>/f2ee/f2eef3c3450ad3e7f67008f04ff851eb390783d8372661d0dd97fb068360639b.cacnk: request sent
2020/04/22 22:33:06 HTTP PUT: https://storage.googleapis.com/<bucketname>/8f3b/8f3b7cf12857a73edb96afe45f4dad05bc97695daceec3a54062ad26b5689715.cacnk: request sent
2020/04/22 22:33:06 HTTP PUT: https://storage.googleapis.com/<bucketname>/5dac/5dac72bd1d0be54a5625781d0ae108275f437861254b683f570bbb4bcbf5fa94.cacnk: response received: 200 OK
2020/04/22 22:33:06 HTTP PUT: https://storage.googleapis.com/<bucketname>/67dd/67dd3bc3c481cb54784eae89a86553a022fa3f16f325d341580ebb5ffac89a1a.cacnk: response received: 200 OK
2020/04/22 22:33:06 HTTP PUT: https://storage.googleapis.com/<bucketname>/8f6d/8f6d1389a95d165e1de44aef9183e0918df3695bc54dde347c08d082b41745f9.cacnk: response received: 200 OK
2020/04/22 22:33:06 HTTP PUT: https://storage.googleapis.com/<bucketname>/cc40/cc4065a576a9f79a1d7455e6fdae5dc056befffea3b178a5abd554eada58603d.cacnk: response received: 200 OK
2020/04/22 22:33:06 HTTP PUT: https://storage.googleapis.com/<bucketname>/3021/3021d108e13e9a63138f02aa57e2034a0ef1dde46993b086804e0c776154523f.cacnk: response received: 200 OK
2020/04/22 22:33:06 HTTP PUT: https://storage.googleapis.com/<bucketname>/f2ee/f2eef3c3450ad3e7f67008f04ff851eb390783d8372661d0dd97fb068360639b.cacnk: response received: 200 OK
2020/04/22 22:33:06 HTTP PUT: https://storage.googleapis.com/<bucketname>/8f3b/8f3b7cf12857a73edb96afe45f4dad05bc97695daceec3a54062ad26b5689715.cacnk: response received: 200 OK
2020/04/22 22:33:06 HTTP PUT: https://storage.googleapis.com/<bucketname>/132f/132faf4e6d4a79880bd93a1a83ea422b979bbdd852f091832b539f6d817c08d4.cacnk: response received: 200 OK
```

(notice the HTTP 502 Bad Gateway in there. If we want desync to support backends that give spurious errors, then we'd need the retry logic to apply in those circumstances. That, however, is a separate issue.)