### PR TITLE
Fix printing of ChunkIDs

### DIFF
--- a/cmd/desync/list.go
+++ b/cmd/desync/list.go
@@ -43,7 +43,7 @@ func runList(ctx context.Context, opt listOptions, args []string) error {
 	}
 	// Write the list of chunk IDs to STDOUT
 	for _, chunk := range c.Chunks {
-		fmt.Fprintln(stdout, chunk.ID)
+		fmt.Fprintln(stdout, chunk.ID.String())
 		// See if we're meant to stop
 		select {
 		case <-ctx.Done():

--- a/cmd/desync/list_test.go
+++ b/cmd/desync/list_test.go
@@ -25,7 +25,6 @@ func TestListCommand(t *testing.T) {
 	// Make sure we have some data, and that it's all valid chunk IDs
 	require.NotZero(t, b.Len())
 	scanner := bufio.NewScanner(b)
-
 	for scanner.Scan() {
 		_, err := desync.ChunkIDFromString(scanner.Text())
 		require.NoError(t, err)

--- a/cmd/desync/list_test.go
+++ b/cmd/desync/list_test.go
@@ -25,6 +25,7 @@ func TestListCommand(t *testing.T) {
 	// Make sure we have some data, and that it's all valid chunk IDs
 	require.NotZero(t, b.Len())
 	scanner := bufio.NewScanner(b)
+
 	for scanner.Scan() {
 		_, err := desync.ChunkIDFromString(scanner.Text())
 		require.NoError(t, err)

--- a/errors.go
+++ b/errors.go
@@ -27,7 +27,7 @@ type ChunkInvalid struct {
 }
 
 func (e ChunkInvalid) Error() string {
-	return fmt.Sprintf("chunk id %s does not match its hash %s", e.ID, e.Sum)
+	return fmt.Sprintf("chunk id %s does not match its hash %s", e.ID.String(), e.Sum.String())
 }
 
 // InvalidFormat is returned when an error occurred when parsing an archive file


### PR DESCRIPTION
Fixes printing after https://github.com/folbricht/desync/commit/0260be97af4d1149e32c5a0936cd14e0aeb1cc64 added a `String()` method to the ChunkID, altering how it's marshaled as per #277 