### PR TITLE
Do not immediately abort the extraction if a seed chunk is invalid 

### DIFF
--- a/assemble.go
+++ b/assemble.go
@@ -25,6 +25,57 @@ type AssembleOptions struct {
 	InvalidSeedAction InvalidSeedAction
 }
 
+// writeChunk tries to write a chunk by looking at the self seed, if it is already existing in the
+// destination file or by taking it from the store
+func writeChunk(c IndexChunk, ss *selfSeed, f *os.File, blocksize uint64, s Store, stats *ExtractStats, isBlank bool) error {
+	// If we already took this chunk from the store we can reuse it by looking
+	// into the selfSeed.
+	if segment := ss.getChunk(c.ID); segment != nil {
+		copied, cloned, err := segment.WriteInto(f, c.Start, c.Size, blocksize, isBlank)
+		if err != nil {
+			return err
+		}
+		stats.addBytesCopied(copied)
+		stats.addBytesCloned(cloned)
+	}
+
+	// If we operate on an existing file there's a good chance we already
+	// have the data written for this chunk. Let's read it from disk and
+	// compare to what is expected.
+	if !isBlank {
+		b := make([]byte, c.Size)
+		if _, err := f.ReadAt(b, int64(c.Start)); err != nil {
+			return err
+		}
+		sum := Digest.Sum(b)
+		if sum == c.ID {
+			// Record we kept this chunk in the file (when using in-place extract)
+			stats.incChunksInPlace()
+			return nil
+		}
+	}
+	// Record this chunk having been pulled from the store
+	stats.incChunksFromStore()
+	// Pull the (compressed) chunk from the store
+	chunk, err := s.GetChunk(c.ID)
+	if err != nil {
+		return err
+	}
+	b, err := chunk.Data()
+	if err != nil {
+		return err
+	}
+	// Might as well verify the chunk size while we're at it
+	if c.Size != uint64(len(b)) {
+		return fmt.Errorf("unexpected size for chunk %s", c.ID)
+	}
+	// Write the decompressed chunk into the file at the right position
+	if _, err = f.WriteAt(b, int64(c.Start)); err != nil {
+		return err
+	}
+	return nil
+}
+
 // AssembleFile re-assembles a file based on a list of index chunks. It runs n
 // goroutines, creating one filehandle for the file "name" per goroutine
 // and writes to the file simultaneously. If progress is provided, it'll be
@@ -156,58 +207,14 @@ func AssembleFile(ctx context.Context, name string, idx Index, s Store, seeds []
 				}
 				c := job.segment.chunks()[0]
 
-				// If we already took this chunk from the store we can reuse it by looking
-				// into the selfSeed.
-				if segment := ss.getChunk(c.ID); segment != nil {
-					copied, cloned, err := segment.WriteInto(f, c.Start, c.Size, blocksize, isBlank)
-					if err != nil {
-						return err
-					}
-					stats.addBytesCopied(copied)
-					stats.addBytesCloned(cloned)
-					// Even if we already confirmed that this chunk is present in the
-					// self-seed, we still need to record it as being written, otherwise
-					// the self-seed position pointer doesn't advance as we expect.
-					ss.add(job.segment)
+				if err := writeChunk(c, ss, f, blocksize, s, stats, isBlank); err != nil {
+					return err
 				}
 
-				// If we operate on an existing file there's a good chance we already
-				// have the data written for this chunk. Let's read it from disk and
-				// compare to what is expected.
-				if !isBlank {
-					b := make([]byte, c.Size)
-					if _, err := f.ReadAt(b, int64(c.Start)); err != nil {
-						return err
-					}
-					sum := Digest.Sum(b)
-					if sum == c.ID {
-						// Record this chunk's been written in the self-seed
-						ss.add(job.segment)
-						// Record we kept this chunk in the file (when using in-place extract)
-						stats.incChunksInPlace()
-						continue
-					}
-				}
-				// Record this chunk having been pulled from the store
-				stats.incChunksFromStore()
-				// Pull the (compressed) chunk from the store
-				chunk, err := s.GetChunk(c.ID)
-				if err != nil {
-					return err
-				}
-				b, err := chunk.Data()
-				if err != nil {
-					return err
-				}
-				// Might as well verify the chunk size while we're at it
-				if c.Size != uint64(len(b)) {
-					return fmt.Errorf("unexpected size for chunk %s", c.ID)
-				}
-				// Write the decompressed chunk into the file at the right position
-				if _, err = f.WriteAt(b, int64(c.Start)); err != nil {
-					return err
-				}
-				// Record this chunk's been written in the self-seed
+				// Record this chunk's been written in the self-seed.
+				// Even if we already confirmed that this chunk is present in the
+				// self-seed, we still need to record it as being written, otherwise
+				// the self-seed position pointer doesn't advance as we expect.
 				ss.add(job.segment)
 			}
 			return nil

