### PR TITLE
Retry 5xx errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Available configuration values:
 - `store-options` - Allows customization of chunk and index stores, for example comression settings, timeouts, retry behavior and keys. Not all options are applicable to every store, some of these like `timeout` are ignored for local stores. Some of these options, such as the client certificates are overwritten with any values set in the command line. Note that the store location used in the command line needs to match the key under `store-options` exactly for these options to be used. Watch out for trailing `/` in URLs.
   - `timeout` - Time limit for chunk read or write operation in nanoseconds. Default: 1 minute. If set to a negative value, timeout is infinite.
   - `error-retry` - Number of times to retry failed chunk requests. Default: 0.
-  - `error-retry-base-interval` - Number of seconds to wait before first retry attempt. Retry attempt number N for the same request will wait N times this interval. Default: 1 second.
+  - `error-retry-base-interval` - Number of seconds to wait before first retry attempt. Retry attempt number N for the same request will wait N times this interval. Default: 0 seconds.
   - `client-cert` - Cerificate file to be used for stores where the server requires mutual SSL.
   - `client-key` - Key file to be used for stores where the server requires mutual SSL.
   - `ca-cert` - Certificate file containing trusted certs or CAs.

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Available configuration values:
 - `store-options` - Allows customization of chunk and index stores, for example comression settings, timeouts, retry behavior and keys. Not all options are applicable to every store, some of these like `timeout` are ignored for local stores. Some of these options, such as the client certificates are overwritten with any values set in the command line. Note that the store location used in the command line needs to match the key under `store-options` exactly for these options to be used. Watch out for trailing `/` in URLs.
   - `timeout` - Time limit for chunk read or write operation in nanoseconds. Default: 1 minute. If set to a negative value, timeout is infinite.
   - `error-retry` - Number of times to retry failed chunk requests. Default: 0.
+  - `error-retry-base-interval` - Number of seconds to wait before first retry attempt. Retry attempt number N for the same request will wait N times this interval. Default: 1 second.
   - `client-cert` - Cerificate file to be used for stores where the server requires mutual SSL.
   - `client-key` - Key file to be used for stores where the server requires mutual SSL.
   - `ca-cert` - Certificate file containing trusted certs or CAs.

--- a/remotehttp.go
+++ b/remotehttp.go
@@ -160,7 +160,7 @@ retry:
 			log.WithField("attempt", attempt).WithField("delay", attempt).Debug("waiting, then retrying")
 			baseInterval := r.opt.ErrorRetryBaseInterval
 			if baseInterval == 0 {
-				baseInterval = 1 * time.Second
+				baseInterval = time.Duration(0)
 			}
 			time.Sleep(time.Duration(attempt) * baseInterval)
 			goto retry

