### PR TITLE
Add information about the seed indexes.

### DIFF
--- a/cmd/desync/info_test.go
+++ b/cmd/desync/info_test.go
@@ -15,7 +15,9 @@ func TestInfoCommand(t *testing.T) {
 		"total": 161,
 		"unique": 131,
 		"in-store": 131,
+		"in-seed": 0,
 		"size": 2097152,
+		"dedup-size-not-in-seed": 1114112,
 		"chunk-size-min": 2048,
 		"chunk-size-avg": 8192,
 		"chunk-size-max": 32768
@@ -26,6 +28,43 @@ func TestInfoCommand(t *testing.T) {
 
 	cmd := newInfoCommand(context.Background())
 	cmd.SetArgs([]string{"-s", "testdata/blob1.store", "testdata/blob1.caibx"})
+	b := new(bytes.Buffer)
+
+	// Redirect the command's output
+	stdout = b
+	cmd.SetOutput(ioutil.Discard)
+	_, err = cmd.ExecuteC()
+	require.NoError(t, err)
+
+	// Decode the output and compare to what's expected
+	got := make(map[string]interface{})
+	err = json.Unmarshal(b.Bytes(), &got)
+	require.NoError(t, err)
+	require.Equal(t, exp, got)
+}
+
+func TestInfoCommandWithSeed(t *testing.T) {
+	expectedOutput := []byte(`{
+		"total": 161,
+		"unique": 131,
+		"in-store": 131,
+		"in-seed": 124,
+		"size": 2097152,
+		"dedup-size-not-in-seed": 80029,
+		"chunk-size-min": 2048,
+		"chunk-size-avg": 8192,
+		"chunk-size-max": 32768
+	}`)
+	exp := make(map[string]interface{})
+	err := json.Unmarshal(expectedOutput, &exp)
+	require.NoError(t, err)
+
+	cmd := newInfoCommand(context.Background())
+	cmd.SetArgs([]string{
+		"-s", "testdata/blob1.store",
+		"--seed", "testdata/blob2.caibx",
+		"testdata/blob1.caibx",
+	})
 	b := new(bytes.Buffer)
 
 	// Redirect the command's output


### PR DESCRIPTION
This adds the ability to add one or more seed indexes to the `info`
command.

The resulting output will contain the number of chunks, from the index
provided in input, that are available in the seed. Similarly to what
it's already done with the store.

Additionally it also shows the size of the unique (non duplicated)
chunks that are not available from the seed.
This information can be used as a way to roughly estimate the download
size of a particular update. For example if we use:
```
desync info --seed local.caibx -s https://[...]/store update.caibx
```
We will get in output the size of the chunks that are required by
`update.caibx` but that are not already available in our local seed. So
these will be the chunks that we must download from the remote store.