### PR TITLE
Additional fixes for the ChunkIDs print

### DIFF
--- a/assemble.go
+++ b/assemble.go
@@ -68,7 +68,7 @@ func writeChunk(c IndexChunk, ss *selfSeed, f *os.File, blocksize uint64, s Stor
 	}
 	// Might as well verify the chunk size while we're at it
 	if c.Size != uint64(len(b)) {
-		return fmt.Errorf("unexpected size for chunk %s", c.ID)
+		return fmt.Errorf("unexpected size for chunk %s", c.ID.String())
 	}
 	// Write the decompressed chunk into the file at the right position
 	if _, err = f.WriteAt(b, int64(c.Start)); err != nil {
@@ -190,7 +190,7 @@ func AssembleFile(ctx context.Context, name string, idx Index, s Store, seeds []
 						if sum != c.ID {
 							if options.InvalidSeedAction == InvalidSeedActionRegenerate {
 								// Try harder before giving up and aborting
-								Log.WithField("ID", c.ID).Info("The seed may have changed during processing, trying to take the chunk from the self seed or the store")
+								Log.WithField("ID", c.ID.String()).Info("The seed may have changed during processing, trying to take the chunk from the self seed or the store")
 								if err := writeChunk(c, ss, f, blocksize, s, stats, isBlank); err != nil {
 									return err
 								}

--- a/errors.go
+++ b/errors.go
@@ -13,7 +13,7 @@ type NoSuchObject struct {
 }
 
 func (e ChunkMissing) Error() string {
-	return fmt.Sprintf("chunk %s missing from store", e.ID)
+	return fmt.Sprintf("chunk %s missing from store", e.ID.String())
 }
 
 func (e NoSuchObject) Error() string {

--- a/untar.go
+++ b/untar.go
@@ -88,7 +88,7 @@ func UnTarIndex(ctx context.Context, fs FilesystemWriter, index Index, s Store, 
 				// Might as well verify the chunk size while we're at it
 				if r.chunk.Size != uint64(len(b)) {
 					close(r.data)
-					return fmt.Errorf("unexpected size for chunk %s", r.chunk.ID)
+					return fmt.Errorf("unexpected size for chunk %s", r.chunk.ID.String())
 				}
 				r.data <- b
 				close(r.data)


### PR DESCRIPTION
Add `.String()` every time we try to print a chunk ID.

Part of https://github.com/folbricht/desync/issues/277