### PR TITLE
GitHub validation improvements

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -12,10 +12,14 @@ on:
       - '**'
 
 jobs:
-  validate-linux:
-    name: Validate on Linux
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
+  build:
+    name: Validate on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-go@v2
@@ -23,16 +27,3 @@ jobs:
           go-version: '^1.14.1'
       - run: go test
       - run: go build ./cmd/desync
-
-  validate-windows:
-    name: Validate on Windows
-    runs-on: windows-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '^1.14.1'
-      - run: go test
-      - run: go build .\cmd\desync
-      

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
 
     timeout-minutes: 10
     steps:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -25,5 +25,13 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '^1.14.1'
+
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - run: go test
       - run: go build ./cmd/desync


### PR DESCRIPTION
Couple of smaller fixes for the GH Actions validation logic:

* The validation is now a matrix job. No more separate Windows/Linux flows.
* Validation will also run on MacOSX
* The set of installed Go modules are cached between runs. The cache is invalidated whenever the set of modules change. This makes building a few seconds faster. The big time sink is still download & installation of go itself; 20 seconds on Linux, 30 seconds on MacOSX, 50 seconds on Windows.