### PR TITLE
datadog is now DataDog, enforced by their go.mod

### DIFF
--- a/compress_datadog.go
+++ b/compress_datadog.go
@@ -3,7 +3,7 @@
 package desync
 
 import (
-	"github.com/datadog/zstd"
+	"github.com/DataDog/zstd"
 )
 
 // Compress a block using the only (currently) supported algorithm

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.15
 
 require (
 	cloud.google.com/go/storage v1.12.0
+	github.com/DataDog/zstd v1.4.5
 	github.com/boljen/go-bitmap v0.0.0-20151001105940-23cd2fb0ce7d
-	github.com/datadog/zstd v1.4.5
 	github.com/dchest/siphash v1.2.2
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/folbricht/tempfile v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
+github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -70,8 +72,6 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/datadog/zstd v1.4.5 h1:PW1WRRmJ8wBxKoaY3HVedZ3k8Pfw4eAJ22yTXutS8cg=
-github.com/datadog/zstd v1.4.5/go.mod h1:inRp+etsHuvVqMPNTXaFlpf/Tj7wqviBtdJoPVrPEFQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
On February 11th, datadog/zstd introduced a `go.mod` describing the library as being `DataDog/zstd`. This introduced build breakage.

Quoting their commit message (DataDog/zstd@9847581ee76d182dd6ad4a0e23795f09297ba123):

> Since we have no external dependancies, the module file is pretty barebone.
> 
> "DataDog" is capitalized as is because it is the current github URL, even though github URLs are case-insensitive; talking to GitHub support, it looks like a migration to a different casing (i.e: datadog) is not 100% compatible (i.e: some systems that are case-sensitive for project names could be impact).
>  
> Since we always run tests for go version N & N-1 (N being latest), we currently support fully 1.14 as a minimum version.
