### PR TITLE
Rewritten gcs filename prefix logic to never include leading slash

### DIFF
--- a/gcs.go
+++ b/gcs.go
@@ -32,6 +32,23 @@ type GCStore struct {
 	GCStoreBase
 }
 
+// normalizeGCPrefix converts path to a regular format,
+// where there never is a leading slash,
+// and every folder name always is followed by a slash
+// so example outputs will be:
+// 		<blank string>
+// 		folder1/
+//		folder1/folder2/folder3/
+func normalizeGCPrefix(path string) string {
+	prefix := strings.Trim(path, "/")
+
+	if prefix != "" {
+		prefix += "/"
+	}
+
+	return prefix
+}
+
 // NewGCStoreBase initializes a base object used for chunk or index stores
 // backed by Google Storage.
 func NewGCStoreBase(u *url.URL, opt StoreOptions) (GCStoreBase, error) {
@@ -44,14 +61,7 @@ func NewGCStoreBase(u *url.URL, opt StoreOptions) (GCStoreBase, error) {
 
 	// Pull the bucket as well as the prefix from a path-style URL
 	s.bucket = u.Host
-	s.prefix = u.Path
-
-	if s.prefix != "" {
-		if s.prefix[0] == '/' {
-			s.prefix = s.prefix[1:]
-		}
-		s.prefix += "/"
-	}
+	s.prefix = normalizeGCPrefix(u.Path)
 
 	client, err := storage.NewClient(ctx)
 	if err != nil {

--- a/gcs_test.go
+++ b/gcs_test.go
@@ -1,0 +1,34 @@
+package desync
+
+import (
+	"testing"
+)
+
+func TestNormalizeGCPrefix(t *testing.T) {
+
+	tests := map[string]struct {
+		path           string
+		expectedPrefix string
+	}{
+		"blank path":                              {"/", ""},
+		"slash only":                              {"/", ""},
+		"path with no slash":                      {"path", "path/"},
+		"path with leading slash":                 {"/path", "path/"},
+		"path with trailing slash":                {"path/", "path/"},
+		"paths with no slashes":                   {"path1/path2", "path1/path2/"},
+		"paths with leading slash":                {"/path1/path2", "path1/path2/"},
+		"paths with trailing slash":               {"path1/path2/", "path1/path2/"},
+		"paths with leading and trailing slashes": {"path1/path2/", "path1/path2/"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			prefix := normalizeGCPrefix(test.path)
+
+			if prefix != test.expectedPrefix {
+				t.Fatalf("path '%s' should normalize into '%s' but was normalized into '%s'", test.path, test.expectedPrefix, prefix)
+			}
+		})
+	}
+}

--- a/gcs_test.go
+++ b/gcs_test.go
@@ -10,7 +10,7 @@ func TestNormalizeGCPrefix(t *testing.T) {
 		path           string
 		expectedPrefix string
 	}{
-		"blank path":                              {"/", ""},
+		"blank path":                              {"", ""},
 		"slash only":                              {"/", ""},
 		"path with no slash":                      {"path", "path/"},
 		"path with leading slash":                 {"/path", "path/"},


### PR DESCRIPTION
The original logic in `gcs.go` would create prefix strings with leading slashes. This would result in item names like `/file1.txt`, `/folder1/file1.txt`, etc.

These paths should not have had leading slashes. For files within folders, Google Cloud Storage ignored the leading slash, but for files in the root, GCS would create a nameless folder - i.e. a folder with the name "". This caused problems for index stores when placing files into the root of a bucket.

This change ensures that the path prefix for the root folder is "" and for an actual folder is `folder1/`, etc.