### PR TITLE
Allow `chunk`/`make` to accept `-` as a shorthand for reading from `stdin`

### DIFF
--- a/cmd/desync/chunk.go
+++ b/cmd/desync/chunk.go
@@ -43,12 +43,17 @@ func runChunk(ctx context.Context, opt chunkOptions, args []string) error {
 
 	dataFile := args[0]
 
-	// Open the blob
-	f, err := os.Open(dataFile)
-	if err != nil {
-		return err
+	var f *os.File
+	if dataFile == "-" {
+		f = os.Stdin
+	} else {
+		// Open the blob
+		f, err = os.Open(dataFile)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
 	}
-	defer f.Close()
 	s, err := f.Seek(int64(opt.startPos), io.SeekStart)
 	if err != nil {
 		return err


### PR DESCRIPTION
This extends the `chunk` and `make` commands to be able to read from stdin when `-` is passed as a filename, as is UNIX tradition.  Note that this implementation is purposefully quite basic and straightforward; when reading from stdin all concurrency is disabled for `make`, and `catar` input is not handled the same way due to the need to parse the header first.  For my purposes (which always deals with blobs rather than `catar` inputs, this is sufficient, however if there's a simple way to allow peeking the input stream then feeding it in to be hashed again, I'm happy to include it here.