### PR TITLE
Added logging to Google Cloud Storage backend

### DIFF
--- a/gcs.go
+++ b/gcs.go
@@ -212,9 +212,11 @@ func (s GCStore) RemoveChunk(id ChunkID) error {
 
 	if err != nil {
 		log.WithError(err).Error("Unable to delete object in GCS bucket")
+		return err
+	} else {
+		log.Debug("Removed chunk from GCS bucket")
+		return nil
 	}
-	log.Debug("Removed chunk from GCS bucket")
-	return err
 }
 
 // Prune removes any chunks from the store that are not contained in a list (map)

--- a/gcs.go
+++ b/gcs.go
@@ -157,6 +157,7 @@ func (s GCStore) StoreChunk(chunk *Chunk) error {
 		log.WithError(err).Error("Error when copying data from local filesystem to object in GCS bucket")
 		return errors.Wrap(err, s.String())
 	}
+
 	err = w.Close()
 	if err != nil {
 		log.WithError(err).Error("Error when finalizing copying of data from local filesystem to object in GCS bucket")
@@ -164,7 +165,6 @@ func (s GCStore) StoreChunk(chunk *Chunk) error {
 	}
 
 	log.Debug("Uploaded chunk to GCS bucket")
-
 	return nil
 }
 

--- a/gcsindex.go
+++ b/gcsindex.go
@@ -6,7 +6,9 @@ import (
 	"net/url"
 	"path"
 
+	"cloud.google.com/go/storage"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // GCIndexStore is a read-write index store with Google Storage backing
@@ -28,10 +30,25 @@ func NewGCIndexStore(location *url.URL, opt StoreOptions) (s GCIndexStore, e err
 // file does not exist.
 func (s GCIndexStore) GetIndexReader(name string) (r io.ReadCloser, err error) {
 	ctx := context.TODO()
+
+	var (
+		log = Log.WithFields(logrus.Fields{
+			"bucket": s.bucket,
+			"name":   s.prefix + name,
+		})
+	)
+
 	obj, err := s.client.Object(s.prefix + name).NewReader(ctx)
-	if err != nil {
+
+	if err == storage.ErrObjectNotExist {
+		log.Warning("Unable to create reader for object in GCS bucket; the object may not exist, or the bucket may not exist, or you may not have permission to access it")
+		return nil, errors.Wrap(err, s.String())
+	} else if err != nil {
+		log.WithError(err).Error("Error when creating index reader from GCS bucket")
 		return nil, errors.Wrap(err, s.String())
 	}
+
+	log.Debug("Created index reader from GCS bucket")
 	return obj, nil
 }
 
@@ -48,13 +65,32 @@ func (s GCIndexStore) GetIndex(name string) (i Index, e error) {
 // StoreIndex writes the index file to the Google Storage store
 func (s GCIndexStore) StoreIndex(name string, idx Index) error {
 	ctx := context.TODO()
+
+	var (
+		log = Log.WithFields(logrus.Fields{
+			"bucket": s.bucket,
+			"name":   s.prefix + name,
+		})
+	)
+
 	w := s.client.Object(s.prefix + name).NewWriter(ctx)
 	w.ContentType = "application/octet-stream"
+
 	_, err := idx.WriteTo(w)
+
 	if err != nil {
+		log.WithError(err).Error("Error when copying data from local filesystem to object in GCS bucket")
 		w.Close()
 		return errors.Wrap(err, path.Base(s.Location))
 	}
+
 	err = w.Close()
-	return errors.Wrap(err, path.Base(s.Location))
+
+	if err != nil {
+		log.WithError(err).Error("Error when finalizing copying of data from local filesystem to object in GCS bucket")
+		return errors.Wrap(err, path.Base(s.Location))
+	}
+
+	log.Debug("Index written to GCS bucket")
+	return nil
 }


### PR DESCRIPTION
All successful accesses result in log output when run in --verbose mode.
All access errors result in log errors in any mode.

Typical output during `untar` with `--verbose` and pulling from a GCS bucket looks like this:

```
time="2020-05-02T23:12:46+02:00" level=debug msg="Created index reader from GCS bucket" bucket=my-test-index-store-2 name=/PerfTestFiles-100MB.caidx
Unpacking [--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------]   0.00%time="2020-05-02T23:12:46+02:00" level=debug msg="Retrieved chunk from GCS bucket" bucket=my-test-chunk-store-2 name=da4d/da4d50be76a6eef083031c8006a94d69ead11c80dce6eab5c27683ab815e0c80.cacnk
time="2020-05-02T23:12:46+02:00" level=debug msg="Retrieved chunk from GCS bucket" bucket=my-test-chunk-store-2 name=fefe/fefe7d6ac3099e7f7cf232d6ebcf5573b56eb0f72caba9463f6b387356c8b91a.cacnk
time="2020-05-02T23:12:46+02:00" level=debug msg="Retrieved chunk from GCS bucket" bucket=my-test-chunk-store-2 name=6a98/6a989936f944366afcbe63e8cb4033da15dbf81a11da1aec770abeb4cae05264.cacnk
time="2020-05-02T23:12:46+02:00" level=debug msg="Retrieved chunk from GCS bucket" bucket=my-test-chunk-store-2 name=d8a5/d8a56faefd53032a86d276b61c0bcb7d8a4db6a0282a38210acc65adcedd48ce.cacnk
time="2020-05-02T23:12:46+02:00" level=debug msg="Retrieved chunk from GCS bucket" bucket=my-test-chunk-store-2 name=c40f/c40f32bd96db6a40197ce8dad834984f39f9281807f5ed002b9db4236cd9a50d.cacnk
time="2020-05-02T23:12:46+02:00" level=debug msg="Retrieved chunk from GCS bucket" bucket=my-test-chunk-store-2 name=a9e4/a9e4417a83b3ad6e687ae8c123e6b059dd7241e8fa0fb56d1024121141c9a1e7.cacnk
time="2020-05-02T23:12:46+02:00" level=debug msg="Retrieved chunk from GCS bucket" bucket=my-test-chunk-store-2 name=705d/705dfd02a184aaf5368f6d9173e5932a359fd53205fd5d92456ebc3a111609c6.cacnk
time="2020-05-02T23:12:46+02:00" level=debug msg="Retrieved chunk from GCS bucket" bucket=my-test-chunk-store-2 name=fbd9/fbd9139e204fa9125c893c0b6347882b8e52f798107663c42ce51d10f7fb01c2.cacnk
time="2020-05-02T23:12:46+02:00" level=debug msg="Retrieved chunk from GCS bucket" bucket=my-test-chunk-store-2 name=7b3b/7b3b5c6b4bd5b8361b12588f05920ce179c21bdcefdf102df4a3af650a2cf9b3.cacnk
Unpacking [>------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------]   0.15% 02m09stime="2020-05-02T23:12:46+02:00" level=debug msg="Retrieved chunk from GCS bucket" bucket=my-test-chunk-store-2 name=55e4/55e4b286fcda9fc7d8286ca20dac64f5031f2caa7bc023778fe9bf35026d43dd.cacnk
time="2020-05-02T23:12:46+02:00" level=debug msg="Retrieved chunk from GCS bucket" bucket=my-test-chunk-store-2 name=08d0/08d04890facfdc8ebe8d32dbaa4780cccdadb21e514c1148e2baa4d82524d4c5.cacnk
time="2020-05-02T23:12:46+02:00" level=debug msg="Retrieved chunk from GCS bucket" bucket=my-test-chunk-store-2 name=a282/a2825f69b68d8ae2c1c3adcd950b057b7f37e366969dbe36d9172362324334ba.cacnk
time="2020-05-02T23:12:46+02:00" level=debug msg="Retrieved chunk from GCS bucket" bucket=my-test-chunk-store-2 name=9d9d/9d9d3f01c521b6c68a51a33d2965ea1a0bee5edbe0b19205c3ee87ae208508c5.cacnk
time="2020-05-02T23:12:46+02:00" level=debug msg="Retrieved chunk from GCS bucket" bucket=my-test-chunk-store-2 name=1ded/1ded968e0b9310f360f73dd4e9e0cdf19b58486881e03b7c28286f7920d046d0.cacnk
```