### PR TITLE
Encryption for chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Among the distinguishing factors:
 - Built-in HTTP(S) index server to read/write indexes
 - Reflinking matching blocks (rather than copying) from seed files if supported by the filesystem (currently only Btrfs and XFS)
 - catar archives can be created from standard tar archives, and they can also be extracted to GNU tar format.
-- Optional chunk store encryption with AES-265-CTR.
+- Optional chunk store encryption with XChaCha20-Poly1305, AES-265-GCM and AES-265-CTR.
 
 ## Terminology
 
@@ -239,11 +239,11 @@ Compressed and uncompressed chunks can live in the same store and don't interfer
 Chunks can be encrypted with a symmetric algorithm on a per-store basis. To use encryption, it has to be enabled in the [configuration](Configuration) file, and an algorithm needs to be specified. A single instance of desync can use multiple stores at the same time, each with a different (or the same) encryption mode and key. Encrypted chunks are stores with file extensions containing the algorithm and a key identifier. If the password for a store is changed, all existing chunks in it will become "invisible" since the extension would no longer match. To change the key, chunks have to be re-encrypted with the new key. That could happen into same, or better, a new store. Create a new store, then either re-chunk the data, or use `desync cache -c <new-store> -s <old-store> <index>` to decrypt the chunks from the old store and re-encrypt with the new key in the new store.
 For all available algorithms, the 256bit encryption key is derived from the configured password by hashing it with SHA256. Encryption nonces or IVs are generated randomly per chunk which can weaken encryption in some modes when used on very large chunk stores, see notes below.
 
-| ID | Algorithm | Notes |
-|:---:|:---:|:---:|
-| `xchacha20-poly1305` | XChaCha20-Poly1305 (AEAD) | Default |
-| `aes-256-gcm` | AES 256bit Galois Counter Mode (AEAD) | Don't use for large chunk stores (>2<sup>32</sup> chunks) |
-| `aes-256-ctr` | AES 256bit Counter Mode | Don't use for large chunk stores (>2<sup>32</sup> chunks) |
+| ID | Algorithm | Key | Nonce/IV | Notes |
+|:---:|:---:|:---:|:---:|:---:|
+| `xchacha20-poly1305` | XChaCha20-Poly1305 (AEAD) | 256bit | 192bit | Default |
+| `aes-256-gcm` | AES 256bit Galois Counter Mode (AEAD) | 256bit | 128bit | Don't use for large chunk stores (>2<sup>32</sup> chunks) |
+| `aes-256-ctr` | AES 256bit Counter Mode | 256bit | 128bit | Don't use for large chunk stores (>2<sup>32</sup> chunks) |
 
 Chunk extensions in stores are chosen based on compression or encryption settings as follows:
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Among the distinguishing factors:
 - Built-in HTTP(S) index server to read/write indexes
 - Reflinking matching blocks (rather than copying) from seed files if supported by the filesystem (currently only Btrfs and XFS)
 - catar archives can be created from standard tar archives, and they can also be extracted to GNU tar format.
-- Optional chunk store encryption with XChaCha20-Poly1305, AES-265-GCM and AES-265-CTR.
+- Optional chunk store encryption with XChaCha20-Poly1305, AES-265-GCM or AES-265-CTR.
 
 ## Terminology
 
@@ -70,7 +70,7 @@ catar archives can also be extracted to GNU tar archive streams. All files in th
 
 ## Tool
 
-The tool is provided for convenience. It uses the desync library and makes most features of it available in a consistent fashion. It does not match upsteam casync's syntax exactly, but tries to be similar at least.
+The tool is provided for convenience. It uses the desync library and makes most features of it available in a consistent fashion. It does not match upstream casync's syntax exactly, but tries to be similar at least.
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -242,10 +242,10 @@ Chunk extensions are chosen based on compression or encryption settings as follo
 
 | Compressed | Encrypted | Extension | Example |
 |:---:|:---:|:---:|:---:|
-| no | no | n/a | `fbef/fbef1a00ceda67e2abc49f707fd70e315fab60eacd19c257e23897339280ce78` |
-| yes | no | `.cacnk` | `ffbef/fbef1a00ceda67e2abc49f707fd70e315fab60eacd19c257e23897339280ce78.cacnk` |
-| no | yes | `.<algorithm>-<keyID>` | `fbef/fbef1a00ceda67e2abc49f707fd70e315fab60eacd19c257e23897339280ce78.aes-256-ctr-635af003` |
-| yes | yes | `.cacnk.<algorithm>-<keyID>` | `fbef/fbef1a00ceda67e2abc49f707fd70e315fab60eacd19c257e23897339280ce78.cacnk.aes-256-ctr-635af003` |
+| no | no | n/a | `fbef/fbef1a00ced..9280ce78` |
+| yes | no | `.cacnk` | `ffbef/fbef1a00ced..9280ce78.cacnk` |
+| no | yes | `.<algorithm>-<keyID>` | `fbef/fbef1a00ced..9280ce78.aes-256-ctr-635af003` |
+| yes | yes | `.cacnk.<algorithm>-<keyID>` | `fbef/fbef1a00ced..9280ce78.cacnk.aes-256-ctr-635af003` |
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Among the distinguishing factors:
 - Built-in HTTP(S) index server to read/write indexes
 - Reflinking matching blocks (rather than copying) from seed files if supported by the filesystem (currently only Btrfs and XFS)
 - catar archives can be created from standard tar archives, and they can also be extracted to GNU tar format.
+- Optional chunk store encryption with AES-265-CTR.
 
 ## Terminology
 
