### PR TITLE
Adds basic pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-added-large-files
+
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: master
+    hooks:
+      - id: go-fmt
+      #- id: go-vet
+      #- id: go-imports
+      #- id: golangci-lint
+      #- id: go-critic
+      #- id: go-unit-tests
+      - id: go-build
+      - id: go-mod-tidy


### PR DESCRIPTION
I continually forget to do things before commit, in most projects I rely on pre-commit (maybe to my detriment).

This adds a basic pre-commit script. https://pre-commit.com/
This is completely opt in. If a user doesn't use pre-commit. Then nothing happens locally or in ci. 

I only selected the least opinionated of all available hooks. I left the opinionated hooks in, if those are something you'd want for the project.

The unit test hook is currently commented out because of a failing cmd unit-test. It should be re-enabled.

```
bearrito@home:~/Git/desync/cmd/desync$ pre-commit run
[WARNING] Unstaged files detected.
[INFO] Stashing unstaged files to /home/bstrausser/.cache/pre-commit/patch1709692795-3024168.
[WARNING] The 'rev' field of repo 'https://github.com/dnephin/pre-commit-golang' appears to be a mutable reference (moving tag / branch).  Mutable references are never updated after first install and are not supported.  See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details.  Hint: `pre-commit autoupdate` often fixes this.
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check for added large files..............................................Passed
go fmt...................................................................Passed
go-build.................................................................Passed
go-mod-tidy..............................................................Passed
```