### PR TITLE
Add new ENV variable to make it easier to parse the progresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ cd desync/cmd/desync && go install
 - `CASYNC_REMOTE_PATH` defines the command to run on the chunk store when using SSH, default "casync"
 - `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_REGION` can be used to define S3 store credentials if only one store is used. Caution, these values take precedence over any S3 credentials set in the config file.
 - `DESYNC_PROGRESSBAR_ENABLED` enables the progress bar if set to anything other than an empty string. By default, the progressbar is only turned on if STDERR is found to be a terminal.
+- `DESYNC_ENABLE_PARSABLE_PROGRESS` prints in STDERR the current operation name, the completed percentage and the estimated remaining time if it is set to anything other than an empty string. This is similar to the default progress bar but without the actual bar.
 - `DESYNC_HTTP_AUTH` sets the expected value in the HTTP Authorization header from clients when using `chunk-server` or `index-server`. It needs to be the full string, with type and encoding like `"Basic dXNlcjpwYXNzd29yZAo="`. Any authorization value provided in the command line takes precedence over the environment variable.
 
 ### Caching

--- a/cmd/desync/progressbar.go
+++ b/cmd/desync/progressbar.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"time"
 
 	"github.com/folbricht/desync"
 	"golang.org/x/crypto/ssh/terminal"
@@ -11,12 +13,24 @@ import (
 // NewProgressBar initializes a wrapper for a https://github.com/cheggaaa/pb
 // progressbar that implements desync.ProgressBar
 func NewProgressBar(prefix string) desync.ProgressBar {
-	if !terminal.IsTerminal(int(os.Stderr.Fd())) && os.Getenv("DESYNC_PROGRESSBAR_ENABLED") == "" {
+	if !terminal.IsTerminal(int(os.Stderr.Fd())) &&
+		os.Getenv("DESYNC_PROGRESSBAR_ENABLED") == "" &&
+		os.Getenv("DESYNC_ENABLE_PARSABLE_PROGRESS") == "" {
 		return nil
 	}
 	bar := pb.New(0).Prefix(prefix)
 	bar.ShowCounters = false
 	bar.Output = stderr
+	if os.Getenv("DESYNC_ENABLE_PARSABLE_PROGRESS") != "" {
+		// This is likely going to a journal or redirected to a file, lower the
+		// refresh rate from the default 200ms to a more manageable 500ms.
+		bar.SetRefreshRate(time.Millisecond * 500)
+		bar.ShowBar = false
+		// Write every progress update in a separate line, instead of using
+		// the default carriage returns.
+		bar.Callback = func(s string) { fmt.Fprintln(os.Stderr, s) }
+		bar.Output = nil
+	}
 	return ProgressBar{bar}
 }
 


### PR DESCRIPTION
Introduce a new environment variable `DESYNC_ENABLE_PARSABLE_PROGRESS`
that allows us to print in output the progress without the progress bar.

This will make it easier to parse the current completion percentage, and
estimated remaining time, without flooding the journal, or where the
stderr was redirected, with very frequent updates that contain long
progress bars.

-----

In theory I could have reused the same `DESYNC_PROGRESSBAR_ENABLED`, but I didn't want to change behavior in case other people were already parsing its output. Also an env var called "progressbar enabled" that doesn't actually print a progress bar was probably too awkward.