### PR TITLE
feat: add HTTP cookie header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Available configuration values:
   - `skip-verify` - Disables data integrity verification when reading chunks to improve performance. Only recommended when chaining chunk stores with the `chunk-server` command using compressed stores.
   - `uncompressed` - Reads and writes uncompressed chunks from/to this store. This can improve performance, especially for local stores or caches. Compressed and uncompressed chunks can coexist in the same store, but only one kind is read or written by one client.
   - `http-auth` - Value of the Authorization header in HTTP requests. This could be a bearer token with `"Bearer <token>"` or a Base64-encoded username and password pair for basic authentication like `"Basic dXNlcjpwYXNzd29yZAo="`.
+  - `http-cookie` - Value of the Cookie header in HTTP requests. This should be in the form of a list of name-value pairs separated by a semicolon and a space (`'; '`) like `"name=value; name2=value2; name3=value3"`.
 
 #### Example config
 
@@ -288,6 +289,9 @@ Available configuration values:
     },
     "https://example.com/*/*/": {
       "http-auth": "Bearer dXNlcjpwYXNzd29yZA=="
+    },
+    "https://cdn.example.com/": {
+      "http-cookie": "PHPSESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43"
     },
     "/path/to/local/cache": {
       "uncompressed": true

--- a/remotehttp.go
+++ b/remotehttp.go
@@ -123,11 +123,6 @@ func (r *RemoteHTTPBase) IssueHttpRequest(method string, u *url.URL, getReader G
 	if r.opt.HTTPCookie != "" {
 		req.Header.Set("Cookie", r.opt.HTTPCookie)
 	}
-	// Set from env var if appropriate
-	httpCookie := os.Getenv("DESYNC_HTTP_COOKIE")
-	if len(httpCookie) != 0 {
-		req.Header.Set("Cookie", httpCookie)
-	}
 
 	log.Debug("sending request")
 	resp, err = r.client.Do(req)

--- a/remotehttp.go
+++ b/remotehttp.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"os"
 	"path"
 	"strings"
 	"time"

--- a/remotehttp.go
+++ b/remotehttp.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -118,6 +119,14 @@ func (r *RemoteHTTPBase) IssueHttpRequest(method string, u *url.URL, getReader G
 	}
 	if r.opt.HTTPAuth != "" {
 		req.Header.Set("Authorization", r.opt.HTTPAuth)
+	}
+	if r.opt.HTTPCookie != "" {
+		req.Header.Set("Cookie", r.opt.HTTPCookie)
+	}
+	// Set from env var if appropriate
+	httpCookie := os.Getenv("DESYNC_HTTP_COOKIE")
+	if len(httpCookie) != 0 {
+		req.Header.Set("Cookie", httpCookie)
 	}
 
 	log.Debug("sending request")

--- a/store.go
+++ b/store.go
@@ -64,6 +64,9 @@ type StoreOptions struct {
 	// Authorization header value for HTTP stores
 	HTTPAuth string `json:"http-auth,omitempty"`
 
+	// Cookie header value for HTTP stores
+	HTTPCookie string `json:"http-cookie,omitempty"`
+
 	// Timeout for waiting for objects to be retrieved. Infinite if negative. Default: 1 minute
 	Timeout time.Duration `json:"timeout,omitempty"`
 


### PR DESCRIPTION
Adds a `HTTPCookie` option to the RemoteHttpStore.

Allows use of desync with a Google Cloud CDN that uses the [Signed Cookies](https://cloud.google.com/cdn/docs/using-signed-cookies) feature.