### PR TITLE
Support passing AWS session token via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ cd desync/cmd/desync && go install
 
 - `CASYNC_SSH_PATH` overrides the default "ssh" with a command to run when connecting to a remote SSH or SFTP chunk store
 - `CASYNC_REMOTE_PATH` defines the command to run on the chunk store when using SSH, default "casync"
-- `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_SESSION_TOKEN`, `S3_REGION` can be used to define S3 store credentials if only one store is used. Caution, these values take precedence over any S3 credentials set in the config file.
+- `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_SESSION_TOKEN`, `S3_REGION` can be used to define S3 store credentials if only one store is used. If `S3_ACCESS_KEY` and `S3_SECRET_KEY` are not defined, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` are also considered. Caution, these values take precedence over any S3 credentials set in the config file.
 - `DESYNC_PROGRESSBAR_ENABLED` enables the progress bar if set to anything other than an empty string. By default, the progressbar is only turned on if STDERR is found to be a terminal.
 - `DESYNC_ENABLE_PARSABLE_PROGRESS` prints in STDERR the current operation name, the completed percentage and the estimated remaining time if it is set to anything other than an empty string. This is similar to the default progress bar but without the actual bar.
 - `DESYNC_HTTP_AUTH` sets the expected value in the HTTP Authorization header from clients when using `chunk-server` or `index-server`. It needs to be the full string, with type and encoding like `"Basic dXNlcjpwYXNzd29yZAo="`. Any authorization value provided in the command line takes precedence over the environment variable.

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ cd desync/cmd/desync && go install
 
 - `CASYNC_SSH_PATH` overrides the default "ssh" with a command to run when connecting to a remote SSH or SFTP chunk store
 - `CASYNC_REMOTE_PATH` defines the command to run on the chunk store when using SSH, default "casync"
-- `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_REGION` can be used to define S3 store credentials if only one store is used. Caution, these values take precedence over any S3 credentials set in the config file.
+- `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_SESSION_TOKEN`, `S3_REGION` can be used to define S3 store credentials if only one store is used. Caution, these values take precedence over any S3 credentials set in the config file.
 - `DESYNC_PROGRESSBAR_ENABLED` enables the progress bar if set to anything other than an empty string. By default, the progressbar is only turned on if STDERR is found to be a terminal.
 - `DESYNC_ENABLE_PARSABLE_PROGRESS` prints in STDERR the current operation name, the completed percentage and the estimated remaining time if it is set to anything other than an empty string. This is similar to the default progress bar but without the actual bar.
 - `DESYNC_HTTP_AUTH` sets the expected value in the HTTP Authorization header from clients when using `chunk-server` or `index-server`. It needs to be the full string, with type and encoding like `"Basic dXNlcjpwYXNzd29yZAo="`. Any authorization value provided in the command line takes precedence over the environment variable.
@@ -184,7 +184,7 @@ No file would need to be stored on disk in this case.
 
 ### S3 chunk stores
 
-desync supports reading from and writing to chunk stores that offer an S3 API, for example hosted in AWS or running on a local server. When using such a store, credentials are passed into the tool either via environment variables `S3_ACCESS_KEY` and `S3_SECRET_KEY` or, if multiples are required, in the config file. Care is required when building those URLs. Below a few examples:
+desync supports reading from and writing to chunk stores that offer an S3 API, for example hosted in AWS or running on a local server. When using such a store, credentials are passed into the tool either via environment variables `S3_ACCESS_KEY`, `S3_SECRET_KEY` and `S3_SESSION_TOKEN` (if needed) or, if multiples are required, in the config file. Care is required when building those URLs. Below a few examples:
 
 #### AWS
 

--- a/cmd/desync/config.go
+++ b/cmd/desync/config.go
@@ -48,6 +48,11 @@ func (c Config) GetS3CredentialsFor(u *url.URL) (*credentials.Credentials, strin
 	region := os.Getenv("S3_REGION")
 	secretKey := os.Getenv("S3_SECRET_KEY")
 	sessionToken := os.Getenv("S3_SESSION_TOKEN")
+	if accessKey == "" && secretKey == "" {
+		accessKey = os.Getenv("AWS_ACCESS_KEY_ID")
+		secretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
+		sessionToken = os.Getenv("AWS_SESSION_TOKEN")
+	}
 	if accessKey != "" || secretKey != "" {
 		return NewStaticCredentials(accessKey, secretKey, sessionToken), region
 	}

--- a/cmd/desync/config.go
+++ b/cmd/desync/config.go
@@ -47,8 +47,9 @@ func (c Config) GetS3CredentialsFor(u *url.URL) (*credentials.Credentials, strin
 	accessKey := os.Getenv("S3_ACCESS_KEY")
 	region := os.Getenv("S3_REGION")
 	secretKey := os.Getenv("S3_SECRET_KEY")
+	sessionToken := os.Getenv("S3_SESSION_TOKEN")
 	if accessKey != "" || secretKey != "" {
-		return NewStaticCredentials(accessKey, secretKey), region
+		return NewStaticCredentials(accessKey, secretKey, sessionToken), region
 	}
 
 	// Look in the config to find a match for scheme+host
@@ -57,12 +58,12 @@ func (c Config) GetS3CredentialsFor(u *url.URL) (*credentials.Credentials, strin
 		Host:   u.Host,
 	}
 	credsConfig := c.S3Credentials[key.String()]
-	creds := NewStaticCredentials("", "")
+	creds := NewStaticCredentials("", "", "")
 	region = credsConfig.AwsRegion
 
 	// if access access-key is present, it takes precedence
 	if credsConfig.AccessKey != "" {
-		creds = NewStaticCredentials(credsConfig.AccessKey, credsConfig.SecretKey)
+		creds = NewStaticCredentials(credsConfig.AccessKey, credsConfig.SecretKey, "")
 	} else if credsConfig.AwsCredentialsFile != "" {
 		creds = NewRefreshableSharedCredentials(credsConfig.AwsCredentialsFile, credsConfig.AwsProfile, time.Now)
 	}

--- a/cmd/desync/credentials.go
+++ b/cmd/desync/credentials.go
@@ -42,11 +42,12 @@ func (cp *StaticCredentialsProvider) Retrieve() (credentials.Value, error) {
 }
 
 // NewStaticCredentials initializes a new set of S3 credentials
-func NewStaticCredentials(accessKey, secretKey string) *credentials.Credentials {
+func NewStaticCredentials(accessKey, secretKey, sessionToken string) *credentials.Credentials {
 	p := &StaticCredentialsProvider{
 		credentials.Value{
 			AccessKeyID:     accessKey,
 			SecretAccessKey: secretKey,
+			SessionToken:    sessionToken,
 		},
 	}
 	return credentials.New(p)


### PR DESCRIPTION
desync already supports taking `aws_session_token` from shared credentials file, but it is not convenient to store token there if it is received by another application that will call desync. This commit allows to pass session token via environment variable like other credentials.

Also while we there, lets add support for the same environment variables as AWS CLI and AWS SDKs accept.

Co-authored-by: Aleksejs Lucko <lu4ik@yandex-team.ru>