### PR TITLE
Write the progress bar attempt number

### DIFF
--- a/fileseed.go
+++ b/fileseed.go
@@ -64,9 +64,10 @@ func (s *FileSeed) LongestMatchWith(chunks []IndexChunk) (int, SeedSegment) {
 	return max, newFileSeedSegment(s.srcFile, match, s.canReflink)
 }
 
-func (s *FileSeed) RegenerateIndex(ctx context.Context, n int) error {
+func (s *FileSeed) RegenerateIndex(ctx context.Context, n int, attempt int, seedNumber int) error {
+	chunkingPrefix := fmt.Sprintf("Attempt %d: Chunking Seed %d ", attempt, seedNumber)
 	index, _, err := IndexFromFile(ctx, s.srcFile, n, s.index.Index.ChunkSizeMin, s.index.Index.ChunkSizeAvg,
-		s.index.Index.ChunkSizeMax, NewProgressBar("Chunking "))
+		s.index.Index.ChunkSizeMax, NewProgressBar(chunkingPrefix))
 	if err != nil {
 		return err
 	}

--- a/nullseed.go
+++ b/nullseed.go
@@ -65,7 +65,7 @@ func (s *nullChunkSeed) LongestMatchWith(chunks []IndexChunk) (int, SeedSegment)
 	}
 }
 
-func (s *nullChunkSeed) RegenerateIndex(ctx context.Context, n int) error {
+func (s *nullChunkSeed) RegenerateIndex(ctx context.Context, n int, attempt int, seedNumber int) error {
 	panic("A nullseed can't be regenerated")
 }
 

--- a/seed.go
+++ b/seed.go
@@ -13,7 +13,7 @@ const DefaultBlockSize = 4096
 // existing chunks or blocks into the target from.
 type Seed interface {
 	LongestMatchWith(chunks []IndexChunk) (int, SeedSegment)
-	RegenerateIndex(ctx context.Context, n int) error
+	RegenerateIndex(ctx context.Context, n int, attempt int, seedNumber int) error
 	SetInvalid(value bool)
 	IsInvalid() bool
 }

--- a/selfseed.go
+++ b/selfseed.go
@@ -79,7 +79,7 @@ func (s *selfSeed) getChunk(id ChunkID) SeedSegment {
 	return newFileSeedSegment(s.file, s.index.Chunks[first:first+1], s.canReflink)
 }
 
-func (s *selfSeed) RegenerateIndex(ctx context.Context, n int) error {
+func (s *selfSeed) RegenerateIndex(ctx context.Context, n int, attempt int, seedNumber int) error {
 	panic("A selfSeed can't be regenerated")
 }
 

--- a/sequencer.go
+++ b/sequencer.go
@@ -83,12 +83,14 @@ func (s SeedSegmentCandidate) isFileSeed() bool {
 }
 
 // RegenerateInvalidSeeds regenerates the index to match the unexpected seed content
-func (r *SeedSequencer) RegenerateInvalidSeeds(ctx context.Context, n int) error {
+func (r *SeedSequencer) RegenerateInvalidSeeds(ctx context.Context, n int, attempt int) error {
+	seedNumber := 1
 	for _, s := range r.seeds {
 		if s.IsInvalid() {
-			if err := s.RegenerateIndex(ctx, n); err != nil {
+			if err := s.RegenerateIndex(ctx, n, attempt, seedNumber); err != nil {
 				return err
 			}
+			seedNumber += 1
 		}
 	}
 	return nil


### PR DESCRIPTION
Currently we have three major steps while extracting a bundle:
validation, seed chunking and assembling.

If one or more seeds are invalid, these steps might be repeated until
Desync is able to make a plan that is correct.

To make it easier to parse and understand what is going on, we prepend
the attempt number to the progress bar description.

In this way, for example, we will have an output like the following:
Attempt 1: Validating    0.00%
Attempt 1: Validating    0.45% 0s
Attempt 2: Chunking Seed 1    0.00%
Attempt 2: Chunking Seed 1    0.27% 00m35s
Attempt 2: Chunking Seed 1  100.00% 12s
Attempt 2: Validating    0.00%
Attempt 2: Validating   30.43% 00m01s
Attempt 2: Validating  100.00% 1s
Attempt 2: Assembling    0.00%
[...]