### PR TITLE
Fix untar progress percentage

### DIFF
--- a/cmd/desync/untar.go
+++ b/cmd/desync/untar.go
@@ -104,9 +104,9 @@ func runUntar(ctx context.Context, opt untarOptions, args []string) error {
 		if err != nil {
 			return err
 		}
+		pb.SetTotal(int(info.Size()))
 		pb.Start()
 		defer pb.Finish()
-		pb.SetTotal(int(info.Size()))
 		r = io.TeeReader(f, pb)
 		return desync.UnTar(ctx, r, fs)
 	}


### PR DESCRIPTION
If we start the progress bar before setting its total size, the progress bar will keep by default a hidden progress percentage. So we will only get the progress animation without the written percentage.

To fix that we should instead set the total before starting the pb.