### PR TITLE
Fix error type from HTTP stores

### DIFF
--- a/remotehttp.go
+++ b/remotehttp.go
@@ -216,6 +216,10 @@ func (r *RemoteHTTP) GetChunk(id ChunkID) (*Chunk, error) {
 	p := r.nameFromID(id)
 	b, err := r.GetObject(p)
 	if err != nil {
+		// The base returns NoSuchObject, but it has to be ChunkMissing for routers to work
+		if _, ok := err.(NoSuchObject); ok {
+			return nil, ChunkMissing{id}
+		}
 		return nil, err
 	}
 	return NewChunkFromStorage(id, b, r.converters, r.opt.SkipVerify)


### PR DESCRIPTION
Fixes https://github.com/folbricht/desync/issues/238

The base-http handler would return `NoSuchObject` for a chunk not found in the store, but for routers to work this needs to be mapped to `ChunkMissing`.