### PR TITLE
The GCS index store should use the path without trailing filename as its root

### DIFF
--- a/cmd/desync/store.go
+++ b/cmd/desync/store.go
@@ -272,7 +272,7 @@ func indexStoreFromLocation(location string, cmdOpt cmdStoreOptions) (desync.Ind
 			return nil, "", err
 		}
 	case "gs":
-		s, err = desync.NewGCIndexStore(loc, opt)
+		s, err = desync.NewGCIndexStore(&p, opt)
 		if err != nil {
 			return nil, "", err
 		}


### PR DESCRIPTION
Attempting to use an URI like `gs://bucket/folder/filename.caibx` used to result in an actual retrieval path of `gs://bucket/folder/filename.caibx/filename.caibx`. This change fixes it. The GCS index store now behaves like other stores.