### PR TITLE
Speed up VerifyIndex

### DIFF
--- a/cmd/desync/verifyindex_test.go
+++ b/cmd/desync/verifyindex_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestVerifyIndexCommand(t *testing.T) {
+	// Validate the index of blob1, we expect it to complete without any error
+	verifyIndex := newVerifyIndexCommand(context.Background())
+	verifyIndex.SetArgs([]string{"testdata/blob1.caibx", "testdata/blob1"})
+	b := new(bytes.Buffer)
+	stderr = b
+	_, err := verifyIndex.ExecuteC()
+	require.NoError(t, err)
+	require.Contains(t, b.String(), "")
+
+	// Do the same for blob2
+	verifyIndex = newVerifyIndexCommand(context.Background())
+	verifyIndex.SetArgs([]string{"testdata/blob2.caibx", "testdata/blob2"})
+	b = new(bytes.Buffer)
+	stderr = b
+	_, err = verifyIndex.ExecuteC()
+	require.NoError(t, err)
+	require.Contains(t, b.String(), "")
+
+	// Run again against the wrong blob
+	verifyIndex = newVerifyIndexCommand(context.Background())
+	verifyIndex.SetArgs([]string{"testdata/blob2.caibx", "testdata/blob1"})
+	_, err = verifyIndex.ExecuteC()
+	require.Error(t, err)
+}


### PR DESCRIPTION
- Add some tests for VerifyIndex
- Reduce code duplication while verifying an index
    We can reuse the validate() function of FileSeedSegment and avoid
duplicating the code here.
- Feed multiple chunks to the workers while verifying an index
    If we send a single chunk to every Goroutine, the workers will complete
their task immediately and then will wait for a new chunk to validate.

    If instead we group together multiple chunks we can improve the overall
performance.

    For example, in my test machine, the required time to verify an index
that pointed to a 5gb image took 30 seconds, and with this patch it
dropped to 24 seconds.