### PR TITLE
Sparse mount support

### DIFF
--- a/cmd/desync/mount-index.go
+++ b/cmd/desync/mount-index.go
@@ -22,7 +22,7 @@ type mountIndexOptions struct {
 	cache     string
 	storeFile string
 	corFile   string
-	desync.SparseMountOptions
+	desync.SparseFileOptions
 }
 
 func newMountIndexCommand(ctx context.Context) *cobra.Command {
@@ -63,7 +63,7 @@ needing to restart the server. This can be done under load as well.
 	flags.StringVarP(&opt.corFile, "cor-file", "", "", "use a copy-on-read sparse file as cache")
 	flags.StringVarP(&opt.StateSaveFile, "cor-state-save", "", "", "file to store the state for copy-on-read")
 	flags.StringVarP(&opt.StateInitFile, "cor-state-init", "", "", "copy-on-read state init file")
-	flags.IntVarP(&opt.StateInitConcurrency, "cor-init-n", "", 1, "number of gorooutines to use for initialization (with --cor-state-init)")
+	flags.IntVarP(&opt.StateInitConcurrency, "cor-init-n", "", 10, "number of gorooutines to use for initialization (with --cor-state-init)")
 	addStoreOptions(&opt.cmdStoreOptions, flags)
 	return cmd
 }
