### PR TITLE
Archives always contain forward-slash paths, even on Windows

### DIFF
--- a/archive_test.go
+++ b/archive_test.go
@@ -2,7 +2,7 @@ package desync
 
 import (
 	"os"
-	"path/filepath"
+	"path"
 	"reflect"
 	"testing"
 )
@@ -55,13 +55,13 @@ func TestArchiveDecoderNesting(t *testing.T) {
 	}{
 		{Type: NodeDirectory{}, Name: ".", UID: 500, GID: 500},
 		{Type: NodeDirectory{}, Name: "dir1", UID: 500, GID: 500},
-		{Type: NodeDirectory{}, Name: filepath.Join("dir1", "sub11"), UID: 500, GID: 500},
-		{Type: NodeFile{}, Name: filepath.Join("dir1", "sub11", "f11"), UID: 500, GID: 500},
-		{Type: NodeFile{}, Name: filepath.Join("dir1", "sub11", "f12"), UID: 500, GID: 500},
-		{Type: NodeDirectory{}, Name: filepath.Join("dir1", "sub12"), UID: 500, GID: 500},
+		{Type: NodeDirectory{}, Name: path.Join("dir1", "sub11"), UID: 500, GID: 500},
+		{Type: NodeFile{}, Name: path.Join("dir1", "sub11", "f11"), UID: 500, GID: 500},
+		{Type: NodeFile{}, Name: path.Join("dir1", "sub11", "f12"), UID: 500, GID: 500},
+		{Type: NodeDirectory{}, Name: path.Join("dir1", "sub12"), UID: 500, GID: 500},
 		{Type: NodeDirectory{}, Name: "dir2", UID: 500, GID: 500},
-		{Type: NodeDirectory{}, Name: filepath.Join("dir2", "sub21"), UID: 500, GID: 500},
-		{Type: NodeDirectory{}, Name: filepath.Join("dir2", "sub22"), UID: 500, GID: 500},
+		{Type: NodeDirectory{}, Name: path.Join("dir2", "sub21"), UID: 500, GID: 500},
+		{Type: NodeDirectory{}, Name: path.Join("dir2", "sub22"), UID: 500, GID: 500},
 		{Type: nil},
 	}
 


### PR DESCRIPTION
Some of the archive tests fail on Windows. Rather than using `filepath.Join` to construct within-archive paths (which will create paths like `dir1\dir2` on Windows, and `dir1/dir2` on Unix), those tests should use plain `path.Join` (which will create paths like `dir1/dir2` on all OSes). Fixed in this PR; now all tests pass on Windows.