### PR TITLE
Fix help doc for mount-index command

### DIFF
--- a/cmd/desync/mount-index.go
+++ b/cmd/desync/mount-index.go
@@ -36,12 +36,13 @@ the index available for read access. Use 'extract' if the goal is to
 assemble the whole blob locally as that is more efficient. Use '-' to read
 the index from STDIN.
 
-When a Copy-on-Read file is given (with -x), the file is used as a fast cache. All chunks
-that are retrieved from the store are written into the file as read operations are
-performed. Once all chunks have been accessed once, the COR file is fully populated. On
-termination, a <name>.state file is written containing information about which chunks
-of the index have or have not been read. A state file is only valid for one cache-file and
-one index. When re-using it with a different index, data corruption can occur.
+When a Copy-on-Read file is given (with --cor-file), the file is used as a fast cache.
+All chunks that are accessed by the mount are retrieved from the store and written into
+the file as read operations are performed. Once all chunks have been accessed, the COR
+file is fully populated. On termination, a <name>.state file is written containing
+information about which chunks of the index have or have not been read. A state file is
+only valid for a one cache-file and one index. When re-using it with a different index,
+data corruption can occur.
 
 This command supports the --store-file option which can be used to define the stores
 and caches in a JSON file. The config can then be reloaded by sending a SIGHUP without


### PR DESCRIPTION
Fix the help string for `mount-index`