--- a/assemble.go
+++ b/assemble.go
@@ -37,6 +37,7 @@ func writeChunk(c IndexChunk, ss *selfSeed, f *os.File, blocksize uint64, s Stor
 		}
 		stats.addBytesCopied(copied)
 		stats.addBytesCloned(cloned)
+		return nil
 	}
 
 	// If we operate on an existing file there's a good chance we already

--- a/cmd/desync/extract.go
+++ b/cmd/desync/extract.go
@@ -42,7 +42,9 @@ the index from STDIN. If a seed is invalid, by default the extract operation wil
 aborted. With the -skip-invalid-seeds, the invalid seeds will be discarded and the
 extraction will continue without them. Otherwise with the -regenerate-invalid-seeds,
 the eventual invalid seed indexes will be regenerated, in memory, by using the
-available data, and neither data nor indexes will be changed on disk.`,
+available data, and neither data nor indexes will be changed on disk. Also, if the seed changes
+while processing, its invalid chunks will be taken from the self seed, or the store, instead
+of aborting.`,
 		Example: `  desync extract -s http://192.168.1.1/ -c /path/to/local file.caibx largefile.bin
   desync extract -s /mnt/store -s /tmp/other/store file.tar.caibx file.tar
   desync extract -s /mnt/store --seed /mnt/v1.caibx v2.caibx v2.vmdk`,

--- a/nullseed.go
+++ b/nullseed.go
@@ -47,8 +47,17 @@ func (s *nullChunkSeed) LongestMatchWith(chunks []IndexChunk) (int, SeedSegment)
 	if len(chunks) == 0 {
 		return 0, nil
 	}
-	var n int
+	var (
+		n     int
+		limit int
+	)
+	if !s.canReflink {
+		limit = 100
+	}
 	for _, c := range chunks {
+		if limit != 0 && limit == n {
+			break
+		}
 		if c.ID != s.id {
 			break
 		}


### PR DESCRIPTION
- Factor out writeChunk to a separate function
- Do not immediately abort the extraction if a seed chunk is invalid

    If the seed points to a RW location it may happen that some files change
while we are in the middle of an extraction.

    When using the "InvalidSeedActionRegenerate" option, we can try harder
and attempt to take the invalid chunks from the self seed or the store.
If both of those fail too, then we abort the entire operation.

- Limit the maximum number of chunks is a single seed sequence

    If a seed is nearly completely equal to the output, we may end up with
just a few SeedSequencer that are very long and others that are just
one/a few chunks long.

    Because each SeedSequencer is handled by a goroutine (from a pool), we
may reach a situation where the majority of the goroutines finish their
operations and are just waiting for the longer SeedSequencer jobs to
end.

    By limiting the maximum amount of chunks in the SeedSequencer, we will
have jobs that are more balanced in term of amount of work.

- When taking a chunk from the self seed, immediately return

    If we were able to take a chunk from the self seed, there is no need to
    continue looking into the existing file and the store.
