### PR TITLE
Add information about the cache

### DIFF
--- a/cmd/desync/info_test.go
+++ b/cmd/desync/info_test.go
@@ -16,8 +16,11 @@ func TestInfoCommand(t *testing.T) {
 		"unique": 131,
 		"in-store": 131,
 		"in-seed": 0,
+		"in-cache": 0,
+		"not-in-seed-nor-cache": 131,
 		"size": 2097152,
 		"dedup-size-not-in-seed": 1114112,
+		"dedup-size-not-in-seed-nor-cache": 1114112,
 		"chunk-size-min": 2048,
 		"chunk-size-avg": 8192,
 		"chunk-size-max": 32768
@@ -49,8 +52,11 @@ func TestInfoCommandWithSeed(t *testing.T) {
 		"unique": 131,
 		"in-store": 131,
 		"in-seed": 124,
+		"in-cache": 0,
+		"not-in-seed-nor-cache": 7,
 		"size": 2097152,
 		"dedup-size-not-in-seed": 80029,
+		"dedup-size-not-in-seed-nor-cache": 80029,
 		"chunk-size-min": 2048,
 		"chunk-size-avg": 8192,
 		"chunk-size-max": 32768
@@ -64,6 +70,47 @@ func TestInfoCommandWithSeed(t *testing.T) {
 		"-s", "testdata/blob1.store",
 		"--seed", "testdata/blob2.caibx",
 		"testdata/blob1.caibx",
+	})
+	b := new(bytes.Buffer)
+
+	// Redirect the command's output
+	stdout = b
+	cmd.SetOutput(ioutil.Discard)
+	_, err = cmd.ExecuteC()
+	require.NoError(t, err)
+
+	// Decode the output and compare to what's expected
+	got := make(map[string]interface{})
+	err = json.Unmarshal(b.Bytes(), &got)
+	require.NoError(t, err)
+	require.Equal(t, exp, got)
+}
+
+func TestInfoCommandWithSeedAndCache(t *testing.T) {
+	expectedOutput := []byte(`{
+		"total": 161,
+		"unique": 131,
+		"in-store": 131,
+		"in-seed": 124,
+		"in-cache": 18,
+		"not-in-seed-nor-cache": 5,
+		"size": 2097152,
+		"dedup-size-not-in-seed": 80029,
+		"dedup-size-not-in-seed-nor-cache": 67099,
+		"chunk-size-min": 2048,
+		"chunk-size-avg": 8192,
+		"chunk-size-max": 32768
+	}`)
+	exp := make(map[string]interface{})
+	err := json.Unmarshal(expectedOutput, &exp)
+	require.NoError(t, err)
+
+	cmd := newInfoCommand(context.Background())
+	cmd.SetArgs([]string{
+		"-s", "testdata/blob2.store",
+		"--seed", "testdata/blob1.caibx",
+		"--cache", "testdata/blob2.cache",
+		"testdata/blob2.caibx",
 	})
 	b := new(bytes.Buffer)
 

--- a/cmd/desync/info_test.go
+++ b/cmd/desync/info_test.go
@@ -64,6 +64,22 @@ func TestInfoCommand(t *testing.T) {
 				"chunk-size-avg": 8192,
 				"chunk-size-max": 32768
 			}`)},
+		{"info command with cache",
+			[]string{"-s", "testdata/blob2.store", "--cache", "testdata/blob2.cache", "testdata/blob2.caibx"},
+			[]byte(`{
+				"total": 161,
+				"unique": 131,
+				"in-store": 131,
+				"in-seed": 0,
+				"in-cache": 18,
+				"not-in-seed-nor-cache": 113,
+				"size": 2097152,
+				"dedup-size-not-in-seed": 1114112,
+				"dedup-size-not-in-seed-nor-cache": 950410,
+				"chunk-size-min": 2048,
+				"chunk-size-avg": 8192,
+				"chunk-size-max": 32768
+			}`)},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			exp := make(map[string]interface{})

--- a/cmd/desync/info_test.go
+++ b/cmd/desync/info_test.go
@@ -11,118 +11,80 @@ import (
 )
 
 func TestInfoCommand(t *testing.T) {
-	expectedOutput := []byte(`{
-		"total": 161,
-		"unique": 131,
-		"in-store": 131,
-		"in-seed": 0,
-		"in-cache": 0,
-		"not-in-seed-nor-cache": 131,
-		"size": 2097152,
-		"dedup-size-not-in-seed": 1114112,
-		"dedup-size-not-in-seed-nor-cache": 1114112,
-		"chunk-size-min": 2048,
-		"chunk-size-avg": 8192,
-		"chunk-size-max": 32768
-	}`)
-	exp := make(map[string]interface{})
-	err := json.Unmarshal(expectedOutput, &exp)
-	require.NoError(t, err)
+	for _, test := range []struct {
+		name           string
+		args           []string
+		expectedOutput []byte
+	}{
+		{"info command with store",
+			[]string{"-s", "testdata/blob1.store", "testdata/blob1.caibx"},
+			[]byte(`{
+				"total": 161,
+				"unique": 131,
+				"in-store": 131,
+				"in-seed": 0,
+				"in-cache": 0,
+				"not-in-seed-nor-cache": 131,
+				"size": 2097152,
+				"dedup-size-not-in-seed": 1114112,
+				"dedup-size-not-in-seed-nor-cache": 1114112,
+				"chunk-size-min": 2048,
+				"chunk-size-avg": 8192,
+				"chunk-size-max": 32768
+			}`)},
+		{"info command with seed",
+			[]string{"-s", "testdata/blob1.store", "--seed", "testdata/blob2.caibx", "testdata/blob1.caibx"},
+			[]byte(`{
+				"total": 161,
+				"unique": 131,
+				"in-store": 131,
+				"in-seed": 124,
+				"in-cache": 0,
+				"not-in-seed-nor-cache": 7,
+				"size": 2097152,
+				"dedup-size-not-in-seed": 80029,
+				"dedup-size-not-in-seed-nor-cache": 80029,
+				"chunk-size-min": 2048,
+				"chunk-size-avg": 8192,
+				"chunk-size-max": 32768
+			}`)},
+		{"info command with seed and cache",
+			[]string{"-s", "testdata/blob2.store", "--seed", "testdata/blob1.caibx", "--cache", "testdata/blob2.cache", "testdata/blob2.caibx"},
+			[]byte(`{
+				"total": 161,
+				"unique": 131,
+				"in-store": 131,
+				"in-seed": 124,
+				"in-cache": 18,
+				"not-in-seed-nor-cache": 5,
+				"size": 2097152,
+				"dedup-size-not-in-seed": 80029,
+				"dedup-size-not-in-seed-nor-cache": 67099,
+				"chunk-size-min": 2048,
+				"chunk-size-avg": 8192,
+				"chunk-size-max": 32768
+			}`)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			exp := make(map[string]interface{})
+			err := json.Unmarshal(test.expectedOutput, &exp)
+			require.NoError(t, err)
 
-	cmd := newInfoCommand(context.Background())
-	cmd.SetArgs([]string{"-s", "testdata/blob1.store", "testdata/blob1.caibx"})
-	b := new(bytes.Buffer)
+			cmd := newInfoCommand(context.Background())
+			cmd.SetArgs(test.args)
+			b := new(bytes.Buffer)
 
-	// Redirect the command's output
-	stdout = b
-	cmd.SetOutput(ioutil.Discard)
-	_, err = cmd.ExecuteC()
-	require.NoError(t, err)
+			// Redirect the command's output
+			stdout = b
+			cmd.SetOutput(ioutil.Discard)
+			_, err = cmd.ExecuteC()
+			require.NoError(t, err)
 
-	// Decode the output and compare to what's expected
-	got := make(map[string]interface{})
-	err = json.Unmarshal(b.Bytes(), &got)
-	require.NoError(t, err)
-	require.Equal(t, exp, got)
-}
-
-func TestInfoCommandWithSeed(t *testing.T) {
-	expectedOutput := []byte(`{
-		"total": 161,
-		"unique": 131,
-		"in-store": 131,
-		"in-seed": 124,
-		"in-cache": 0,
-		"not-in-seed-nor-cache": 7,
-		"size": 2097152,
-		"dedup-size-not-in-seed": 80029,
-		"dedup-size-not-in-seed-nor-cache": 80029,
-		"chunk-size-min": 2048,
-		"chunk-size-avg": 8192,
-		"chunk-size-max": 32768
-	}`)
-	exp := make(map[string]interface{})
-	err := json.Unmarshal(expectedOutput, &exp)
-	require.NoError(t, err)
-
-	cmd := newInfoCommand(context.Background())
-	cmd.SetArgs([]string{
-		"-s", "testdata/blob1.store",
-		"--seed", "testdata/blob2.caibx",
-		"testdata/blob1.caibx",
-	})
-	b := new(bytes.Buffer)
-
-	// Redirect the command's output
-	stdout = b
-	cmd.SetOutput(ioutil.Discard)
-	_, err = cmd.ExecuteC()
-	require.NoError(t, err)
-
-	// Decode the output and compare to what's expected
-	got := make(map[string]interface{})
-	err = json.Unmarshal(b.Bytes(), &got)
-	require.NoError(t, err)
-	require.Equal(t, exp, got)
-}
-
-func TestInfoCommandWithSeedAndCache(t *testing.T) {
-	expectedOutput := []byte(`{
-		"total": 161,
-		"unique": 131,
-		"in-store": 131,
-		"in-seed": 124,
-		"in-cache": 18,
-		"not-in-seed-nor-cache": 5,
-		"size": 2097152,
-		"dedup-size-not-in-seed": 80029,
-		"dedup-size-not-in-seed-nor-cache": 67099,
-		"chunk-size-min": 2048,
-		"chunk-size-avg": 8192,
-		"chunk-size-max": 32768
-	}`)
-	exp := make(map[string]interface{})
-	err := json.Unmarshal(expectedOutput, &exp)
-	require.NoError(t, err)
-
-	cmd := newInfoCommand(context.Background())
-	cmd.SetArgs([]string{
-		"-s", "testdata/blob2.store",
-		"--seed", "testdata/blob1.caibx",
-		"--cache", "testdata/blob2.cache",
-		"testdata/blob2.caibx",
-	})
-	b := new(bytes.Buffer)
-
-	// Redirect the command's output
-	stdout = b
-	cmd.SetOutput(ioutil.Discard)
-	_, err = cmd.ExecuteC()
-	require.NoError(t, err)
-
-	// Decode the output and compare to what's expected
-	got := make(map[string]interface{})
-	err = json.Unmarshal(b.Bytes(), &got)
-	require.NoError(t, err)
-	require.Equal(t, exp, got)
+			// Decode the output and compare to what's expected
+			got := make(map[string]interface{})
+			err = json.Unmarshal(b.Bytes(), &got)
+			require.NoError(t, err)
+			require.Equal(t, exp, got)
+		})
+	}
 }


### PR DESCRIPTION
- Add information about the cache

  When using `desync info` it might be useful to have additional
information regarding your local cache.

  For example knowing the amount of chunks that can be picked up by your
cache can be used as a metric to ensure the cache is actually working as
expected.

  With this commit we add `in-cache` to print the number of chunks that
the cache already has, `not-in-seed-nor-cache` with the number of chunks
that needs to be downloaded from the store and finally
`dedup-size-not-in-seed-nor-cache` with the size of the chunks that
needs to be downloaded from the store.

- Reduce code duplication in info_test
- Add info test with cache and without a seed