@@ -116,7 +116,7 @@ func runMountIndex(ctx context.Context, opt mountIndexOptions, args []string) er
 	// Pick a filesystem based on the options
 	var ifs desync.MountFS
 	if opt.corFile != "" {
-		fs, err := desync.NewSparseMountFS(idx, mountFName, s, opt.corFile, opt.SparseMountOptions)
+		fs, err := desync.NewSparseMountFS(idx, mountFName, s, opt.corFile, opt.SparseFileOptions)
 		if err != nil {
 			return err
 		}

--- a/cmd/desync/options.go
+++ b/cmd/desync/options.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// cmdStoreOptions are used to pass additional options to store initalization from the
+// cmdStoreOptions are used to pass additional options to store initialization from the
 // commandline. These generally override settings from the config file.
 type cmdStoreOptions struct {
 	n             int

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	cloud.google.com/go/storage v1.6.0
+	github.com/boljen/go-bitmap v0.0.0-20151001105940-23cd2fb0ce7d
 	github.com/datadog/zstd v1.4.5
 	github.com/dchest/siphash v1.2.1
 	github.com/fatih/color v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/boljen/go-bitmap v0.0.0-20151001105940-23cd2fb0ce7d h1:zsO4lp+bjv5XvPTF58Vq+qgmZEYZttJK+CWtSZhKenI=
+github.com/boljen/go-bitmap v0.0.0-20151001105940-23cd2fb0ce7d/go.mod h1:f1iKL6ZhUWvbk7PdWVmOaak10o86cqMUYEmn1CZNGEI=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/mount-index.go
+++ b/mount-index.go
@@ -109,14 +109,13 @@ func (f *indexFileHandle) read(dest []byte, off int64) (fuse.ReadResult, syscall
 
 // MountIndex mounts an index file under a FUSE mount point. The mount will only expose a single
 // blob file as represented by the index.
-func MountIndex(ctx context.Context, idx Index, path, name string, s Store, n int) error {
-	ifs := NewIndexMountFS(idx, name, s)
+func MountIndex(ctx context.Context, idx Index, ifs fs.InodeEmbedder, path string, s Store, n int) error {
 	opts := &fs.Options{}
 	server, err := fs.Mount(path, ifs, opts)
 	if err != nil {
 		return err
 	}
-	go func() { // Unmount the server when the contex expires
+	go func() { // Unmount the server when the context expires
 		<-ctx.Done()
 		server.Unmount()
 	}()

--- a/mount-index.go
+++ b/mount-index.go
@@ -15,6 +15,12 @@ import (
 	"github.com/hanwen/go-fuse/v2/fuse"
 )
 
+type MountFS interface {
+	fs.InodeEmbedder
+
+	Close() error
+}
+
 // IndexMountFS is used to FUSE mount an index file (as a blob, not an archive).
 // It present a single file underneath the mountpoint.
 type IndexMountFS struct {
@@ -26,6 +32,7 @@ type IndexMountFS struct {
 }
 
 var _ fs.NodeOnAdder = &IndexMountFS{}
+var _ MountFS = &IndexMountFS{}
 
 // NewIndexMountFS initializes a FUSE filesystem mount based on an index and a chunk store.
 func NewIndexMountFS(idx Index, name string, s Store) *IndexMountFS {
@@ -45,6 +52,10 @@ func (r *IndexMountFS) OnAdd(ctx context.Context) {
 	}
 	ch := r.NewPersistentInode(ctx, n, fs.StableAttr{Mode: fuse.S_IFREG})
 	r.AddChild(r.FName, ch, false)
+}
+
+func (r *IndexMountFS) Close() error {
+	return nil
 }
 
 var _ fs.NodeGetattrer = &indexFile{}
@@ -109,7 +120,7 @@ func (f *indexFileHandle) read(dest []byte, off int64) (fuse.ReadResult, syscall
 
 // MountIndex mounts an index file under a FUSE mount point. The mount will only expose a single
 // blob file as represented by the index.
-func MountIndex(ctx context.Context, idx Index, ifs fs.InodeEmbedder, path string, s Store, n int) error {
+func MountIndex(ctx context.Context, idx Index, ifs MountFS, path string, s Store, n int) error {
 	opts := &fs.Options{}
 	server, err := fs.Mount(path, ifs, opts)
 	if err != nil {
@@ -117,6 +128,9 @@ func MountIndex(ctx context.Context, idx Index, ifs fs.InodeEmbedder, path strin
 	}
 	go func() { // Unmount the server when the context expires
 		<-ctx.Done()
+		if err := ifs.Close(); err != nil {
+			fmt.Fprintln(os.Stderr, "error during unmount:", err)
+		}
 		server.Unmount()
 	}()
 	server.Wait()

--- a/mount-index_linux_test.go
+++ b/mount-index_linux_test.go
@@ -56,7 +56,7 @@ func TestMountIndex(t *testing.T) {
 
 	// Start the Fuse mount
 	go func() {
-		ifs := NewIndexMountFS(idx, "blob1", s)
+		ifs := NewIndexMountFS(index, "blob1", s)
 		MountIndex(ctx, index, ifs, mnt, s, 10)
 		wg.Done()
 	}()

--- a/mount-index_linux_test.go
+++ b/mount-index_linux_test.go
@@ -56,7 +56,8 @@ func TestMountIndex(t *testing.T) {
 
 	// Start the Fuse mount
 	go func() {
-		MountIndex(ctx, index, mnt, "blob1", s, 10)
+		ifs := NewIndexMountFS(idx, "blob1", s)
+		MountIndex(ctx, index, ifs, mnt, s, 10)
 		wg.Done()
 	}()
 

--- a/mount-sparse.go
+++ b/mount-sparse.go
@@ -23,6 +23,7 @@ type SparseMountFS struct {
 }
 
 var _ fs.NodeOnAdder = &SparseMountFS{}
+var _ MountFS = &SparseMountFS{}
 
 // NewSparseMountFS initializes a FUSE filesystem mount based on an index, a sparse file and a chunk store.
 func NewSparseMountFS(idx Index, name string, s Store, sparseFile string) (*SparseMountFS, error) {
@@ -45,6 +46,11 @@ func (r *SparseMountFS) OnAdd(ctx context.Context) {
 	}
 	ch := r.NewPersistentInode(ctx, n, fs.StableAttr{Mode: fuse.S_IFREG})
 	r.AddChild(r.FName, ch, false)
+}
+
+// Close the sparse file and save its state.
+func (r *SparseMountFS) Close() error {
+	return r.sf.Close()
 }
 
 var _ fs.NodeGetattrer = &indexFile{}

--- a/mount-sparse.go
+++ b/mount-sparse.go
@@ -1,0 +1,87 @@
+// +build !windows
+
+package desync
+
+import (
+	"context"
+	"io"
+	"syscall"
+	"time"
+
+	"github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
+)
+
+// SparseMountFS is used to FUSE mount an index file (as a blob, not an archive).
+// It uses a (local) sparse file as cache to improve performance. Every chunk that
+// is being read is written into the sparse file
+type SparseMountFS struct {
+	fs.Inode
+
+	FName string // File name in the mountpoint
+	sf    *SparseFile
+}
+
+var _ fs.NodeOnAdder = &SparseMountFS{}
+
+// NewSparseMountFS initializes a FUSE filesystem mount based on an index, a sparse file and a chunk store.
+func NewSparseMountFS(idx Index, name string, s Store, sparseFile string) (*SparseMountFS, error) {
+	sf, err := NewSparseFile(sparseFile, idx, s)
+	if err != nil {
+		return nil, err
+	}
+	return &SparseMountFS{
+		FName: name,
+		sf:    sf,
+	}, err
+}
+
+// OnAdd is used to build the static filesystem structure at the start of the mount.
+func (r *SparseMountFS) OnAdd(ctx context.Context) {
+	n := &sparseIndexFile{
+		sf:    r.sf,
+		mtime: time.Now(),
+		size:  r.sf.Length(),
+	}
+	ch := r.NewPersistentInode(ctx, n, fs.StableAttr{Mode: fuse.S_IFREG})
+	r.AddChild(r.FName, ch, false)
+}
+
+var _ fs.NodeGetattrer = &indexFile{}
+var _ fs.NodeOpener = &indexFile{}
+
+type sparseIndexFile struct {
+	fs.Inode
+	sf    *SparseFile
+	size  int64
+	mtime time.Time
+}
+
+func (n *sparseIndexFile) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, syscall.Errno) {
+	fh, err := n.sf.Open()
+	if err != nil {
+		Log.WithError(err).Error("failed to open sparse file")
+		return fh, fuse.FOPEN_KEEP_CACHE, syscall.EIO
+	}
+	return fh, fuse.FOPEN_KEEP_CACHE, fs.OK
+}
+
+func (n *sparseIndexFile) Read(ctx context.Context, fh fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
+	f := fh.(*SparseFileHandle)
+	length, err := f.ReadAt(dest, off)
+	if err != nil {
+		if err == io.EOF {
+			return fuse.ReadResultData(dest[:length]), fs.OK
+		}
+		Log.WithError(err).Error("failed to read sparse file")
+		return fuse.ReadResultData(dest[:length]), syscall.EIO
+	}
+	return fuse.ReadResultData(dest[:length]), fs.OK
+}
+
+func (n *sparseIndexFile) Getattr(ctx context.Context, fh fs.FileHandle, out *fuse.AttrOut) syscall.Errno {
+	out.Mode = fuse.S_IFREG | 0444
+	out.Size = uint64(n.size)
+	out.Mtime = uint64(n.mtime.Unix())
+	return fs.OK
+}

--- a/mount-sparse.go
+++ b/mount-sparse.go
@@ -25,9 +25,25 @@ type SparseMountFS struct {
 var _ fs.NodeOnAdder = &SparseMountFS{}
 var _ MountFS = &SparseMountFS{}
 
+type SparseMountOptions struct {
+	// Optional, save the state of the sparse file on exit or SIGHUP. The state file
+	// contains information which chunks from the index have been read and are
+	// populated in the sparse file. If the state and sparse file exist and match,
+	// the sparse file is used as is (not re-populated).
+	StateSaveFile string
+
+	// Optional, load all chunks that are marked as read in this state file. It is used
+	// to pre-populate a new sparse file if the sparse file or the save state file aren't
+	// present or don't match the index. SaveStateFile and StateInitFile can be the same.
+	StateInitFile string
+
+	// Optional, number of goroutines to preload chunks from StateInitFile.
+	StateInitConcurrency int
+}
+
 // NewSparseMountFS initializes a FUSE filesystem mount based on an index, a sparse file and a chunk store.
-func NewSparseMountFS(idx Index, name string, s Store, sparseFile string) (*SparseMountFS, error) {
-	sf, err := NewSparseFile(sparseFile, idx, s)
+func NewSparseMountFS(idx Index, name string, s Store, sparseFile string, opt SparseMountOptions) (*SparseMountFS, error) {
+	sf, err := NewSparseFile(sparseFile, idx, s, opt)
 	if err != nil {
 		return nil, err
 	}
@@ -48,9 +64,14 @@ func (r *SparseMountFS) OnAdd(ctx context.Context) {
 	r.AddChild(r.FName, ch, false)
 }
 
+// Save the state of the sparse file.
+func (r *SparseMountFS) WriteState() error {
+	return r.sf.WriteState()
+}
+
 // Close the sparse file and save its state.
 func (r *SparseMountFS) Close() error {
-	return r.sf.Close()
+	return r.sf.WriteState()
 }
 
 var _ fs.NodeGetattrer = &indexFile{}

--- a/mount-sparse.go
+++ b/mount-sparse.go
@@ -25,24 +25,8 @@ type SparseMountFS struct {
 var _ fs.NodeOnAdder = &SparseMountFS{}
 var _ MountFS = &SparseMountFS{}
 
-type SparseMountOptions struct {
-	// Optional, save the state of the sparse file on exit or SIGHUP. The state file
-	// contains information which chunks from the index have been read and are
-	// populated in the sparse file. If the state and sparse file exist and match,
-	// the sparse file is used as is (not re-populated).
-	StateSaveFile string
-
-	// Optional, load all chunks that are marked as read in this state file. It is used
-	// to pre-populate a new sparse file if the sparse file or the save state file aren't
-	// present or don't match the index. SaveStateFile and StateInitFile can be the same.
-	StateInitFile string
-
-	// Optional, number of goroutines to preload chunks from StateInitFile.
-	StateInitConcurrency int
-}
-
 // NewSparseMountFS initializes a FUSE filesystem mount based on an index, a sparse file and a chunk store.
-func NewSparseMountFS(idx Index, name string, s Store, sparseFile string, opt SparseMountOptions) (*SparseMountFS, error) {
+func NewSparseMountFS(idx Index, name string, s Store, sparseFile string, opt SparseFileOptions) (*SparseMountFS, error) {
 	sf, err := NewSparseFile(sparseFile, idx, s, opt)
 	if err != nil {
 		return nil, err

--- a/sparse-file.go
+++ b/sparse-file.go
@@ -249,16 +249,18 @@ func (l *sparseFileLoader) loadState(r io.Reader) error {
 		return err
 	}
 
-	// Very basic check that the state file really is for the sparse
-	// file and not something else.
-	if len(b) != len(l.chunks) {
-		return errors.New("sparse state file does not match the index")
-	}
-
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
 	l.done = b
+
+	// Very basic check that the state file really is for the sparse
+	// file and not something else.
+	// comparaison in octet. integer division
+	chunks := len(l.chunks)
+	if (chunks%8 == 0 && l.done.Len()/8 != chunks/8) || (chunks%8 != 0 && l.done.Len()/8 != 1+chunks/8) {
+		return errors.New("sparse state file does not match the index")
+	}
 
 	return nil
 }

--- a/sparse-file.go
+++ b/sparse-file.go
@@ -1,0 +1,173 @@
+package desync
+
+import (
+	"os"
+	"sort"
+	"sync"
+)
+
+// SparseFile represents a file that is written as it is read (Copy-on-read). It is
+// used as a fast cache. Any chunk read from the store to satisfy a read operation
+// is written to the file.
+type SparseFile struct {
+	name string
+	idx  Index
+
+	loader *sparseFileLoader
+}
+
+// SparseFileHandle is used to access a sparse file. All read operations performed
+// on the handle are either done on the file if the required ranges are available
+// or loaded from the store and written to the file.
+type SparseFileHandle struct {
+	sf   *SparseFile
+	file *os.File
+}
+
+func NewSparseFile(name string, idx Index, s Store) (*SparseFile, error) {
+	f, err := os.Create(name)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	return &SparseFile{
+		name:   name,
+		idx:    idx,
+		loader: newSparseFileLoader(name, idx, s),
+	}, nil
+}
+
+// Open returns a handle for a sparse file.
+func (sf *SparseFile) Open() (*SparseFileHandle, error) {
+	file, err := os.Open(sf.name)
+	return &SparseFileHandle{
+		sf:   sf,
+		file: file,
+	}, err
+}
+
+// Length returns the size of the index used for the sparse file.
+func (sf *SparseFile) Length() int64 {
+	return sf.idx.Length()
+}
+
+// ReadAt reads from the sparse file. All accessed ranges are first written
+// to the file and then returned.
+func (h *SparseFileHandle) ReadAt(b []byte, offset int64) (int, error) {
+	if err := h.sf.loader.loadRange(offset, int64(len(b))); err != nil {
+		return 0, err
+	}
+	return h.file.ReadAt(b, offset)
+}
+
+func (h *SparseFileHandle) Close() error {
+	return h.file.Close()
+}
+
+type sparseIndexChunk struct {
+	IndexChunk
+	once sync.Once
+}
+
+// Loader for sparse files
+type sparseFileLoader struct {
+	name string
+	done []bool
+	mu   sync.RWMutex
+	s    Store
+
+	chunks []*sparseIndexChunk
+}
+
+func newSparseFileLoader(name string, idx Index, s Store) *sparseFileLoader {
+	chunks := make([]*sparseIndexChunk, 0, len(idx.Chunks))
+	for _, c := range idx.Chunks {
+		chunks = append(chunks, &sparseIndexChunk{IndexChunk: c})
+	}
+
+	return &sparseFileLoader{
+		name:   name,
+		done:   make([]bool, len(idx.Chunks)),
+		chunks: chunks,
+		s:      s,
+	}
+}
+
+// For a given byte range, returns the index of the first and last chunk needed to populate it
+func (l *sparseFileLoader) indexRange(start, length int64) (int, int) {
+	end := uint64(start + length - 1)
+	firstChunk := sort.Search(len(l.chunks), func(i int) bool { return start < int64(l.chunks[i].Start+l.chunks[i].Size) })
+	if length < 1 {
+		return firstChunk, firstChunk
+	}
+	if firstChunk >= len(l.chunks) { // reading past the end, load the last chunk
+		return len(l.chunks) - 1, len(l.chunks) - 1
+	}
+
+	// Could do another binary search to find the last, but in reality, most reads are short enough to fall
+	// into one or two chunks only, so may as well use a for loop here.
+	lastChunk := firstChunk
+	for i := firstChunk + 1; i < len(l.chunks); i++ {
+		if end < l.chunks[i].Start {
+			break
+		}
+		lastChunk++
+	}
+	return firstChunk, lastChunk
+}
+
+// Loads all the chunks needed to populate the given byte range (if not already loaded)
+func (l *sparseFileLoader) loadRange(start, length int64) error {
+	first, last := l.indexRange(start, length)
+	var chunksNeeded []int
+	l.mu.RLock()
+	for i := first; i <= last; i++ {
+		if l.done[i] {
+			continue
+		}
+		chunksNeeded = append(chunksNeeded, i)
+	}
+	l.mu.RUnlock()
+
+	// TODO: Load the chunks concurrently
+	for _, chunk := range chunksNeeded {
+		if err := l.loadChunk(chunk); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (l *sparseFileLoader) loadChunk(i int) error {
+	var loadErr error
+	l.chunks[i].once.Do(func() {
+		c, err := l.s.GetChunk(l.chunks[i].ID)
+		if err != nil {
+			loadErr = err
+			return
+		}
+		b, err := c.Uncompressed()
+		if err != nil {
+			loadErr = err
+			return
+		}
+
+		f, err := os.OpenFile(l.name, os.O_RDWR, 0666)
+		if err != nil {
+			loadErr = err
+			return
+		}
+		defer f.Close()
+
+		if _, err := f.WriteAt(b, int64(l.chunks[i].Start)); err != nil {
+			loadErr = err
+			return
+		}
+
+		l.mu.Lock()
+		l.done[i] = true
+		l.mu.Unlock()
+	})
+	return loadErr
+}

--- a/sparse-file_test.go
+++ b/sparse-file_test.go
@@ -73,7 +73,7 @@ func TestSparseFileRead(t *testing.T) {
 	require.NoError(t, err)
 
 	// Initialize the sparse file and open a handle
-	sparse, err := NewSparseFile(sparseFile.Name(), index, s)
+	sparse, err := NewSparseFile(sparseFile.Name(), index, s, SparseMountOptions{})
 	require.NoError(t, err)
 	h, err := sparse.Open()
 	require.NoError(t, err)

--- a/sparse-file_test.go
+++ b/sparse-file_test.go
@@ -1,0 +1,107 @@
+package desync
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoaderChunkRange(t *testing.T) {
+	idx := Index{
+		Chunks: []IndexChunk{
+			{Start: 0, Size: 10, ID: ChunkID{0}},
+			{Start: 10, Size: 10, ID: ChunkID{1}},
+			{Start: 20, Size: 10, ID: ChunkID{2}},
+		},
+	}
+
+	loader := newSparseFileLoader("", idx, nil)
+
+	tests := []struct {
+		// Input ranges
+		start  int64
+		length int64
+
+		// Expected output (chunk positions and length)
+		first int
+		last  int
+	}{
+		{start: 0, length: 0, first: 0, last: 0},  // empty read at the start
+		{start: 0, length: 1, first: 0, last: 0},  // one byte at the start
+		{start: 10, length: 1, first: 1, last: 1}, // first byte in the 2nd chunk
+		{start: 19, length: 1, first: 1, last: 1}, // last byte in the 2nd chunk
+		{start: 0, length: 20, first: 0, last: 1}, // first two whole chunks
+		{start: 5, length: 10, first: 0, last: 1}, // spanning first two chunks
+		{start: 0, length: 30, first: 0, last: 2}, // whole file
+		{start: 29, length: 0, first: 2, last: 2}, // empty read at the end
+		{start: 29, length: 1, first: 2, last: 2}, // one byte at the end
+		{start: 30, length: 1, first: 2, last: 2}, // read past the end
+	}
+
+	for _, test := range tests {
+		first, chunks := loader.indexRange(test.start, test.length)
+		require.Equal(t, test.first, first, "first chunk")
+		require.Equal(t, test.last, chunks, "number of chunks")
+	}
+}
+
+func TestSparseFileRead(t *testing.T) {
+	// Sparse output file
+	sparseFile, err := ioutil.TempFile("", "")
+	require.NoError(t, err)
+	defer os.Remove(sparseFile.Name())
+
+	// Open the store
+	s, err := NewLocalStore("testdata/blob1.store", StoreOptions{})
+	require.NoError(t, err)
+	defer s.Close()
+
+	// Read the index
+	indexFile, err := os.Open("testdata/blob1.caibx")
+	require.NoError(t, err)
+	defer indexFile.Close()
+	index, err := IndexFromReader(indexFile)
+	require.NoError(t, err)
+
+	// // Calculate the expected hash
+	b, err := ioutil.ReadFile("testdata/blob1")
+	require.NoError(t, err)
+
+	// Initialize the sparse file and open a handle
+	sparse, err := NewSparseFile(sparseFile.Name(), index, s)
+	require.NoError(t, err)
+	h, err := sparse.Open()
+	require.NoError(t, err)
+	defer h.Close()
+
+	// Read a few randome ranges and compare to the expected blob content
+	for i := 0; i < 10; i++ {
+		start := rand.Intn(int(index.Length()))
+		length := rand.Intn(int(index.Index.ChunkSizeMax))
+
+		fromSparse := make([]byte, length)
+		fromBlob := make([]byte, length)
+
+		_, err := h.ReadAt(fromSparse, int64(start))
+		require.NoError(t, err)
+
+		_, err = bytes.NewReader(b).ReadAt(fromBlob, int64(start))
+		require.NoError(t, err)
+
+		require.Equal(t, fromBlob, fromSparse)
+	}
+
+	// Read the whole file. After this is should match the whole blob
+	whole := make([]byte, index.Length())
+	_, err = h.ReadAt(whole, 0)
+	require.NoError(t, err)
+
+	blobHash := sha256.Sum256(b)
+	sparseHash := sha256.Sum256(whole)
+	require.Equal(t, blobHash, sparseHash)
+}

--- a/sparse-file_test.go
+++ b/sparse-file_test.go
@@ -73,7 +73,7 @@ func TestSparseFileRead(t *testing.T) {
 	require.NoError(t, err)
 
 	// Initialize the sparse file and open a handle
-	sparse, err := NewSparseFile(sparseFile.Name(), index, s, SparseMountOptions{})
+	sparse, err := NewSparseFile(sparseFile.Name(), index, s, SparseFileOptions{})
 	require.NoError(t, err)
 	h, err := sparse.Open()
 	require.NoError(t, err)


### PR DESCRIPTION
Supports caching into a sparse file when using the `mount-index` command. The cache file is updated as blocks are read from the mount. Once every chunk has been read at least once, the cache file basically a complete extracted blob. An optional state file can be used to remember the state of the cache file (which chunks have been extracted into it). 