### PR TITLE
Get the correct size for block devices

### DIFF
--- a/ioctl_nonlinux.go
+++ b/ioctl_nonlinux.go
@@ -14,3 +14,17 @@ func CanClone(dstFile string, srcFile string) bool {
 func CloneRange(dst, src *os.File, srcOffset, srcLength, dstOffset uint64) error {
 	return errors.New("Not available on this platform")
 }
+
+// GetFileSize determines the size, in Bytes, of the file located at the given
+// fileName.
+func GetFileSize(fileName string) (size uint64, err error) {
+	info, err := os.Stat(fileName)
+	if err != nil {
+		return 0, err
+	}
+	fm := info.Mode()
+	if isDevice(fm) {
+		// TODO we probably should do something platform specific here to get the correct size
+	}
+	return uint64(info.Size()), nil
+}

--- a/make.go
+++ b/make.go
@@ -60,21 +60,21 @@ func IndexFromFile(ctx context.Context,
 	}
 	f.Close()
 
-	// Adjust n if it's a small file that doesn't have n*max bytes
-	info, err := os.Stat(name)
+	size, err := GetFileSize(name)
 	if err != nil {
 		return index, stats, err
 	}
-	nn := int(info.Size()/int64(max)) + 1
-	if nn < n {
-		n = nn
+
+	// Adjust n if it's a small file that doesn't have n*max bytes
+	nn := size/max + 1
+	if nn < uint64(n) {
+		n = int(nn)
 	}
-	size := uint64(info.Size())
 	span := size / uint64(n) // initial spacing between chunkers
 
 	// Setup and start the progressbar if any
 	if pb != nil {
-		pb.SetTotal(int(info.Size()))
+		pb.SetTotal(int(size))
 		pb.Start()
 		defer pb.Finish()
 	}


### PR DESCRIPTION
The function `Size()` of `FileInfo` returns the length in bytes for
regular files. However if we use a block device, `Size()` will return a
length of zero.

To chunk a file, we use the size to split the expected work in even
parts.

For this reason, when we wanted to generate an index from a block
device, due to the incorrect reported zero size, the whole task was
carried out by a single Goroutine.

With this commit we use the ioctl `BLKGETSIZE64` to get the correct size
for block devices.

In a test environment the `make` operation against a block device took 2
minutes and 20 seconds to complete with the current master branch and
only 24 seconds with this patch.
