### PR TITLE
Create a progress bar for the plan validation

### DIFF
--- a/assemble.go
+++ b/assemble.go
@@ -46,11 +46,9 @@ func AssembleFile(ctx context.Context, name string, idx Index, s Store, seeds []
 	g, ctx := errgroup.WithContext(ctx)
 
 	// Setup and start the progressbar if any
-	if pb != nil {
-		pb.SetTotal(len(idx.Chunks))
-		pb.Start()
-		defer pb.Finish()
-	}
+	pb.SetTotal(len(idx.Chunks))
+	pb.Start()
+	defer pb.Finish()
 
 	// Initialize stats to be gathered during extraction
 	stats := &ExtractStats{
@@ -118,9 +116,7 @@ func AssembleFile(ctx context.Context, name string, idx Index, s Store, seeds []
 		defer f.Close()
 		g.Go(func() error {
 			for job := range in {
-				if pb != nil {
-					pb.Add(job.segment.lengthChunks())
-				}
+				pb.Add(job.segment.lengthChunks())
 				if job.source != nil {
 					// If we have a seedSegment we expect 1 or more chunks between
 					// the start and the end of this segment.

--- a/assemble_test.go
+++ b/assemble_test.go
@@ -40,7 +40,7 @@ func TestExtract(t *testing.T) {
 		in.Name(),
 		10,
 		ChunkSizeMinDefault, ChunkSizeAvgDefault, ChunkSizeMaxDefault,
-		nil,
+		NewProgressBar(""),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -57,7 +57,7 @@ func TestExtract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := ChopFile(context.Background(), in.Name(), index.Chunks, s, 10, nil); err != nil {
+	if err := ChopFile(context.Background(), in.Name(), index.Chunks, s, 10, NewProgressBar("")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -128,7 +128,7 @@ func TestExtract(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			defer os.Remove(test.outfile)
 			if _, err := AssembleFile(context.Background(), test.outfile, index, test.store, nil,
-				AssembleOptions{10, InvalidSeedActionBailOut}, nil,
+				AssembleOptions{10, InvalidSeedActionBailOut}, NewProgressBar(""),
 			); err != nil {
 				t.Fatal(err)
 			}
@@ -230,14 +230,14 @@ func TestSeed(t *testing.T) {
 				dst.Name(),
 				10,
 				ChunkSizeMinDefault, ChunkSizeAvgDefault, ChunkSizeMaxDefault,
-				nil,
+				NewProgressBar(""),
 			)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			// Chop up the input file into the store
-			if err := ChopFile(context.Background(), dst.Name(), dstIndex.Chunks, s, 10, nil); err != nil {
+			if err := ChopFile(context.Background(), dst.Name(), dstIndex.Chunks, s, 10, NewProgressBar("")); err != nil {
 				t.Fatal(err)
 			}
 
@@ -258,7 +258,7 @@ func TestSeed(t *testing.T) {
 					seedFile.Name(),
 					10,
 					ChunkSizeMinDefault, ChunkSizeAvgDefault, ChunkSizeMaxDefault,
-					nil,
+					NewProgressBar(""),
 				)
 				if err != nil {
 					t.Fatal(err)
@@ -271,7 +271,7 @@ func TestSeed(t *testing.T) {
 			}
 
 			if _, err := AssembleFile(context.Background(), dst.Name(), dstIndex, s, seeds,
-				AssembleOptions{10, InvalidSeedActionBailOut}, nil,
+				AssembleOptions{10, InvalidSeedActionBailOut}, NewProgressBar(""),
 			); err != nil {
 				t.Fatal(err)
 			}

--- a/assemble_test.go
+++ b/assemble_test.go
@@ -128,7 +128,7 @@ func TestExtract(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			defer os.Remove(test.outfile)
 			if _, err := AssembleFile(context.Background(), test.outfile, index, test.store, nil,
-				AssembleOptions{10, InvalidSeedActionBailOut}, NewProgressBar(""),
+				AssembleOptions{10, InvalidSeedActionBailOut},
 			); err != nil {
 				t.Fatal(err)
 			}
@@ -271,7 +271,7 @@ func TestSeed(t *testing.T) {
 			}
 
 			if _, err := AssembleFile(context.Background(), dst.Name(), dstIndex, s, seeds,
-				AssembleOptions{10, InvalidSeedActionBailOut}, NewProgressBar(""),
+				AssembleOptions{10, InvalidSeedActionBailOut},
 			); err != nil {
 				t.Fatal(err)
 			}

--- a/chop.go
+++ b/chop.go
@@ -16,11 +16,9 @@ func ChopFile(ctx context.Context, name string, chunks []IndexChunk, ws WriteSto
 	g, ctx := errgroup.WithContext(ctx)
 
 	// Setup and start the progressbar if any
-	if pb != nil {
-		pb.SetTotal(len(chunks))
-		pb.Start()
-		defer pb.Finish()
-	}
+	pb.SetTotal(len(chunks))
+	pb.Start()
+	defer pb.Finish()
 
 	s := NewChunkStorage(ws)
 
@@ -35,9 +33,7 @@ func ChopFile(ctx context.Context, name string, chunks []IndexChunk, ws WriteSto
 		g.Go(func() error {
 			for c := range in {
 				// Update progress bar if any
-				if pb != nil {
-					pb.Add(1)
-				}
+				pb.Increment()
 
 				chunk, err := readChunkFromFile(f, c)
 				if err != nil {

--- a/cmd/desync/cache.go
+++ b/cmd/desync/cache.go
@@ -113,7 +113,7 @@ func runCache(ctx context.Context, opt cacheOptions, args []string) error {
 	defer dst.Close()
 
 	// If this is a terminal, we want a progress bar
-	pb := NewProgressBar("")
+	pb := desync.NewProgressBar("")
 
 	// Pull all the chunks, and load them into the cache in the process
 	return desync.Copy(ctx, ids, s, dst, opt.n, pb)

--- a/cmd/desync/chop.go
+++ b/cmd/desync/chop.go
@@ -110,7 +110,7 @@ func runChop(ctx context.Context, opt chopOptions, args []string) error {
 	}
 
 	// If this is a terminal, we want a progress bar
-	pb := NewProgressBar("")
+	pb := desync.NewProgressBar("")
 
 	// Chop up the file into chunks and store them in the target store
 	return desync.ChopFile(ctx, dataFile, chunks, s, opt.n, pb)

--- a/cmd/desync/extract.go
+++ b/cmd/desync/extract.go
@@ -158,7 +158,7 @@ func writeWithTmpFile(ctx context.Context, name string, idx desync.Index, s desy
 }
 
 func writeInplace(ctx context.Context, name string, idx desync.Index, s desync.Store, seeds []desync.Seed, assembleOpt desync.AssembleOptions) (*desync.ExtractStats, error) {
-	pb := NewProgressBar("")
+	pb := desync.NewProgressBar("")
 
 	// Build the blob from the chunks, writing everything into given filename
 	return desync.AssembleFile(ctx, name, idx, s, seeds, assembleOpt, pb)

--- a/cmd/desync/extract.go
+++ b/cmd/desync/extract.go
@@ -158,10 +158,8 @@ func writeWithTmpFile(ctx context.Context, name string, idx desync.Index, s desy
 }
 
 func writeInplace(ctx context.Context, name string, idx desync.Index, s desync.Store, seeds []desync.Seed, assembleOpt desync.AssembleOptions) (*desync.ExtractStats, error) {
-	pb := desync.NewProgressBar("")
-
 	// Build the blob from the chunks, writing everything into given filename
-	return desync.AssembleFile(ctx, name, idx, s, seeds, assembleOpt, pb)
+	return desync.AssembleFile(ctx, name, idx, s, seeds, assembleOpt)
 }
 
 func readSeeds(dstFile string, locations []string, opts cmdStoreOptions) ([]desync.Seed, error) {

--- a/cmd/desync/make.go
+++ b/cmd/desync/make.go
@@ -67,7 +67,7 @@ func runMake(ctx context.Context, opt makeOptions, args []string) error {
 	}
 
 	// Split up the file and create and index from it
-	pb := NewProgressBar("Chunking ")
+	pb := desync.NewProgressBar("Chunking ")
 	index, stats, err := desync.IndexFromFile(ctx, dataFile, opt.n, min, avg, max, pb)
 	if err != nil {
 		return err
@@ -75,7 +75,7 @@ func runMake(ctx context.Context, opt makeOptions, args []string) error {
 
 	// Chop up the file into chunks and store them in the target store if a store was given
 	if s != nil {
-		pb := NewProgressBar("Storing ")
+		pb := desync.NewProgressBar("Storing ")
 		if err := desync.ChopFile(ctx, dataFile, index.Chunks, s, opt.n, pb); err != nil {
 			return err
 		}

--- a/cmd/desync/untar.go
+++ b/cmd/desync/untar.go
@@ -99,17 +99,15 @@ func runUntar(ctx context.Context, opt untarOptions, args []string) error {
 		defer f.Close()
 		var r io.Reader = f
 		pb := desync.NewProgressBar("Unpacking ")
-		if pb != nil {
-			// Get the file size to initialize the progress bar
-			info, err := f.Stat()
-			if err != nil {
-				return err
-			}
-			pb.Start()
-			defer pb.Finish()
-			pb.SetTotal(int(info.Size()))
-			r = io.TeeReader(f, pb)
+		// Get the file size to initialize the progress bar
+		info, err := f.Stat()
+		if err != nil {
+			return err
 		}
+		pb.Start()
+		defer pb.Finish()
+		pb.SetTotal(int(info.Size()))
+		r = io.TeeReader(f, pb)
 		return desync.UnTar(ctx, r, fs)
 	}
 

--- a/cmd/desync/untar.go
+++ b/cmd/desync/untar.go
@@ -98,7 +98,7 @@ func runUntar(ctx context.Context, opt untarOptions, args []string) error {
 		}
 		defer f.Close()
 		var r io.Reader = f
-		pb := NewProgressBar("Unpacking ")
+		pb := desync.NewProgressBar("Unpacking ")
 		if pb != nil {
 			// Get the file size to initialize the progress bar
 			info, err := f.Stat()
@@ -125,5 +125,5 @@ func runUntar(ctx context.Context, opt untarOptions, args []string) error {
 		return err
 	}
 
-	return desync.UnTarIndex(ctx, fs, index, s, opt.n, NewProgressBar("Unpacking "))
+	return desync.UnTarIndex(ctx, fs, index, s, opt.n, desync.NewProgressBar("Unpacking "))
 }

--- a/cmd/desync/verifyindex.go
+++ b/cmd/desync/verifyindex.go
@@ -44,7 +44,7 @@ func runVerifyIndex(ctx context.Context, opt verifyIndexOptions, args []string) 
 	}
 
 	// If this is a terminal, we want a progress bar
-	pb := NewProgressBar("")
+	pb := desync.NewProgressBar("")
 
 	// Chop up the file into chunks and store them in the target store
 	return desync.VerifyIndex(ctx, dataFile, idx, opt.n, pb)

--- a/copy.go
+++ b/copy.go
@@ -15,19 +15,15 @@ func Copy(ctx context.Context, ids []ChunkID, src Store, dst WriteStore, n int, 
 	g, ctx := errgroup.WithContext(ctx)
 
 	// Setup and start the progressbar if any
-	if pb != nil {
-		pb.SetTotal(len(ids))
-		pb.Start()
-		defer pb.Finish()
-	}
+	pb.SetTotal(len(ids))
+	pb.Start()
+	defer pb.Finish()
 
 	// Start the workers
 	for i := 0; i < n; i++ {
 		g.Go(func() error {
 			for id := range in {
-				if pb != nil {
-					pb.Increment()
-				}
+				pb.Increment()
 				hasChunk, err := dst.HasChunk(id)
 				if err != nil {
 					return err

--- a/fileseed.go
+++ b/fileseed.go
@@ -66,7 +66,7 @@ func (s *FileSeed) LongestMatchWith(chunks []IndexChunk) (int, SeedSegment) {
 
 func (s *FileSeed) RegenerateIndex(ctx context.Context, n int) error {
 	index, _, err := IndexFromFile(ctx, s.srcFile, n, s.index.Index.ChunkSizeMin, s.index.Index.ChunkSizeAvg,
-		s.index.Index.ChunkSizeMax, nil)
+		s.index.Index.ChunkSizeMax, NewProgressBar("Chunking "))
 	if err != nil {
 		return err
 	}

--- a/make.go
+++ b/make.go
@@ -73,11 +73,9 @@ func IndexFromFile(ctx context.Context,
 	span := size / uint64(n) // initial spacing between chunkers
 
 	// Setup and start the progressbar if any
-	if pb != nil {
-		pb.SetTotal(int(size))
-		pb.Start()
-		defer pb.Finish()
-	}
+	pb.SetTotal(int(size))
+	pb.Start()
+	defer pb.Finish()
 
 	// Null chunks is produced when a large section of null bytes is chunked. There are no
 	// split points in those sections so it's always of max chunk size. Used for optimizations
@@ -135,9 +133,7 @@ func IndexFromFile(ctx context.Context,
 		for chunk := range w.results {
 			// Assemble the list of chunks in the index
 			index.Chunks = append(index.Chunks, chunk)
-			if pb != nil {
-				pb.Set(int(chunk.Start + chunk.Size))
-			}
+			pb.Set(int(chunk.Start + chunk.Size))
 			stats.incAccepted()
 		}
 		// Done reading all chunks from this worker, check for any errors

--- a/make_test.go
+++ b/make_test.go
@@ -68,7 +68,7 @@ func TestParallelChunking(t *testing.T) {
 						f.Name(),
 						n,
 						ChunkSizeMinDefault, ChunkSizeAvgDefault, ChunkSizeMaxDefault,
-						nil,
+						NewProgressBar(""),
 					)
 					if err != nil {
 						t.Fatal(err)

--- a/nullprogressbar.go
+++ b/nullprogressbar.go
@@ -1,0 +1,33 @@
+package desync
+
+// NullProgressBar wraps https://github.com/cheggaaa/pb and is used when we don't want to show a progressbar.
+type NullProgressBar struct {
+}
+
+func (p NullProgressBar) Finish() {
+	/// Nothing to do
+}
+
+func (p NullProgressBar) Increment() int {
+	return 0
+}
+
+func (p NullProgressBar) Add(add int) int {
+	return 0
+}
+
+func (p NullProgressBar) SetTotal(total int) {
+	// Nothing to do
+}
+
+func (p NullProgressBar) Start() {
+	// Nothing to do
+}
+
+func (p NullProgressBar) Set(current int) {
+	// Nothing to do
+}
+
+func (p NullProgressBar) Write(b []byte) (n int, err error) {
+	return 0, nil
+}

--- a/progressbar.go
+++ b/progressbar.go
@@ -15,7 +15,7 @@ func NewProgressBar(prefix string) ProgressBar {
 	if !terminal.IsTerminal(int(os.Stderr.Fd())) &&
 		os.Getenv("DESYNC_PROGRESSBAR_ENABLED") == "" &&
 		os.Getenv("DESYNC_ENABLE_PARSABLE_PROGRESS") == "" {
-		return nil
+		return NullProgressBar{}
 	}
 	bar := pb.New(0).Prefix(prefix)
 	bar.ShowCounters = false

--- a/progressbar.go
+++ b/progressbar.go
@@ -1,18 +1,17 @@
-package main
+package desync
 
 import (
 	"fmt"
 	"os"
 	"time"
 
-	"github.com/folbricht/desync"
 	"golang.org/x/crypto/ssh/terminal"
 	pb "gopkg.in/cheggaaa/pb.v1"
 )
 
 // NewProgressBar initializes a wrapper for a https://github.com/cheggaaa/pb
 // progressbar that implements desync.ProgressBar
-func NewProgressBar(prefix string) desync.ProgressBar {
+func NewProgressBar(prefix string) ProgressBar {
 	if !terminal.IsTerminal(int(os.Stderr.Fd())) &&
 		os.Getenv("DESYNC_PROGRESSBAR_ENABLED") == "" &&
 		os.Getenv("DESYNC_ENABLE_PARSABLE_PROGRESS") == "" {
@@ -20,7 +19,7 @@ func NewProgressBar(prefix string) desync.ProgressBar {
 	}
 	bar := pb.New(0).Prefix(prefix)
 	bar.ShowCounters = false
-	bar.Output = stderr
+	bar.Output = os.Stderr
 	if os.Getenv("DESYNC_ENABLE_PARSABLE_PROGRESS") != "" {
 		// This is likely going to a journal or redirected to a file, lower the
 		// refresh rate from the default 200ms to a more manageable 500ms.
@@ -31,30 +30,30 @@ func NewProgressBar(prefix string) desync.ProgressBar {
 		bar.Callback = func(s string) { fmt.Fprintln(os.Stderr, s) }
 		bar.Output = nil
 	}
-	return ProgressBar{bar}
+	return DefaultProgressBar{bar}
 }
 
-// ProgressBar wraps https://github.com/cheggaaa/pb and implements desync.ProgressBar
-type ProgressBar struct {
+// DefaultProgressBar wraps https://github.com/cheggaaa/pb and implements desync.ProgressBar
+type DefaultProgressBar struct {
 	*pb.ProgressBar
 }
 
 // SetTotal sets the upper bounds for the progress bar
-func (p ProgressBar) SetTotal(total int) {
+func (p DefaultProgressBar) SetTotal(total int) {
 	p.ProgressBar.SetTotal(total)
 }
 
 // Start displaying the progress bar
-func (p ProgressBar) Start() {
+func (p DefaultProgressBar) Start() {
 	p.ProgressBar.Start()
 }
 
 // Set the current value
-func (p ProgressBar) Set(current int) {
+func (p DefaultProgressBar) Set(current int) {
 	p.ProgressBar.Set(current)
 }
 
 // Write the current state of the progressbar
-func (p ProgressBar) Write(b []byte) (n int, err error) {
+func (p DefaultProgressBar) Write(b []byte) (n int, err error) {
 	return p.ProgressBar.Write(b)
 }

--- a/selfseed_test.go
+++ b/selfseed_test.go
@@ -111,7 +111,7 @@ func TestSelfSeed(t *testing.T) {
 
 			// Extract the file
 			stats, err := AssembleFile(context.Background(), dst.Name(), idx, s, nil,
-				AssembleOptions{1, InvalidSeedActionBailOut}, NewProgressBar(""),
+				AssembleOptions{1, InvalidSeedActionBailOut},
 			)
 			if err != nil {
 				t.Fatal(err)

--- a/selfseed_test.go
+++ b/selfseed_test.go
@@ -111,7 +111,7 @@ func TestSelfSeed(t *testing.T) {
 
 			// Extract the file
 			stats, err := AssembleFile(context.Background(), dst.Name(), idx, s, nil,
-				AssembleOptions{1, InvalidSeedActionBailOut}, nil,
+				AssembleOptions{1, InvalidSeedActionBailOut}, NewProgressBar(""),
 			)
 			if err != nil {
 				t.Fatal(err)

--- a/untar.go
+++ b/untar.go
@@ -62,11 +62,9 @@ func UnTarIndex(ctx context.Context, fs FilesystemWriter, index Index, s Store, 
 	g, ctx := errgroup.WithContext(ctx)
 
 	// Initialize and start progress bar if one was provided
-	if pb != nil {
-		pb.SetTotal(len(index.Chunks))
-		pb.Start()
-		defer pb.Finish()
-	}
+	pb.SetTotal(len(index.Chunks))
+	pb.Start()
+	defer pb.Finish()
 
 	// Use a pipe as input to untar and write the chunks into that (in the right
 	// order of course)
@@ -131,9 +129,7 @@ func UnTarIndex(ctx context.Context, fs FilesystemWriter, index Index, s Store, 
 				if data == nil {
 					break loop
 				}
-				if pb != nil {
-					pb.Increment()
-				}
+				pb.Increment()
 				b := <-data
 				if _, err := io.Copy(w, bytes.NewReader(b)); err != nil {
 					return err

--- a/verifyindex.go
+++ b/verifyindex.go
@@ -15,11 +15,9 @@ func VerifyIndex(ctx context.Context, name string, idx Index, n int, pb Progress
 	g, ctx := errgroup.WithContext(ctx)
 
 	// Setup and start the progressbar if any
-	if pb != nil {
-		pb.SetTotal(len(idx.Chunks))
-		pb.Start()
-		defer pb.Finish()
-	}
+	pb.SetTotal(len(idx.Chunks))
+	pb.Start()
+	defer pb.Finish()
 
 	stat, err := os.Stat(name)
 	if err != nil {
@@ -45,9 +43,7 @@ func VerifyIndex(ctx context.Context, name string, idx Index, n int, pb Progress
 				}
 
 				// Update progress bar, if any
-				if pb != nil {
-					pb.Add(len(c))
-				}
+				pb.Add(len(c))
 			}
 			return nil
 		})


### PR DESCRIPTION
Validating a plan could take a non trivial amount of time, depending on
the size of a plan and by the I/O speed.

With this commit we add a progress bar that shows the status of the
validation and prefixes the assembling progress bar with "Assembling ".

---

I added just the validation and not the actual "planning" because, from my testings, the planning is usually done nearly instantaneously and the progress percentage would just go from 0% to 100%.