@@ -233,6 +234,10 @@ If the client configures the HTTP chunk server to be uncompressed (`chunk-server
 
 Compressed and uncompressed chunks can live in the same store and don't interfere with each other. A store that's configured for compressed chunks by configuring it client-side will not see the uncompressed chunks that may be present. `prune` and `verify` too will ignore any chunks written in the other format. Both kinds of chunks can be accessed by multiple clients concurrently and independently.
 
+### Chunk Encryption
+
+Chunks can be encrypted with a symmetric algorithm on a per-store basis. To use encryption, it has to be enabled in the [configuration](Configuration) file, and an algorithm needs to be specified. A single instance of desync can use multiple stores at the same time, each with a different (or the same) encryption mode and key. Encryption passwords can not be changed for a store as that would invalidate the existing chunks in the store. To change the key, create a new store, then either re-chunk the data, or use `desync cache -c <new-store> -s <old-store> <index>` to decrypt the chunks from the old store and re-encrypt with the new key in the new store.
+
 ### Configuration
 
 For most use cases, it is sufficient to use the tool's default configuration not requiring a config file. Having a config file `$HOME/.config/desync/config.json` allows for further customization of timeouts, error retry behaviour or credentials that can't be set via command-line options or environment variables. All values have sensible defaults if unconfigured. Only add configuration for values that differ from the defaults. To view the current configuration, use `desync config`. If no config file is present, this will show the defaults. To create a config file allowing custom values, use `desync config -w` which will write the current configuration to the file, then edit the file.
@@ -242,17 +247,20 @@ Available configuration values:
 - `http-timeout` *DEPRECATED, see `store-options.<Location>.timeout`* - HTTP request timeout used in HTTP stores (not S3) in nanoseconds
 - `http-error-retry` *DEPRECATED, see `store-options.<Location>.error-retry` - Number of times to retry failed chunk requests from HTTP stores
 - `s3-credentials` - Defines credentials for use with S3 stores. Especially useful if more than one S3 store is used. The key in the config needs to be the URL scheme and host used for the store, excluding the path, but including the port number if used in the store URL. It is also possible to use a [standard aws credentials file](https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html) in order to store s3 credentials.
-- `store-options` - Allows customization of chunk and index stores, for example comression settings, timeouts, retry behavior and keys. Not all options are applicable to every store, some of these like `timeout` are ignored for local stores. Some of these options, such as the client certificates are overwritten with any values set in the command line. Note that the store location used in the command line needs to match the key under `store-options` exactly for these options to be used. Watch out for trailing `/` in URLs.
+- `store-options` - Allows customization of chunk and index stores, for example compression settings, timeouts, retry behavior and keys. Not all options are applicable to every store, some of these like `timeout` are ignored for local stores. Some of these options, such as the client certificates are overwritten with any values set in the command line. Note that the store location used in the command line needs to match the key under `store-options` exactly for these options to be used. Watch out for trailing `/` in URLs.
   - `timeout` - Time limit for chunk read or write operation in nanoseconds. Default: 1 minute. If set to a negative value, timeout is infinite.
   - `error-retry` - Number of times to retry failed chunk requests. Default: 0.
   - `error-retry-base-interval` - Number of nanoseconds to wait before first retry attempt. Retry attempt number N for the same request will wait N times this interval. Default: 0.
-  - `client-cert` - Cerificate file to be used for stores where the server requires mutual SSL.
+  - `client-cert` - Certificate file to be used for stores where the server requires mutual SSL.
   - `client-key` - Key file to be used for stores where the server requires mutual SSL.
   - `ca-cert` - Certificate file containing trusted certs or CAs.
   - `trust-insecure` - Trust any certificate presented by the server.
   - `skip-verify` - Disables data integrity verification when reading chunks to improve performance. Only recommended when chaining chunk stores with the `chunk-server` command using compressed stores.
   - `uncompressed` - Reads and writes uncompressed chunks from/to this store. This can improve performance, especially for local stores or caches. Compressed and uncompressed chunks can coexist in the same store, but only one kind is read or written by one client.
   - `http-auth` - Value of the Authorization header in HTTP requests. This could be a bearer token with `"Bearer <token>"` or a Base64-encoded username and password pair for basic authentication like `"Basic dXNlcjpwYXNzd29yZAo="`.
+  - `encryption` - Must be set to `true` to encrypt chunks in the store.
+  - `encryption-password` - Encryption password to use for all chunks in the store.
+  - `encryption-algorithm` - Optional, symmetric encryption algorithm. Default `aes-256-ctr`.
 
 #### Example config
 
@@ -287,6 +295,11 @@ Available configuration values:
     },
     "/path/to/local/cache": {
       "uncompressed": true
+    },
+    "/path/to/encrypted/store": {
+      "encryption": true,
+      "encryption-algorithm": "aes-256-ctr",
+      "encryption-password": "mystorepassword"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Among the distinguishing factors:
 - Built-in HTTP(S) index server to read/write indexes
 - Reflinking matching blocks (rather than copying) from seed files if supported by the filesystem (currently only Btrfs and XFS)
 - catar archives can be created from standard tar archives, and they can also be extracted to GNU tar format.
-- Optional chunk store encryption with XChaCha20-Poly1305, AES-265-GCM or AES-265-CTR.
+- Optional chunk store encryption with XChaCha20-Poly1305 or AES-265-GCM.
 
 ## Terminology
 
@@ -243,7 +243,6 @@ For all available algorithms, the 256bit encryption key is derived from the conf
 |:---:|:---:|:---:|:---:|:---:|
 | `xchacha20-poly1305` | XChaCha20-Poly1305 (AEAD) | 256bit | 192bit | Default |
 | `aes-256-gcm` | AES 256bit Galois Counter Mode (AEAD) | 256bit | 128bit | Don't use for large chunk stores (>2<sup>32</sup> chunks) |
-| `aes-256-ctr` | AES 256bit Counter Mode | 256bit | 128bit | Don't use for large chunk stores (>2<sup>32</sup> chunks) |
 
 Chunk extensions in stores are chosen based on compression or encryption settings as follows:
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,16 @@ Compressed and uncompressed chunks can live in the same store and don't interfer
 
 ### Chunk Encryption
 
-Chunks can be encrypted with a symmetric algorithm on a per-store basis. To use encryption, it has to be enabled in the [configuration](Configuration) file, and an algorithm needs to be specified. A single instance of desync can use multiple stores at the same time, each with a different (or the same) encryption mode and key. Encryption passwords can not be changed for a store as that would invalidate the existing chunks in the store. To change the key, create a new store, then either re-chunk the data, or use `desync cache -c <new-store> -s <old-store> <index>` to decrypt the chunks from the old store and re-encrypt with the new key in the new store.
+Chunks can be encrypted with a symmetric algorithm on a per-store basis. To use encryption, it has to be enabled in the [configuration](Configuration) file, and an algorithm needs to be specified. A single instance of desync can use multiple stores at the same time, each with a different (or the same) encryption mode and key. Encrypted chunks are stores with file extensions containing the algorithm and a key identifier. If the password for a store is changed, all existing chunks in it will become "invisible" since the extension would no longer match. To change the key, chunks have to be re-encrypted with the new key. That could happen into same, or better, a new store. Create a new store, then either re-chunk the data, or use `desync cache -c <new-store> -s <old-store> <index>` to decrypt the chunks from the old store and re-encrypt with the new key in the new store.
+
+Chunk extensions are chosen based on compression or encryption settings as follows:
+
+| Compressed | Encrypted | Extension | Example |
+|:---:|:---:|:---:|:---:|
+| no | no | n/a | `fbef/fbef1a00ceda67e2abc49f707fd70e315fab60eacd19c257e23897339280ce78` |
+| yes | no | `.cacnk` | `ffbef/fbef1a00ceda67e2abc49f707fd70e315fab60eacd19c257e23897339280ce78.cacnk` |
+| no | yes | `.<algorithm>-<keyID>` | `fbef/fbef1a00ceda67e2abc49f707fd70e315fab60eacd19c257e23897339280ce78.aes-256-ctr-635af003` |
+| yes | yes | `.cacnk.<algorithm>-<keyID>` | `fbef/fbef1a00ceda67e2abc49f707fd70e315fab60eacd19c257e23897339280ce78.cacnk.aes-256-ctr-635af003` |
 
 ### Configuration
 

--- a/compress.go
+++ b/compress.go
@@ -21,3 +21,22 @@ func Compress(src []byte) ([]byte, error) {
 func Decompress(dst, src []byte) ([]byte, error) {
 	return decoder.DecodeAll(src, dst)
 }
+
+// Compression layer converter. Compresses/decompresses chunk data
+// to and from storage. Implements the converter interface.
+type Compressor struct{}
+
+var _ converter = Compressor{}
+
+func (d Compressor) toStorage(in []byte) ([]byte, error) {
+	return Compress(in)
+}
+
+func (d Compressor) fromStorage(in []byte) ([]byte, error) {
+	return Decompress(nil, in)
+}
+
+func (d Compressor) equal(c converter) bool {
+	_, ok := c.(Compressor)
+	return ok
+}

--- a/compress.go
+++ b/compress.go
@@ -40,3 +40,7 @@ func (d Compressor) equal(c converter) bool {
 	_, ok := c.(Compressor)
 	return ok
 }
+
+func (d Compressor) storageExtension() string {
+	return ".cacnk"
+}

--- a/const.go
+++ b/const.go
@@ -137,9 +137,3 @@ var (
 		CaFormatTableTailMarker:   "CaFormatTableTailMarker",
 	}
 )
-
-// CompressedChunkExt is the file extension used for compressed chunks
-const CompressedChunkExt = ".cacnk"
-
-// UncompressedChunkExt is the file extension of uncompressed chunks
-const UncompressedChunkExt = ""

--- a/converter.go
+++ b/converter.go
@@ -1,5 +1,7 @@
 package desync
 
+import "strings"
+
 // Converters are modifiers for chunk data, such as compression or encryption.
 // They are used to prepare chunk data for storage, or to read it from storage.
 // The order of the conversion layers matters. When plain data is prepared for
@@ -63,6 +65,16 @@ func (s Converters) equal(c Converters) bool {
 	return true
 }
 
+// Extension to be used in storage. Concatenation of converter
+// extensions in order (towards storage).
+func (s Converters) storageExtension() string {
+	var ext strings.Builder
+	for _, layer := range s {
+		ext.WriteString(layer.storageExtension())
+	}
+	return ext.String()
+}
+
 // converter is a storage data modifier layer.
 type converter interface {
 	// Convert data from it's original form to storage format.
@@ -75,5 +87,10 @@ type converter interface {
 	// the output may be used for the next conversion layer.
 	fromStorage([]byte) ([]byte, error)
 
+	// Returns the file extension that should be used for a
+	// chunk when stored. Usually a concatenation of layers.
+	storageExtension() string
+
+	// True is one converter matches another exactly.
 	equal(converter) bool
 }

--- a/converter.go
+++ b/converter.go
@@ -77,21 +77,3 @@ type converter interface {
 
 	equal(converter) bool
 }
-
-// Compression layer
-type Compressor struct{}
-
-var _ converter = Compressor{}
-
-func (d Compressor) toStorage(in []byte) ([]byte, error) {
-	return Compress(in)
-}
-
-func (d Compressor) fromStorage(in []byte) ([]byte, error) {
-	return Decompress(nil, in)
-}
-
-func (d Compressor) equal(c converter) bool {
-	_, ok := c.(Compressor)
-	return ok
-}

--- a/encrypt.go
+++ b/encrypt.go
@@ -8,69 +8,9 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"io"
 
 	"golang.org/x/crypto/chacha20poly1305"
 )
-
-// aes256ctr is an encryption layer for chunk storage. It
-// encrypts/decrypts to/from storage using aes-256-ctr.
-// The key is generated from a passphrase with SHA256.
-type aes256ctr struct {
-	key   []byte
-	block cipher.Block
-
-	// Chunk extension with identifier derived from the key.
-	extension string
-}
-
-var _ converter = aes256ctr{}
-
-func NewAES256CTR(passphrase string) (aes256ctr, error) {
-	key := sha256.Sum256([]byte(passphrase))
-	keyHash := sha256.Sum256(key[:])
-	extension := fmt.Sprintf(".aes-256-ctr-%x", keyHash[:4])
-	block, err := aes.NewCipher(key[:])
-	return aes256ctr{key: key[:], block: block, extension: extension}, err
-}
-
-// encrypt for storage. The IV is prepended to the data.
-func (d aes256ctr) toStorage(in []byte) ([]byte, error) {
-	out := make([]byte, aes.BlockSize+len(in))
-	iv := out[:aes.BlockSize]
-	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
-		return nil, err
-	}
-	stream := cipher.NewCTR(d.block, iv)
-	stream.XORKeyStream(out[aes.BlockSize:], in)
-	return out, nil
-}
-
-// decrypt from storage. The IV is taken from the start of the
-// chunk data. This by itself does not verify integrity. That
-// is achieved by the existing chunk validation.
-func (d aes256ctr) fromStorage(in []byte) ([]byte, error) {
-	if len(in) < aes.BlockSize {
-		return nil, errors.New("no iv prefix found in chunk, not encrypted or wrong algorithm")
-	}
-	out := make([]byte, len(in)-aes.BlockSize)
-	iv := in[:aes.BlockSize]
-	stream := cipher.NewCTR(d.block, iv)
-	stream.XORKeyStream(out, in[aes.BlockSize:])
-	return out, nil
-}
-
-func (d aes256ctr) equal(c converter) bool {
-	other, ok := c.(aes256ctr)
-	if !ok {
-		return false
-	}
-	return bytes.Equal(d.key, other.key)
-}
-
-func (d aes256ctr) storageExtension() string {
-	return d.extension
-}
 
 // xchacha20poly1305 is an encryption layer for chunk storage. It
 // encrypts/decrypts to/from storage using ChaCha20-Poly1305 AEAD.
@@ -83,7 +23,7 @@ type xchacha20poly1305 struct {
 	extension string
 }
 
-var _ converter = aes256ctr{}
+var _ converter = xchacha20poly1305{}
 
 func NewXChaCha20Poly1305(passphrase string) (xchacha20poly1305, error) {
 	key := sha256.Sum256([]byte(passphrase))
@@ -137,7 +77,7 @@ type aes256gcm struct {
 	extension string
 }
 
-var _ converter = aes256ctr{}
+var _ converter = aes256gcm{}
 
 func NewAES256GCM(passphrase string) (aes256gcm, error) {
 	key := sha256.Sum256([]byte(passphrase))

--- a/encrypt.go
+++ b/encrypt.go
@@ -9,6 +9,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+
+	"golang.org/x/crypto/chacha20poly1305"
 )
 
 // aes256ctr is an encryption layer for chunk storage. It
@@ -67,5 +69,117 @@ func (d aes256ctr) equal(c converter) bool {
 }
 
 func (d aes256ctr) storageExtension() string {
+	return d.extension
+}
+
+// xchacha20poly1305 is an encryption layer for chunk storage. It
+// encrypts/decrypts to/from storage using ChaCha20-Poly1305 AEAD.
+// The key is generated from a passphrase with SHA256.
+type xchacha20poly1305 struct {
+	key  []byte
+	aead cipher.AEAD
+
+	// Chunk extension with identifier derived from the key.
+	extension string
+}
+
+var _ converter = aes256ctr{}
+
+func NewXChaCha20Poly1305(passphrase string) (xchacha20poly1305, error) {
+	key := sha256.Sum256([]byte(passphrase))
+	keyHash := sha256.Sum256(key[:])
+	extension := fmt.Sprintf(".xchacha20-poly1305-%x", keyHash[:4])
+	aead, err := chacha20poly1305.NewX(key[:])
+	return xchacha20poly1305{key: key[:], aead: aead, extension: extension}, err
+}
+
+// encrypt for storage. The nonce is prepended to the data.
+func (d xchacha20poly1305) toStorage(in []byte) ([]byte, error) {
+	out := make([]byte, d.aead.NonceSize(), d.aead.NonceSize()+len(in)+d.aead.Overhead())
+	nonce := out[:d.aead.NonceSize()]
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, err
+	}
+	return d.aead.Seal(out, nonce, in, nil), nil
+}
+
+// decrypt from storage. The nonce is taken from the start of the
+// chunk data. This by itself does not verify integrity. That
+// is achieved by the existing chunk validation.
+func (d xchacha20poly1305) fromStorage(in []byte) ([]byte, error) {
+	if len(in) < d.aead.NonceSize() {
+		return nil, errors.New("no nonce prefix found in chunk, not encrypted or wrong algorithm")
+	}
+	nonce := in[:d.aead.NonceSize()]
+	return d.aead.Open(nil, nonce, in[d.aead.NonceSize():], nil)
+}
+
+func (d xchacha20poly1305) equal(c converter) bool {
+	other, ok := c.(xchacha20poly1305)
+	if !ok {
+		return false
+	}
+	return bytes.Equal(d.key, other.key)
+}
+
+func (d xchacha20poly1305) storageExtension() string {
+	return d.extension
+}
+
+// aes256gcm is an encryption layer for chunk storage. It
+// encrypts/decrypts to/from storage using AES 256 GCM.
+// The key is generated from a passphrase with SHA256.
+type aes256gcm struct {
+	key  []byte
+	aead cipher.AEAD
+
+	// Chunk extension with identifier derived from the key.
+	extension string
+}
+
+var _ converter = aes256ctr{}
+
+func NewAES256GCM(passphrase string) (aes256gcm, error) {
+	key := sha256.Sum256([]byte(passphrase))
+	keyHash := sha256.Sum256(key[:])
+	extension := fmt.Sprintf(".aes-256-gcm-%x", keyHash[:4])
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return aes256gcm{}, err
+	}
+	aead, err := cipher.NewGCM(block)
+	return aes256gcm{key: key[:], aead: aead, extension: extension}, err
+}
+
+// encrypt for storage. The nonce is prepended to the data.
+func (d aes256gcm) toStorage(in []byte) ([]byte, error) {
+	out := make([]byte, d.aead.NonceSize(), d.aead.NonceSize()+len(in)+d.aead.Overhead())
+	nonce := out[:d.aead.NonceSize()]
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, err
+	}
+	return d.aead.Seal(out, nonce, in, nil), nil
+}
+
+// decrypt from storage. The nonce is taken from the start of the
+// chunk data. This by itself does not verify integrity. That
+// is achieved by the existing chunk validation.
+func (d aes256gcm) fromStorage(in []byte) ([]byte, error) {
+	if len(in) < d.aead.NonceSize() {
+		return nil, errors.New("no nonce prefix found in chunk, not encrypted or wrong algorithm")
+	}
+	nonce := in[:d.aead.NonceSize()]
+	return d.aead.Open(nil, nonce, in[d.aead.NonceSize():], nil)
+}
+
+func (d aes256gcm) equal(c converter) bool {
+	other, ok := c.(aes256gcm)
+	if !ok {
+		return false
+	}
+	return bytes.Equal(d.key, other.key)
+}
+
+func (d aes256gcm) storageExtension() string {
 	return d.extension
 }

--- a/encrypt.go
+++ b/encrypt.go
@@ -39,7 +39,8 @@ func (d aes256ctr) toStorage(in []byte) ([]byte, error) {
 }
 
 // decrypt from storage. The IV is taken from the start of the
-// chunk data.
+// chunk data. This by itself does not verify integrity. That
+// is achieved by the existing chunk validation.
 func (d aes256ctr) fromStorage(in []byte) ([]byte, error) {
 	if len(in) < aes.BlockSize {
 		return nil, errors.New("no iv prefix found in chunk, not encrypted or wrong algorithm")

--- a/encrypt.go
+++ b/encrypt.go
@@ -1,0 +1,60 @@
+package desync
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"errors"
+	"io"
+)
+
+// aes256ctr is an encryption layer for chunk storage. It
+// encrypts/decrypts to/from storage using aes-256-ctr.
+// The key is generated from a passphrase with SHA256.
+type aes256ctr struct {
+	key   []byte
+	block cipher.Block
+}
+
+var _ converter = aes256ctr{}
+
+func NewAES256CTR(passphrase string) (aes256ctr, error) {
+	key := sha256.Sum256([]byte(passphrase))
+	block, err := aes.NewCipher(key[:])
+	return aes256ctr{key: key[:], block: block}, err
+}
+
+// encrypt for storage. The IV is prepended to the data.
+func (d aes256ctr) toStorage(in []byte) ([]byte, error) {
+	out := make([]byte, aes.BlockSize+len(in))
+	iv := out[:aes.BlockSize]
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		return nil, err
+	}
+	stream := cipher.NewCTR(d.block, iv)
+	stream.XORKeyStream(out[aes.BlockSize:], in)
+	return out, nil
+}
+
+// decrypt from storage. The IV is taken from the start of the
+// chunk data.
+func (d aes256ctr) fromStorage(in []byte) ([]byte, error) {
+	if len(in) < aes.BlockSize {
+		return nil, errors.New("no iv prefix found in chunk, not encrypted or wrong algorithm")
+	}
+	out := make([]byte, len(in)-aes.BlockSize)
+	iv := in[:aes.BlockSize]
+	stream := cipher.NewCTR(d.block, iv)
+	stream.XORKeyStream(out, in[aes.BlockSize:])
+	return out, nil
+}
+
+func (d aes256ctr) equal(c converter) bool {
+	other, ok := c.(aes256ctr)
+	if !ok {
+		return false
+	}
+	return bytes.Equal(d.key, other.key)
+}

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -1,0 +1,57 @@
+package desync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAES256CTREncryptDecrypt(t *testing.T) {
+	plainIn := []byte{1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
+
+	// Make two converters. One for encryption and one for decryption. Could use
+	// just one but this way we confirm the key generation is consistent
+	enc, err := NewAES256CTR("secret-password")
+	require.NoError(t, err)
+	dec, err := NewAES256CTR("secret-password")
+	require.NoError(t, err)
+
+	// Encrypt the data
+	ciphertext, err := enc.toStorage(plainIn)
+	require.NoError(t, err)
+
+	// Confirm the ciphertext is actually different than what went in
+	require.NotEqual(t, plainIn, ciphertext)
+
+	// Decrypt it
+	plainOut, err := dec.fromStorage(ciphertext)
+	require.NoError(t, err)
+
+	// This should match the original data of course
+	require.Equal(t, plainIn, plainOut)
+
+	// Make another instance with a different password
+	diffPw, err := NewAES256CTR("something-else")
+	require.NoError(t, err)
+
+	// Try to decrypt the data, should end up with garbage
+	diffOut, err := diffPw.fromStorage(ciphertext)
+	require.NoError(t, err)
+	require.NotEqual(t, plainIn, diffOut)
+}
+
+func TestAES256CTRCompare(t *testing.T) {
+	// Make three converters. Two with the same, one with a diff password
+	enc1, err := NewAES256CTR("secret-password")
+	require.NoError(t, err)
+	enc2, err := NewAES256CTR("secret-password")
+	require.NoError(t, err)
+	diffPw, err := NewAES256CTR("something-else")
+	require.NoError(t, err)
+
+	// Check equality method
+	require.True(t, enc1.equal(enc2))
+	require.True(t, enc2.equal(enc1))
+	require.False(t, diffPw.equal(enc1))
+	require.False(t, enc1.equal(diffPw))
+}

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -55,3 +55,17 @@ func TestAES256CTRCompare(t *testing.T) {
 	require.False(t, diffPw.equal(enc1))
 	require.False(t, enc1.equal(diffPw))
 }
+
+func TestAES256CTRExtension(t *testing.T) {
+	enc1, err := NewAES256CTR("secret-password")
+	require.NoError(t, err)
+
+	// Confirm that we have a key-handle in the file extension
+	require.Equal(t, ".aes-256-ctr-16db3403", enc1.extension)
+
+	// If algorithm and password are the same, the same key
+	// handle (extension) should be produced every time
+	enc2, err := NewAES256CTR("secret-password")
+	require.NoError(t, err)
+	require.Equal(t, enc1.extension, enc2.extension)
+}

--- a/gcs.go
+++ b/gcs.go
@@ -54,7 +54,7 @@ func normalizeGCPrefix(path string) string {
 // backed by Google Storage.
 func NewGCStoreBase(u *url.URL, opt StoreOptions) (GCStoreBase, error) {
 	ctx := context.TODO()
-	converters, err := opt.converters()
+	converters, err := opt.StorageConverters()
 	if err != nil {
 		return GCStoreBase{}, err
 	}

--- a/gcs.go
+++ b/gcs.go
@@ -80,7 +80,7 @@ func (s GCStoreBase) String() string {
 	return s.Location
 }
 
-// Close the GCS base store. NOP opertation but needed to implement the store interface.
+// Close the GCS base store. NOP operation but needed to implement the store interface.
 func (s GCStoreBase) Close() error { return nil }
 
 // NewGCStore creates a chunk store with Google Storage backing. The URL
@@ -258,28 +258,16 @@ func (s GCStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 
 func (s GCStore) nameFromID(id ChunkID) string {
 	sID := id.String()
-	name := s.prefix + sID[0:4] + "/" + sID
-	if s.opt.Uncompressed {
-		name += UncompressedChunkExt
-	} else {
-		name += CompressedChunkExt
-	}
+	name := s.prefix + sID[0:4] + "/" + sID + s.converters.storageExtension()
 	return name
 }
 
 func (s GCStore) idFromName(name string) (ChunkID, error) {
-	var n string
-	if s.opt.Uncompressed {
-		if !strings.HasSuffix(name, UncompressedChunkExt) {
-			return ChunkID{}, fmt.Errorf("object %s is not a chunk", name)
-		}
-		n = strings.TrimSuffix(strings.TrimPrefix(name, s.prefix), UncompressedChunkExt)
-	} else {
-		if !strings.HasSuffix(name, CompressedChunkExt) {
-			return ChunkID{}, fmt.Errorf("object %s is not a chunk", name)
-		}
-		n = strings.TrimSuffix(strings.TrimPrefix(name, s.prefix), CompressedChunkExt)
+	extension := s.converters.storageExtension()
+	if !strings.HasSuffix(name, extension) {
+		return ChunkID{}, fmt.Errorf("object %s is not a chunk", name)
 	}
+	n := strings.TrimSuffix(strings.TrimPrefix(name, s.prefix), extension)
 	fragments := strings.Split(n, "/")
 	if len(fragments) != 2 {
 		return ChunkID{}, fmt.Errorf("incorrect chunk name for object %s", name)

--- a/gcs.go
+++ b/gcs.go
@@ -53,9 +53,12 @@ func normalizeGCPrefix(path string) string {
 // NewGCStoreBase initializes a base object used for chunk or index stores
 // backed by Google Storage.
 func NewGCStoreBase(u *url.URL, opt StoreOptions) (GCStoreBase, error) {
-	var err error
 	ctx := context.TODO()
-	s := GCStoreBase{Location: u.String(), opt: opt, converters: opt.converters()}
+	converters, err := opt.converters()
+	if err != nil {
+		return GCStoreBase{}, err
+	}
+	s := GCStoreBase{Location: u.String(), opt: opt, converters: converters}
 	if u.Scheme != "gs" {
 		return s, fmt.Errorf("invalid scheme '%s', expected 'gs'", u.Scheme)
 	}

--- a/httphandler.go
+++ b/httphandler.go
@@ -124,12 +124,9 @@ func (h HTTPHandler) put(id ChunkID, w http.ResponseWriter, r *http.Request) {
 }
 
 func (h HTTPHandler) idFromPath(p string) (ChunkID, error) {
-	ext := CompressedChunkExt
-	if !h.compressed {
-		if strings.HasSuffix(p, CompressedChunkExt) {
-			return ChunkID{}, errors.New("compressed chunk requested from http chunk store serving uncompressed chunks")
-		}
-		ext = UncompressedChunkExt
+	ext := h.converters.storageExtension()
+	if !strings.HasSuffix(p, ext) {
+		return ChunkID{}, errors.New("invalid chunk type, verify compression and encryption settings")
 	}
 	sID := strings.TrimSuffix(path.Base(p), ext)
 	if len(sID) < 4 {

--- a/httphandler_test.go
+++ b/httphandler_test.go
@@ -111,7 +111,7 @@ func TestHTTPHandlerEncryption(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start a read-write capable server with Encryption, no Compression
-	enc, err := NewAES256CTR("testpassword")
+	enc, err := NewXChaCha20Poly1305("testpassword")
 	require.NoError(t, err)
 	server := httptest.NewServer(NewHTTPHandler(upstream, true, false, []converter{enc}, ""))
 	defer server.Close()

--- a/local.go
+++ b/local.go
@@ -42,7 +42,11 @@ func NewLocalStore(dir string, opt StoreOptions) (LocalStore, error) {
 	if !info.IsDir() {
 		return LocalStore{}, fmt.Errorf("%s is not a directory", dir)
 	}
-	return LocalStore{Base: dir, opt: opt, converters: opt.converters()}, nil
+	converters, err := opt.converters()
+	if err != nil {
+		return LocalStore{}, err
+	}
+	return LocalStore{Base: dir, opt: opt, converters: converters}, nil
 }
 
 // GetChunk reads and returns one (compressed!) chunk from the store

--- a/local.go
+++ b/local.go
@@ -131,6 +131,7 @@ func (s LocalStore) Verify(ctx context.Context, n int, repair bool, w io.Writer)
 
 	// Go trough all chunks underneath Base, filtering out other files, then feed
 	// the IDs to the workers
+	extension := s.converters.storageExtension()
 	err := filepath.Walk(s.Base, func(path string, info os.FileInfo, err error) error {
 		// See if we're meant to stop
 		select {
@@ -145,18 +146,10 @@ func (s LocalStore) Verify(ctx context.Context, n int, repair bool, w io.Writer)
 			return nil
 		}
 		// Skip compressed chunks if this is running in uncompressed mode and vice-versa
-		var sID string
-		if s.opt.Uncompressed {
-			if !strings.HasSuffix(path, UncompressedChunkExt) {
-				return nil
-			}
-			sID = strings.TrimSuffix(filepath.Base(path), UncompressedChunkExt)
-		} else {
-			if !strings.HasSuffix(path, CompressedChunkExt) {
-				return nil
-			}
-			sID = strings.TrimSuffix(filepath.Base(path), CompressedChunkExt)
+		if !strings.HasSuffix(filepath.Base(path), extension) {
+			return nil
 		}
+		sID := strings.TrimSuffix(filepath.Base(path), extension)
 		// Convert the name into a checksum, if that fails we're probably not looking
 		// at a chunk file and should skip it.
 		id, err := ChunkIDFromString(sID)
@@ -175,6 +168,7 @@ func (s LocalStore) Verify(ctx context.Context, n int, repair bool, w io.Writer)
 // Prune removes any chunks from the store that are not contained in a list
 // of chunks
 func (s LocalStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
+	extension := s.converters.storageExtension()
 	// Go trough all chunks underneath Base, filtering out other directories and files
 	err := filepath.Walk(s.Base, func(path string, info os.FileInfo, err error) error {
 		// See if we're meant to stop
@@ -195,20 +189,11 @@ func (s LocalStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 			_ = os.Remove(path)
 			return nil
 		}
-
 		// Skip compressed chunks if this is running in uncompressed mode and vice-versa
-		var sID string
-		if s.opt.Uncompressed {
-			if !strings.HasSuffix(path, UncompressedChunkExt) {
-				return nil
-			}
-			sID = strings.TrimSuffix(filepath.Base(path), UncompressedChunkExt)
-		} else {
-			if !strings.HasSuffix(path, CompressedChunkExt) {
-				return nil
-			}
-			sID = strings.TrimSuffix(filepath.Base(path), CompressedChunkExt)
+		if !strings.HasSuffix(filepath.Base(path), extension) {
+			return nil
 		}
+		sID := strings.TrimSuffix(filepath.Base(path), extension)
 		// Convert the name into a checksum, if that fails we're probably not looking
 		// at a chunk file and should skip it.
 		id, err := ChunkIDFromString(sID)
@@ -250,11 +235,6 @@ func (s LocalStore) Close() error { return nil }
 func (s LocalStore) nameFromID(id ChunkID) (dir, name string) {
 	sID := id.String()
 	dir = filepath.Join(s.Base, sID[0:4])
-	name = filepath.Join(dir, sID)
-	if s.opt.Uncompressed {
-		name += UncompressedChunkExt
-	} else {
-		name += CompressedChunkExt
-	}
+	name = filepath.Join(dir, sID) + s.converters.storageExtension()
 	return
 }

--- a/local.go
+++ b/local.go
@@ -42,7 +42,7 @@ func NewLocalStore(dir string, opt StoreOptions) (LocalStore, error) {
 	if !info.IsDir() {
 		return LocalStore{}, fmt.Errorf("%s is not a directory", dir)
 	}
-	converters, err := opt.converters()
+	converters, err := opt.StorageConverters()
 	if err != nil {
 		return LocalStore{}, err
 	}

--- a/local_test.go
+++ b/local_test.go
@@ -282,11 +282,12 @@ func TestLocalStorePasswordMismatch(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, dataIn, dataOut)
 
-	// Try to get the chunk with a bad password, expect a signature mismatch
+	// Try to get the chunk with a bad password, expect a not-found
+	// since the chunk extensions are different for diff keys.
 	_, err = s2.GetChunk(id)
 	require.Error(t, err)
 
-	if _, ok := err.(ChunkInvalid); !ok {
-		t.Fatalf("expected ChunkInvalid error, but got %T", err)
+	if _, ok := err.(ChunkMissing); !ok {
+		t.Fatalf("expected ChunkMissing error, but got %T", err)
 	}
 }

--- a/local_test.go
+++ b/local_test.go
@@ -235,7 +235,7 @@ func TestLocalStoreCompressedEncrypted(t *testing.T) {
 	require.NoError(t, err)
 
 	// First decrypt it, using the correct password
-	dec, _ := NewAES256CTR("test-password")
+	dec, _ := NewXChaCha20Poly1305("test-password")
 	decrypted, err := dec.fromStorage(b)
 	require.NoError(t, err)
 

--- a/local_test.go
+++ b/local_test.go
@@ -147,3 +147,146 @@ func TestLocalStoreErrorHandling(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestLocalStoreUncompressedEncrypted(t *testing.T) {
+	store := t.TempDir()
+
+	s, err := NewLocalStore(store,
+		StoreOptions{
+			Uncompressed:       true,
+			Encryption:         true,
+			EncryptionPassword: "test-password",
+		},
+	)
+	require.NoError(t, err)
+
+	// Make up some data and store it
+	dataIn := []byte("some data")
+
+	chunkIn := NewChunk(dataIn)
+	id := chunkIn.ID()
+
+	err = s.StoreChunk(chunkIn)
+	require.NoError(t, err)
+
+	// Check it's in the store
+	hasChunk, err := s.HasChunk(id)
+	require.NoError(t, err)
+	require.True(t, hasChunk, "chunk not found in store")
+
+	// Pull the data the "official" way
+	chunkOut, err := s.GetChunk(id)
+	require.NoError(t, err)
+
+	dataOut, err := chunkOut.Data()
+	require.NoError(t, err)
+
+	// Compare the data that went in with what came out
+	require.Equal(t, dataIn, dataOut)
+
+	// Now let's look at the file in the store directly to make sure it's actually
+	// encrypted, meaning it should not match the plain (uncompressed) text
+	_, name := s.nameFromID(id)
+	b, err := ioutil.ReadFile(name)
+	require.NoError(t, err)
+	require.NotEqual(t, dataIn, b, "chunk is not encrypted")
+}
+
+func TestLocalStoreCompressedEncrypted(t *testing.T) {
+	store := t.TempDir()
+
+	s, err := NewLocalStore(store,
+		StoreOptions{
+			Uncompressed:       false,
+			Encryption:         true,
+			EncryptionPassword: "test-password",
+		},
+	)
+	require.NoError(t, err)
+
+	// Make up some data and store it
+	dataIn := []byte("some data")
+
+	chunkIn := NewChunk(dataIn)
+	id := chunkIn.ID()
+
+	err = s.StoreChunk(chunkIn)
+	require.NoError(t, err)
+
+	// Check it's in the store
+	hasChunk, err := s.HasChunk(id)
+	require.NoError(t, err)
+	require.True(t, hasChunk, "chunk not found in store")
+
+	// Pull the data the "official" way
+	chunkOut, err := s.GetChunk(id)
+	require.NoError(t, err)
+
+	dataOut, err := chunkOut.Data()
+	require.NoError(t, err)
+
+	// Compare the data that went in with what came out
+	require.Equal(t, dataIn, dataOut)
+
+	// Now let's look at the file in the store directly and confirm it is
+	// compressed and encrypted (in that order!).
+	_, name := s.nameFromID(id)
+	b, err := ioutil.ReadFile(name)
+	require.NoError(t, err)
+
+	// First decrypt it, using the correct password
+	dec, _ := NewAES256CTR("test-password")
+	decrypted, err := dec.fromStorage(b)
+	require.NoError(t, err)
+
+	// Now decompress
+	decompressed, err := Decompress(nil, decrypted)
+	require.NoError(t, err)
+
+	// And it should match the original content
+	require.Equal(t, dataIn, decompressed)
+}
+
+func TestLocalStorePasswordMismatch(t *testing.T) {
+	store := t.TempDir()
+
+	// Build 2 stores accessing the same files but with different passwords
+	s1, err := NewLocalStore(store,
+		StoreOptions{
+			Encryption:         true,
+			EncryptionPassword: "good-password",
+		},
+	)
+	require.NoError(t, err)
+	s2, err := NewLocalStore(store,
+		StoreOptions{
+			Encryption:         true,
+			EncryptionPassword: "bad-password",
+		},
+	)
+	require.NoError(t, err)
+
+	// Make up some data and store it using the good password
+	dataIn := []byte("some data")
+
+	chunkIn := NewChunk(dataIn)
+	id := chunkIn.ID()
+
+	err = s1.StoreChunk(chunkIn)
+	require.NoError(t, err)
+
+	// Pull the data with the good password and compare it
+	chunkOut, err := s1.GetChunk(id)
+	require.NoError(t, err)
+	dataOut, err := chunkOut.Data()
+	require.NoError(t, err)
+	require.Equal(t, dataIn, dataOut)
+
+	// Try to get the chunk with a bad password, expect a signature mismatch
+	_, err = s2.GetChunk(id)
+	require.Error(t, err)
+
+	if _, ok := err.(ChunkInvalid); !ok {
+		t.Fatalf("expected ChunkInvalid error, but got %T", err)
+	}
+}

--- a/remotehttp.go
+++ b/remotehttp.go
@@ -157,11 +157,10 @@ func (r *RemoteHTTPBase) IssueRetryableHttpRequest(method string, u *url.URL, ge
 retry:
 	attempt++
 	statusCode, responseBody, err := r.IssueHttpRequest(method, u, getReader, attempt)
-
 	if (err != nil) || (statusCode >= 500 && statusCode < 600) {
 		if attempt >= r.opt.ErrorRetry {
 			log.WithField("attempt", attempt).Debug("failed, giving up")
-			return 0, nil, err
+			return statusCode, responseBody, err
 		} else {
 			log.WithField("attempt", attempt).WithField("delay", attempt).Debug("waiting, then retrying")
 			time.Sleep(time.Duration(attempt) * r.opt.ErrorRetryBaseInterval)

--- a/remotehttp.go
+++ b/remotehttp.go
@@ -256,11 +256,6 @@ func (r *RemoteHTTP) StoreChunk(chunk *Chunk) error {
 
 func (r *RemoteHTTP) nameFromID(id ChunkID) string {
 	sID := id.String()
-	name := path.Join(sID[0:4], sID)
-	if r.opt.Uncompressed {
-		name += UncompressedChunkExt
-	} else {
-		name += CompressedChunkExt
-	}
+	name := path.Join(sID[0:4], sID) + r.converters.storageExtension()
 	return name
 }

--- a/remotehttp.go
+++ b/remotehttp.go
@@ -89,7 +89,11 @@ func NewRemoteHTTPStoreBase(location *url.URL, opt StoreOptions) (*RemoteHTTPBas
 	}
 	client := &http.Client{Transport: tr, Timeout: timeout}
 
-	return &RemoteHTTPBase{location: location, client: client, opt: opt, converters: opt.converters()}, nil
+	converters, err := opt.converters()
+	if err != nil {
+		return nil, err
+	}
+	return &RemoteHTTPBase{location: location, client: client, opt: opt, converters: converters}, nil
 }
 
 func (r *RemoteHTTPBase) String() string {

--- a/remotehttp.go
+++ b/remotehttp.go
@@ -89,7 +89,7 @@ func NewRemoteHTTPStoreBase(location *url.URL, opt StoreOptions) (*RemoteHTTPBas
 	}
 	client := &http.Client{Transport: tr, Timeout: timeout}
 
-	converters, err := opt.converters()
+	converters, err := opt.StorageConverters()
 	if err != nil {
 		return nil, err
 	}

--- a/remotehttp_test.go
+++ b/remotehttp_test.go
@@ -331,7 +331,7 @@ func TestRemoteHTTPPutEncrypted(t *testing.T) {
 
 	// If everything worked, the request body should be the chunk data, first
 	// compressed, then encrypted. Unwind it manually to check the layers are in order.
-	dec, err := NewAES256CTR("testpassword")
+	dec, err := NewXChaCha20Poly1305("testpassword")
 	require.NoError(t, err)
 	decrypted, err := dec.fromStorage(body.Bytes())
 	require.NoError(t, err)

--- a/s3.go
+++ b/s3.go
@@ -32,8 +32,11 @@ type S3Store struct {
 
 // NewS3StoreBase initializes a base object used for chunk or index stores backed by S3.
 func NewS3StoreBase(u *url.URL, s3Creds *credentials.Credentials, region string, opt StoreOptions, lookupType minio.BucketLookupType) (S3StoreBase, error) {
-	var err error
-	s := S3StoreBase{Location: u.String(), opt: opt, converters: opt.converters()}
+	converters, err := opt.converters()
+	if err != nil {
+		return S3StoreBase{}, err
+	}
+	s := S3StoreBase{Location: u.String(), opt: opt, converters: converters}
 	if !strings.HasPrefix(u.Scheme, "s3+http") {
 		return s, fmt.Errorf("invalid scheme '%s', expected 's3+http' or 's3+https'", u.Scheme)
 	}

--- a/s3.go
+++ b/s3.go
@@ -32,7 +32,7 @@ type S3Store struct {
 
 // NewS3StoreBase initializes a base object used for chunk or index stores backed by S3.
 func NewS3StoreBase(u *url.URL, s3Creds *credentials.Credentials, region string, opt StoreOptions, lookupType minio.BucketLookupType) (S3StoreBase, error) {
-	converters, err := opt.converters()
+	converters, err := opt.StorageConverters()
 	if err != nil {
 		return S3StoreBase{}, err
 	}

--- a/sftp.go
+++ b/sftp.go
@@ -139,7 +139,7 @@ func (s *SFTPStoreBase) nameFromID(id ChunkID) string {
 
 // NewSFTPStore initializes a chunk store using SFTP over SSH.
 func NewSFTPStore(location *url.URL, opt StoreOptions) (*SFTPStore, error) {
-	converters, err := opt.converters()
+	converters, err := opt.StorageConverters()
 	if err != nil {
 		return nil, err
 	}

--- a/sftp.go
+++ b/sftp.go
@@ -143,7 +143,11 @@ func (s *SFTPStoreBase) nameFromID(id ChunkID) string {
 
 // NewSFTPStore initializes a chunk store using SFTP over SSH.
 func NewSFTPStore(location *url.URL, opt StoreOptions) (*SFTPStore, error) {
-	s := &SFTPStore{make(chan *SFTPStoreBase, opt.N), location, opt.N, opt.converters()}
+	converters, err := opt.converters()
+	if err != nil {
+		return nil, err
+	}
+	s := &SFTPStore{make(chan *SFTPStoreBase, opt.N), location, opt.N, converters}
 	for i := 0; i < opt.N; i++ {
 		c, err := newSFTPStoreBase(location, opt)
 		if err != nil {

--- a/sftpindex.go
+++ b/sftpindex.go
@@ -17,7 +17,7 @@ type SFTPIndexStore struct {
 
 // NewSFTPIndexStore initializes and index store backed by SFTP over SSH.
 func NewSFTPIndexStore(location *url.URL, opt StoreOptions) (*SFTPIndexStore, error) {
-	b, err := newSFTPStoreBase(location, opt)
+	b, err := newSFTPStoreBase(location, opt, "")
 	if err != nil {
 		return nil, err
 	}

--- a/store.go
+++ b/store.go
@@ -2,6 +2,7 @@ package desync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -86,17 +87,38 @@ type StoreOptions struct {
 
 	// Store and read chunks uncompressed, without chunk file extension
 	Uncompressed bool `json:"uncompressed"`
+
+	// Store encryption settings. The only algorithm currently supported is aes-256-ctr which
+	// is also the default.
+	Encryption          bool   `json:"encryption"`
+	EncryptionAlgorithm string `json:"encryption-algorithm"`
+	EncryptionPassword  string `json:"encryption-password"`
 }
 
 // Returns data converters that convert between plain and storage-format. Each layer
 // represents a modification such as compression or encryption and is applied in order
 // depending the direction of data. If data is written to storage, the layer's toStorage
-// method is called in the order they are returned. If data is read, the fromStorage
+// method is called in the order they are defined. If data is read, the fromStorage
 // method is called in reverse order.
-func (o StoreOptions) converters() []converter {
-	var m []converter
+func (o StoreOptions) converters() ([]converter, error) {
+	var c []converter
 	if !o.Uncompressed {
-		m = append(m, Compressor{})
+		c = append(c, Compressor{})
 	}
-	return m
+	if o.Encryption {
+		if o.EncryptionPassword == "" {
+			return nil, errors.New("no encryption password configured")
+		}
+		switch o.EncryptionAlgorithm {
+		case "", "aes-256-ctr":
+			enc, err := NewAES256CTR(o.EncryptionPassword)
+			if err != nil {
+				return nil, err
+			}
+			c = append(c, enc)
+		default:
+			return nil, fmt.Errorf("unsupported encryption algorithm %q", o.EncryptionAlgorithm)
+		}
+	}
+	return c, nil
 }

--- a/store.go
+++ b/store.go
@@ -89,7 +89,7 @@ type StoreOptions struct {
 	Uncompressed bool `json:"uncompressed"`
 
 	// Store encryption settings. Currently supported algorithms are xchacha20-poly1305 (default)
-	// aes-256-gcm, and aes-256-ctr.
+	// and aes-256-gcm.
 	Encryption          bool   `json:"encryption,omitempty"`
 	EncryptionAlgorithm string `json:"encryption-algorithm,omitempty"`
 	EncryptionPassword  string `json:"encryption-password,omitempty"`
@@ -118,12 +118,6 @@ func (o StoreOptions) StorageConverters() ([]converter, error) {
 			c = append(c, enc)
 		case "aes-256-gcm":
 			enc, err := NewAES256GCM(o.EncryptionPassword)
-			if err != nil {
-				return nil, err
-			}
-			c = append(c, enc)
-		case "aes-256-ctr":
-			enc, err := NewAES256CTR(o.EncryptionPassword)
 			if err != nil {
 				return nil, err
 			}

--- a/store.go
+++ b/store.go
@@ -90,9 +90,9 @@ type StoreOptions struct {
 
 	// Store encryption settings. The only algorithm currently supported is aes-256-ctr which
 	// is also the default.
-	Encryption          bool   `json:"encryption"`
-	EncryptionAlgorithm string `json:"encryption-algorithm"`
-	EncryptionPassword  string `json:"encryption-password"`
+	Encryption          bool   `json:"encryption,omitempty"`
+	EncryptionAlgorithm string `json:"encryption-algorithm,omitempty"`
+	EncryptionPassword  string `json:"encryption-password,omitempty"`
 }
 
 // Returns data converters that convert between plain and storage-format. Each layer


### PR DESCRIPTION
Adds chunk encryption as option to chunk stores. Supports aes-256-ctr at this point (though this could be expanded to other key sizes or algorithms). The key is generated by hashing the password with SHA256. For now the only way to configure encryption is by using the config file.

TODO:
- [x] Document how to use it
- [x] Add a way to provide encryption for HTTP chunk servers, since the store config doesn't apply to server-side HTTP. Probably a new set of options.
- [x] Perhaps a couple more tests, ideally a high-level one that uses a config.json

Any (early) feedback is welcome.