### PR TITLE
Test a seed that changes while an extraction is in progress

### DIFF
--- a/sequencer.go
+++ b/sequencer.go
@@ -26,6 +26,8 @@ type SeedSegmentCandidate struct {
 
 type Plan []SeedSegmentCandidate
 
+var MockValidate = false
+
 // NewSeedSequencer initializes a new sequencer from a number of seeds.
 func NewSeedSequencer(idx Index, src ...Seed) *SeedSequencer {
 	return &SeedSequencer{
@@ -108,6 +110,10 @@ func (p Plan) Validate(ctx context.Context, n int, pb ProgressBar) (err error) {
 		in      = make(chan Job)
 		fileMap = make(map[string]*os.File)
 	)
+	if MockValidate {
+		// This is used in the automated tests to mock a plan that is valid
+		return nil
+	}
 	length := 0
 	for _, s := range p {
 		if !s.isFileSeed() {

--- a/testdata/blob2
+++ b/testdata/blob2
@@ -1,0 +1,1 @@
+../cmd/desync/testdata/blob2

--- a/testdata/blob2.caibx
+++ b/testdata/blob2.caibx
@@ -1,0 +1,1 @@
+../cmd/desync/testdata/blob2.caibx

--- a/testdata/blob2.store
+++ b/testdata/blob2.store
@@ -1,0 +1,1 @@
+../cmd/desync/testdata/blob2.store

--- a/testdata/blob2_corrupted
+++ b/testdata/blob2_corrupted
@@ -1,0 +1,1 @@
+../cmd/desync/testdata/blob2_corrupted

--- a/testdata/blob2_corrupted.caibx
+++ b/testdata/blob2_corrupted.caibx
@@ -1,0 +1,1 @@
+../cmd/desync/testdata/blob2_corrupted.caibx


### PR DESCRIPTION
This adds an automated tests for #220.

I added an environment variable in `sequencer` because that seemed the cleaner way to mock  the `Validate()` function.
Please let me know if instead there is a better way to do that.