--- a/remotehttp.go
+++ b/remotehttp.go
@@ -95,94 +95,105 @@ func (r *RemoteHTTPBase) String() string {
 // Close the HTTP store. NOP operation but needed to implement the interface.
 func (r *RemoteHTTPBase) Close() error { return nil }
 
-// GetObject reads and returns an object in the form of []byte from the store
-func (r *RemoteHTTPBase) GetObject(name string) ([]byte, error) {
-	u, _ := r.location.Parse(name)
+// Send a single HTTP request.
+func (r *RemoteHTTPBase) IssueHttpRequest(method string, u *url.URL, rdr io.Reader, attempt int) (int, []byte, error) {
+
 	var (
-		resp    *http.Response
-		attempt int
-		log     = Log.WithFields(logrus.Fields{
-			"method": "GET",
-			"url":    u.String(),
+		resp *http.Response
+		log  = Log.WithFields(logrus.Fields{
+			"method":  method,
+			"url":     u.String(),
+			"attempt": attempt,
 		})
 	)
-retry:
-	attempt++
-	req, err := http.NewRequest("GET", u.String(), nil)
+
+	req, err := http.NewRequest(method, u.String(), rdr)
 	if err != nil {
-		return nil, err
+		log.Debug("unable to create new request")
+		return 0, nil, err
 	}
 	if r.opt.HTTPAuth != "" {
 		req.Header.Set("Authorization", r.opt.HTTPAuth)
 	}
-	log.Debug("request sent")
+
+	log.Debug("sending request")
 	resp, err = r.client.Do(req)
 	if err != nil {
-		if attempt >= r.opt.ErrorRetry {
-			log.WithField("attempt", attempt).WithError(err).Error("failed, giving up")
-			return nil, errors.Wrap(err, u.String())
-		}
-		log.WithField("attempt", attempt).WithError(err).Error("failed, retrying")
-		goto retry
+		log.WithError(err).Error("error while sending request")
+		return 0, nil, errors.Wrap(err, u.String())
 	}
-	log.WithField("status", resp.StatusCode).Debug("response received")
+
 	defer resp.Body.Close()
-	switch resp.StatusCode {
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.WithError(err).Error("error while reading response")
+		return 0, nil, errors.Wrap(err, u.String())
+	}
+
+	log.WithField("statusCode", resp.StatusCode).Debug("response received")
+	return resp.StatusCode, b, nil
+}
+
+// Send a single HTTP request, retrying if a retryable error has occurred.
+func (r *RemoteHTTPBase) IssueRetryableHttpRequest(method string, u *url.URL, rdr io.Reader) (int, []byte, error) {
+
+	var (
+		attempt int
+		log     = Log.WithFields(logrus.Fields{
+			"method": method,
+			"url":    u.String(),
+		})
+	)
+
+retry:
+	attempt++
+	statusCode, responseBody, err := r.IssueHttpRequest(method, u, rdr, attempt)
+
+	if (err != nil) || (statusCode >= 500 && statusCode < 600) {
+		if attempt >= r.opt.ErrorRetry {
+			log.WithField("attempt", attempt).Debug("failed, giving up")
+			return 0, nil, err
+		} else {
+			log.WithField("attempt", attempt).WithField("delay", attempt).Debug("waiting, then retrying")
+			baseInterval := r.opt.ErrorRetryBaseInterval
+			if baseInterval == 0 {
+				baseInterval = 1 * time.Second
+			}
+			time.Sleep(time.Duration(attempt) * baseInterval)
+			goto retry
+		}
+	}
+
+	return statusCode, responseBody, nil
+}
+
+// GetObject reads and returns an object in the form of []byte from the store
+func (r *RemoteHTTPBase) GetObject(name string) ([]byte, error) {
+	u, _ := r.location.Parse(name)
+	statusCode, responseBody, err := r.IssueRetryableHttpRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	switch statusCode {
 	case 200: // expected
+		return responseBody, nil
 	case 404:
 		return nil, NoSuchObject{name}
 	default:
-		return nil, fmt.Errorf("unexpected status code %d from %s", resp.StatusCode, name)
+		return nil, fmt.Errorf("unexpected status code %d from %s", statusCode, name)
 	}
-	b, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		if attempt >= r.opt.ErrorRetry {
-			log.WithField("attempt", attempt).WithError(err).Error("failed, giving up")
-			return nil, errors.Wrap(err, u.String())
-		}
-		log.WithField("attempt", attempt).WithError(err).Error("failed, retrying")
-		goto retry
-	}
-	return b, nil
 }
 
 // StoreObject stores an object to the store.
 func (r *RemoteHTTPBase) StoreObject(name string, rdr io.Reader) error {
-
 	u, _ := r.location.Parse(name)
-	var (
-		resp    *http.Response
-		err     error
-		attempt int
-		log     = Log.WithFields(logrus.Fields{
-			"method": "PUT",
-			"url":    u.String(),
-		})
-	)
-retry:
-	attempt++
-	req, err := http.NewRequest("PUT", u.String(), rdr)
+	statusCode, responseBody, err := r.IssueRetryableHttpRequest("PUT", u, rdr)
 	if err != nil {
 		return err
 	}
-	if r.opt.HTTPAuth != "" {
-		req.Header.Set("Authorization", r.opt.HTTPAuth)
-	}
-	log.Debug("request sent")
-	resp, err = r.client.Do(req)
-	if err != nil {
-		if attempt >= r.opt.ErrorRetry {
-			log.WithField("attempt", attempt).WithError(err).Error("failed, giving up")
-			return err
-		}
-		log.WithField("attempt", attempt).WithError(err).Error("failed, retrying")
-		goto retry
-	}
-	log.WithField("status", resp.StatusCode).Debug("response received")
-	defer resp.Body.Close()
-	msg, _ := ioutil.ReadAll(resp.Body)
-	if resp.StatusCode != 200 {
-		return errors.New(string(msg))
+	if statusCode != 200 {
+		return errors.New(string(responseBody))
 	}
 	return nil
 }
@@ -214,44 +225,18 @@ func (r *RemoteHTTP) GetChunk(id ChunkID) (*Chunk, error) {
 func (r *RemoteHTTP) HasChunk(id ChunkID) (bool, error) {
 	p := r.nameFromID(id)
 	u, _ := r.location.Parse(p)
-	var (
-		resp    *http.Response
-		err     error
-		attempt int
-		log     = Log.WithFields(logrus.Fields{
-			"method": "HEAD",
-			"url":    u.String(),
-		})
-	)
-retry:
-	attempt++
-	req, err := http.NewRequest("HEAD", u.String(), nil)
+
+	statusCode, _, err := r.IssueRetryableHttpRequest("HEAD", u, nil)
 	if err != nil {
 		return false, err
 	}
-	if r.opt.HTTPAuth != "" {
-		req.Header.Set("Authorization", r.opt.HTTPAuth)
-	}
-	log.Debug("request sent")
-	resp, err = r.client.Do(req)
-	if err != nil {
-		if attempt >= r.opt.ErrorRetry {
-			log.WithField("attempt", attempt).WithError(err).Error("failed, giving up")
-			return false, err
-		}
-		log.WithField("attempt", attempt).WithError(err).Error("failed, retrying")
-		goto retry
-	}
-	log.WithField("status", resp.StatusCode).Debug("response received")
-	io.Copy(ioutil.Discard, resp.Body)
-	resp.Body.Close()
-	switch resp.StatusCode {
+	switch statusCode {
 	case 200:
 		return true, nil
 	case 404:
 		return false, nil
 	default:
-		return false, fmt.Errorf("unexpected status code: %s", resp.Status)
+		return false, fmt.Errorf("unexpected status code: %d", statusCode)
 	}
 }
 

--- a/remotehttp_test.go
+++ b/remotehttp_test.go
@@ -1,10 +1,13 @@
 package desync
 
 import (
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 )
 
 func TestHTTPStoreURL(t *testing.T) {
@@ -36,6 +39,262 @@ func TestHTTPStoreURL(t *testing.T) {
 			s.GetChunk(chunkID)
 			if requestURI != test.serverPath {
 				t.Fatalf("got request uri '%s', want '%s'", requestURI, test.serverPath)
+			}
+		})
+	}
+}
+
+func TestHasChunk(t *testing.T) {
+	var attemptCount int
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attemptCount++
+		switch r.URL.String() {
+		case "/0000/0000000100000000000000000000000000000000000000000000000000000000.cacnk":
+			w.WriteHeader(http.StatusOK)
+		case "/0000/0000000200000000000000000000000000000000000000000000000000000000.cacnk":
+			w.WriteHeader(http.StatusNotFound)
+		case "/0000/0000000300000000000000000000000000000000000000000000000000000000.cacnk":
+			w.WriteHeader(http.StatusBadRequest)
+		case "/0000/0000000400000000000000000000000000000000000000000000000000000000.cacnk":
+			w.WriteHeader(http.StatusForbidden)
+		case "/0000/0000000500000000000000000000000000000000000000000000000000000000.cacnk":
+			w.WriteHeader(http.StatusBadGateway)
+			io.WriteString(w, "Bad Gateway")
+		case "/0000/0000000600000000000000000000000000000000000000000000000000000000.cacnk":
+			if attemptCount >= 2 {
+				w.WriteHeader(http.StatusOK)
+			} else {
+				w.WriteHeader(http.StatusBadGateway)
+				io.WriteString(w, "Bad Gateway")
+			}
+		case "/0000/0000000700000000000000000000000000000000000000000000000000000000.cacnk":
+			if attemptCount >= 3 {
+				w.WriteHeader(http.StatusNotFound)
+			} else {
+				w.WriteHeader(http.StatusBadGateway)
+				io.WriteString(w, "Bad Gateway")
+			}
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer ts.Close()
+	u, _ := url.Parse(ts.URL)
+
+	tests := map[string]struct {
+		chunkId      ChunkID
+		hasChunk     bool
+		hasError     bool
+		attemptCount int
+	}{
+		// The default case is a successful chunk test operation
+		"chunk exists": {ChunkID{0, 0, 0, 1}, true, false, 1},
+		// HTTP 404 Not Found - Testing a chunk that does not exist should result in an immediate 'does not exist' response
+		"chunk does not exist": {ChunkID{0, 0, 0, 2}, false, false, 1},
+		// HTTP 400 Bad Request - should fail immediately
+		"bad request": {ChunkID{0, 0, 0, 3}, false, true, 1},
+		// HTTP 403 Forbidden - should fail immediately
+		"forbidden": {ChunkID{0, 0, 0, 4}, false, true, 1},
+		// HTTP 503 Bad Gateway - should retry, but ultimately fail
+		"permanent 503": {ChunkID{0, 0, 0, 5}, false, true, 5},
+		// HTTP 503 Bad Gateway - should retry, and a subsequent successful call should return that the chunk exists
+		"temporary 503, then chunk exists": {ChunkID{0, 0, 0, 6}, true, false, 2},
+		// HTTP 503 Bad Gateway - should retry, and a subsequent successful call should report that the chunk does not exist immediately
+		"temporary 503, then chunk does not exist": {ChunkID{0, 0, 0, 7}, false, false, 3},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			u.Path = "/"
+			s, err := NewRemoteHTTPStore(u, StoreOptions{ErrorRetry: 5, ErrorRetryBaseInterval: time.Duration(1) * time.Microsecond})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			attemptCount = 0
+			hasChunk, err := s.HasChunk(test.chunkId)
+			if (hasChunk != test.hasChunk) || ((err != nil) != test.hasError) || (attemptCount != test.attemptCount) {
+				t.Errorf("expected hasChunk = %t / hasError = %t / attemptCount = %d, got %t / %t / %d", test.hasChunk, test.hasError, test.attemptCount, hasChunk, (err != nil), attemptCount)
+			}
+		})
+	}
+}
+
+func TestGetChunk(t *testing.T) {
+	var attemptCount int
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attemptCount++
+		switch r.URL.String() {
+		case "/3bc8/3bc8e3230df5515b1b40e938e49ebc765c6157d4cf4e2b9d5f9c272571365395":
+			w.WriteHeader(http.StatusOK)
+			io.WriteString(w, "Chunk Content String 1")
+		case "/0000/0000000100000000000000000000000000000000000000000000000000000000":
+			w.WriteHeader(http.StatusOK)
+			io.WriteString(w, "Chunk Content With hash mismatch")
+		case "/0000/0000000200000000000000000000000000000000000000000000000000000000":
+			w.WriteHeader(http.StatusNotFound)
+		case "/0000/0000000300000000000000000000000000000000000000000000000000000000":
+			w.WriteHeader(http.StatusBadRequest)
+			io.WriteString(w, "BadRequest")
+		case "/0000/0000000400000000000000000000000000000000000000000000000000000000":
+			w.WriteHeader(http.StatusForbidden)
+			io.WriteString(w, "Forbidden")
+		case "/0000/0000000500000000000000000000000000000000000000000000000000000000":
+			w.WriteHeader(http.StatusBadGateway)
+			io.WriteString(w, "Bad Gateway")
+		case "/65a1/65a128d0658c4cf0941771c7090fea6d9c6f981810659c24c91ba23edd71574b":
+			if attemptCount >= 2 {
+				w.WriteHeader(http.StatusOK)
+				io.WriteString(w, "Chunk Content String 6")
+			} else {
+				w.WriteHeader(http.StatusBadGateway)
+				io.WriteString(w, "Bad Gateway")
+			}
+		case "/0000/0000000700000000000000000000000000000000000000000000000000000000":
+			if attemptCount >= 3 {
+				w.WriteHeader(http.StatusNotFound)
+			} else {
+				w.WriteHeader(http.StatusBadGateway)
+				io.WriteString(w, "Bad Gateway")
+			}
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer ts.Close()
+	u, _ := url.Parse(ts.URL)
+
+	tests := map[string]struct {
+		chunkId      ChunkID
+		content      string
+		hasError     bool
+		attemptCount int
+	}{
+
+		// The default case is a successful get chunk operation
+		"chunk exists": {ChunkID{0x3b, 0xc8, 0xe3, 0x23, 0x0d, 0xf5, 0x51, 0x5b, 0x1b, 0x40, 0xe9, 0x38, 0xe4, 0x9e, 0xbc, 0x76, 0x5c, 0x61, 0x57, 0xd4, 0xcf, 0x4e, 0x2b, 0x9d, 0x5f, 0x9c, 0x27, 0x25, 0x71, 0x36, 0x53, 0x95}, "Chunk Content String 1", false, 1},
+		// Fetching a chunk where the hash does not match the contents should fail for a store where verification is enabled
+		"chunk exists, but invalid hash": {ChunkID{0, 0, 0, 1}, "", true, 1},
+		// HTTP 404 Not Found - Fetching a chunk that does not exist should fail immediately
+		"chunk does not exist": {ChunkID{0, 0, 0, 2}, "", true, 1},
+		// HTTP 400 Bad Request - should fail immediately
+		"bad request": {ChunkID{0, 0, 0, 3}, "", true, 1},
+		// HTTP 403 Forbidden - should fail immediately
+		"forbidden": {ChunkID{0, 0, 0, 4}, "", true, 1},
+		// HTTP 503 Bad Gateway - should retry, but ultimately fail
+		"permanent 503": {ChunkID{0, 0, 0, 5}, "", true, 5},
+		// HTTP 503 Bad Gateway - should retry, and a subsequent successful call should return a successful chunk
+		"temporary 503, then chunk exists": {ChunkID{0x65, 0xa1, 0x28, 0xd0, 0x65, 0x8c, 0x4c, 0xf0, 0x94, 0x17, 0x71, 0xc7, 0x09, 0x0f, 0xea, 0x6d, 0x9c, 0x6f, 0x98, 0x18, 0x10, 0x65, 0x9c, 0x24, 0xc9, 0x1b, 0xa2, 0x3e, 0xdd, 0x71, 0x57, 0x4b}, "Chunk Content String 6", false, 2},
+		// HTTP 503 Bad Gateway - should retry, and a subsequent successful call should report that the chunk does not exist, thereby failing immediately
+		"temporary 503, then chunk does not exist": {ChunkID{0, 0, 0, 7}, "", true, 3},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			u.Path = "/"
+			s, err := NewRemoteHTTPStore(u, StoreOptions{ErrorRetry: 5, ErrorRetryBaseInterval: time.Duration(1) * time.Microsecond, Uncompressed: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			attemptCount = 0
+			content, err := s.GetChunk(test.chunkId)
+			content_string := ""
+			if content != nil {
+				uncompressedContent, _ := content.Uncompressed()
+				content_string = string(uncompressedContent)
+			}
+			if (content_string != test.content) || ((err != nil) != test.hasError) || (attemptCount != test.attemptCount) {
+				t.Errorf("expected content = \"%s\" / hasError = %t / attemptCount = %d, got \"%s\" / %t / %d", test.content, test.hasError, test.attemptCount, content_string, (err != nil), attemptCount)
+			}
+		})
+	}
+}
+
+func TestPutChunk(t *testing.T) {
+	var attemptCount int
+	var writtenContent []byte
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attemptCount++
+		switch r.URL.String() {
+		case "/3bc8/3bc8e3230df5515b1b40e938e49ebc765c6157d4cf4e2b9d5f9c272571365395":
+			content, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				io.WriteString(w, err.Error())
+			} else {
+				writtenContent = content
+				w.WriteHeader(http.StatusOK)
+			}
+		case "/0000/0000000300000000000000000000000000000000000000000000000000000000":
+			w.WriteHeader(http.StatusBadRequest)
+			io.WriteString(w, "BadRequest")
+		case "/0000/0000000400000000000000000000000000000000000000000000000000000000":
+			w.WriteHeader(http.StatusForbidden)
+			io.WriteString(w, "Forbidden")
+		case "/0000/0000000500000000000000000000000000000000000000000000000000000000":
+			w.WriteHeader(http.StatusBadGateway)
+			io.WriteString(w, "Bad Gateway")
+		case "/65a1/65a128d0658c4cf0941771c7090fea6d9c6f981810659c24c91ba23edd71574b":
+			if attemptCount >= 2 {
+				content, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					io.WriteString(w, err.Error())
+				} else {
+					writtenContent = content
+					w.WriteHeader(http.StatusOK)
+				}
+			} else {
+				w.WriteHeader(http.StatusBadGateway)
+				io.WriteString(w, "Bad Gateway")
+			}
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer ts.Close()
+	u, _ := url.Parse(ts.URL)
+
+	tests := map[string]struct {
+		chunkId        ChunkID
+		content        string
+		writtenContent string
+		hasError       bool
+		attemptCount   int
+	}{
+		// The typical path is a successful store operation
+		"store chunk successful": {ChunkID{0x3b, 0xc8, 0xe3, 0x23, 0x0d, 0xf5, 0x51, 0x5b, 0x1b, 0x40, 0xe9, 0x38, 0xe4, 0x9e, 0xbc, 0x76, 0x5c, 0x61, 0x57, 0xd4, 0xcf, 0x4e, 0x2b, 0x9d, 0x5f, 0x9c, 0x27, 0x25, 0x71, 0x36, 0x53, 0x95}, "Chunk Content String 1", "Chunk Content String 1", false, 1},
+		// Attempting to store a chunk with null content will be errored by the library itself, and will not result in any HTTP requests
+		"store chunk not allowed with no chunk content": {ChunkID{0, 0, 0, 2}, "", "", true, 0},
+		// HTTP 400 Bad Request - should fail immediately
+		"bad request": {ChunkID{0, 0, 0, 3}, "3", "", true, 1},
+		// HTTP 403 Forbidden - should fail immediately
+		"forbidden": {ChunkID{0, 0, 0, 4}, "4", "", true, 1},
+		// HTTP 503 Bad Gateway - should retry, but ultimately fail
+		"permanent 503": {ChunkID{0, 0, 0, 5}, "5", "", true, 5},
+		// HTTP 503 Bad Gateway - should retry, and a subsequent successful call should make the entire operation succeed
+		"temporary 503, then store chunk successful": {ChunkID{0x65, 0xa1, 0x28, 0xd0, 0x65, 0x8c, 0x4c, 0xf0, 0x94, 0x17, 0x71, 0xc7, 0x09, 0x0f, 0xea, 0x6d, 0x9c, 0x6f, 0x98, 0x18, 0x10, 0x65, 0x9c, 0x24, 0xc9, 0x1b, 0xa2, 0x3e, 0xdd, 0x71, 0x57, 0x4b}, "Chunk Content String 6", "Chunk Content String 6", false, 2},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			u.Path = "/"
+			s, err := NewRemoteHTTPStore(u, StoreOptions{ErrorRetry: 5, ErrorRetryBaseInterval: time.Duration(1) * time.Microsecond, Uncompressed: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			attemptCount = 0
+			writtenContent = nil
+			chunk, _ := NewChunkWithID(test.chunkId, []byte(test.content), nil, true)
+			err = s.StoreChunk(chunk)
+			writtenContentString := ""
+			if writtenContent != nil {
+				writtenContentString = string(writtenContent)
+			}
+			if ((err != nil) != test.hasError) || (attemptCount != test.attemptCount) || (writtenContentString != test.writtenContent) {
+				t.Errorf("expected writtenContent = \"%s\" / hasError = %t / attemptCount = %d, got \"%s\" / %t / %d", test.writtenContent, test.hasError, test.attemptCount, writtenContentString, (err != nil), attemptCount)
 			}
 		})
 	}

--- a/remotehttp_test.go
+++ b/remotehttp_test.go
@@ -106,7 +106,7 @@ func TestHasChunk(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			u.Path = "/"
-			s, err := NewRemoteHTTPStore(u, StoreOptions{ErrorRetry: 5, ErrorRetryBaseInterval: time.Duration(1) * time.Microsecond})
+			s, err := NewRemoteHTTPStore(u, StoreOptions{ErrorRetry: 5, ErrorRetryBaseInterval: time.Microsecond})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -192,7 +192,7 @@ func TestGetChunk(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			u.Path = "/"
-			s, err := NewRemoteHTTPStore(u, StoreOptions{ErrorRetry: 5, ErrorRetryBaseInterval: time.Duration(1) * time.Microsecond, Uncompressed: true})
+			s, err := NewRemoteHTTPStore(u, StoreOptions{ErrorRetry: 5, ErrorRetryBaseInterval: time.Microsecond, Uncompressed: true})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -280,7 +280,7 @@ func TestPutChunk(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			u.Path = "/"
-			s, err := NewRemoteHTTPStore(u, StoreOptions{ErrorRetry: 5, ErrorRetryBaseInterval: time.Duration(1) * time.Microsecond, Uncompressed: true})
+			s, err := NewRemoteHTTPStore(u, StoreOptions{ErrorRetry: 5, ErrorRetryBaseInterval: time.Microsecond, Uncompressed: true})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/remotehttpindex.go
+++ b/remotehttpindex.go
@@ -44,11 +44,16 @@ func (r *RemoteHTTPIndex) GetIndex(name string) (i Index, e error) {
 
 // StoreIndex adds a new chunk to the store
 func (r *RemoteHTTPIndex) StoreIndex(name string, idx Index) error {
-	rdr, w := io.Pipe()
 
-	go func() {
-		defer w.Close()
-		idx.WriteTo(w)
-	}()
-	return r.StoreObject(name, rdr)
+	getReader := func() io.Reader {
+
+		rdr, w := io.Pipe()
+		go func() {
+			defer w.Close()
+			idx.WriteTo(w)
+		}()
+		return rdr
+	}
+
+	return r.StoreObject(name, getReader)
 }

--- a/store.go
+++ b/store.go
@@ -71,6 +71,11 @@ type StoreOptions struct {
 	// with unreliable connections. Default: 0
 	ErrorRetry int `json:"error-retry,omitempty"`
 
+	// Number of seconds to wait before first retry attempt.
+	// Retry attempt number N for the same request will wait N times this interval.
+	// Default: 1 second
+	ErrorRetryBaseInterval time.Duration `json:"error-retry-base-interval,omitempty"`
+
 	// If SkipVerify is true, this store will not verfiy the data it reads and serves up. This is
 	// helpful when a store is merely a proxy and the data will pass through additional stores
 	// before being used. Verifying the checksum of a chunk requires it be uncompressed, so if


### PR DESCRIPTION
(This is based on PR #158  - only the two commits on Apr 25th are unique to this PR)

This change provides retry mechanisms for REST API 5xx errors, in addition to the internal errors that were retried. It provides linear backoff during successive retries for a single request. There's a sizable test suite for `remotehttp` as well now. Documentation has been updated to mention the `error-retry-base-interval` setting.

With this change, I have successfully used tar + untar with a 100MB test file set against Google Cloud Storage, and had it work successfully despite one intermittent HTTP 502 response in the middle (this used to make the entire operation fail).

A couple of things are worth pointing out:
- I have centralized all HTTP activity within `remotehttp` to `IssueRetryableHttpRequest` / `IssueHttpRequest`. The logic was getting too complicated to have it duplicated across 3 functions.
- The current implementation will always read the response body, even for HTTP PUT and HTTP HEAD operations. This is wasteful but I wasn't up for doing specialization there. I do not expect that to make a significant performance difference (response bodies should be small for those requests).
- The previous interface expected anyone who called `remotehttp.StoreObject()` to provide an `io.Reader` for the body. I have changed this into a function that returns an `io.Reader`. This way, retrying the same HTTP request will be done with a fresh `io.Reader` (which should emit the same set of bytes as the previous one) for each attempt.
- The `remotehttpindex.StoreIndex()` operation will, when there are intermittent 5xx errors, serialize the index and feed it into a pipe once per attempt. This is wasteful, but the alternative is to serialize all of the index up-front for every request, and keep it in a buffer across all retries. That is wasteful when there are no errors. I have chosen to optimize performance for the no-error case.
- The retry base interval is tweakable per-store, just like the pre-existing max retry count.