### PR TITLE
Support OCI registries for chunk storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Reading a chunk takes two requests (manifest by tag, then blob), an existence ch
 Credentials are looked up in the following order, first match wins:
 
 1. The `DESYNC_OCI_USERNAME` and `DESYNC_OCI_PASSWORD` environment variables. Convenient in CI, e.g. with the ephemeral `GITHUB_TOKEN` in GitHub Actions.
-2. The `oci-credentials` section of the config file (see [Configuration](#configuration)), keyed by host and repository with glob support.
+2. The `oci-credentials` section of the config file (see [Configuration](#configuration)), keyed by the full store URL with glob support, the same format as `store-options` keys.
 3. The Docker credential store. If you're logged in with `docker login ghcr.io` or `oras login ghcr.io`, desync picks those credentials up without any configuration.
 
 Anonymous access works for public repositories, so extracting from a public store needs no credentials at all. For ghcr.io, pushing requires a token with the `write:packages` scope, and note that new ghcr.io packages default to private visibility.
@@ -339,7 +339,7 @@ The usual [store options](#configuration-reference) apply, keyed by the full sto
 
 #### Pruning
 
-`desync prune` deletes the manifests of all chunks not referenced by the given indexes. Only tags that parse as chunk IDs are considered. Reclaiming the space held by the then-unreferenced blobs is left to the registry's own garbage collection. Manifest deletion is not supported by every registry: the distribution registry requires it to be enabled with `REGISTRY_STORAGE_DELETE_ENABLED=true`, and ghcr.io only supports deletion through the GitHub Packages API, not the registry API — for ghcr.io, use a cleanup action for untagged/unwanted versions instead.
+`desync prune` deletes the manifests of all chunks not referenced by the given indexes. Only tags that parse as chunk IDs are considered, and of those only manifests with the desync chunk artifact type are deleted, so an unrelated artifact tagged with a chunk-ID-shaped hex string is safe. Reclaiming the space held by the then-unreferenced blobs is left to the registry's own garbage collection. Manifest deletion is not supported by every registry: the distribution registry requires it to be enabled with `REGISTRY_STORAGE_DELETE_ENABLED=true`, and ghcr.io only supports deletion through the GitHub Packages API, not the registry API — for ghcr.io, use a cleanup action for untagged/unwanted versions instead.
 
 #### Examples
 
@@ -620,7 +620,7 @@ This can be combined with store failover by providing the same syntax as used in
 
 - **`s3-credentials`** — Credentials for S3 stores. The key must be the URL scheme and host used for the store, excluding the path, but including the port if used in the store URL. Keys can contain glob patterns (`*`, `?`, `[…]`). See [filepath.Match](https://pkg.go.dev/path/filepath#Match) for wildcard details. Standard [AWS credentials files](https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html) are also supported.
 
-- **`oci-credentials`** — Credentials for OCI registry stores. The key must be the registry host and repository path, excluding the URL scheme, e.g. `ghcr.io/myuser/repo`. Keys can contain glob patterns. If no entry matches and no credentials are set in the environment, the Docker credential store is used, so registries logged into with `docker login` or `oras login` are picked up automatically.
+- **`oci-credentials`** — Credentials for OCI registry stores. The key must be the store URL, e.g. `oci+https://ghcr.io/myuser/repo`, the same format as `store-options` keys. Keys can contain glob patterns. If no entry matches and no credentials are set in the environment, the Docker credential store is used, so registries logged into with `docker login` or `oras login` are picked up automatically.
 
 - **`store-options`** — Per-store customization of compression, timeouts, retry behavior, and keys. Not all options apply to every store type. The store location in the command line must match the key exactly for options to apply. Glob patterns are also supported; a config file where more than one key matches a single store is considered invalid.
 
@@ -669,7 +669,7 @@ This can be combined with store failover by providing the same syntax as used in
        }
   },
   "oci-credentials": {
-    "ghcr.io/myuser/repo": {
+    "oci+https://ghcr.io/myuser/repo": {
       "username": "myuser",
       "secret": "MYSECRET"
     }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ desync is a Go library and CLI tool that re-implements [casync](https://github.c
 ## Key Features
 
 - **Parallel chunking** — identical output to casync, up to 10x faster
-- **Multiple store backends** — local, HTTP(S), S3/GCS, SFTP, SSH
+- **Multiple store backends** — local, HTTP(S), S3/GCS, SFTP, SSH, OCI registries
 - **Store chaining and caching** — combine stores with failover groups
 - **Seeds and reflinks** — clone blocks from existing files on Btrfs/XFS
 - **Built-in servers** — HTTP(S) chunk server and index server with proxy support
@@ -35,6 +35,7 @@ desync is a Go library and CLI tool that re-implements [casync](https://github.c
   - [Chaining and Caching](#chaining-and-caching)
   - [Failover Groups](#failover-groups)
   - [S3 Store URLs](#s3-store-urls)
+  - [OCI Registry Stores](#oci-registry-stores)
   - [Compressed vs Uncompressed](#compressed-vs-uncompressed)
   - [Chunk Encryption](#chunk-encryption)
   - [Remote Indexes](#remote-indexes)
@@ -258,6 +259,19 @@ s3+http://127.0.0.1:9000/bucket/prefix?lookup=path
 s3+https://s3.internal.company/bucket/prefix?lookup=dns
 s3+https://example.com/bucket/prefix?lookup=auto
 ```
+
+</details>
+
+<details>
+<summary><h3>OCI Registry Stores</h3></summary>
+
+OCI registries can be used to store chunks, using [ORAS](https://oras.land/docs/) to treat the registry as content-addressable storage. Use the `oci+https` scheme when pointing at OCI stores. If the store does not support TLS, use `oci+http` instead.
+
+```text
+oci+https://ghcr.io/myuser/repo
+```
+
+Since the OCI specification identifies blobs by SHA256 digest, OCI stores require desync to run with `--digest=sha256` instead of the default SHA512/256. Credentials are provided via the `oci-credentials` section of the config file (see [Configuration](#configuration)).
 
 </details>
 
@@ -497,6 +511,8 @@ This can be combined with store failover by providing the same syntax as used in
 
 - **`s3-credentials`** — Credentials for S3 stores. The key must be the URL scheme and host used for the store, excluding the path, but including the port if used in the store URL. Keys can contain glob patterns (`*`, `?`, `[…]`). See [filepath.Match](https://pkg.go.dev/path/filepath#Match) for wildcard details. Standard [AWS credentials files](https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html) are also supported.
 
+- **`oci-credentials`** — Credentials for OCI registry stores. The key must be the registry host and repository path, excluding the URL scheme, e.g. `ghcr.io/myuser/repo`.
+
 - **`store-options`** — Per-store customization of compression, timeouts, retry behavior, and keys. Not all options apply to every store type. The store location in the command line must match the key exactly for options to apply. Glob patterns are also supported; a config file where more than one key matches a single store is considered invalid.
 
   | Option | Description | Default |
@@ -542,6 +558,12 @@ This can be combined with store failover by providing the same syntax as used in
            "aws-region": "us-west-2",
            "aws-profile": "profile_refreshable"
        }
+  },
+  "oci-credentials": {
+    "ghcr.io/myuser/repo": {
+      "username": "myuser",
+      "secret": "MYSECRET"
+    }
   },
   "store-options": {
     "https://192.168.1.1/store": {

--- a/README.md
+++ b/README.md
@@ -170,13 +170,13 @@ catar archives can also be extracted to GNU tar archive streams. All files in th
 
 ### Capabilities
 
-| Operation | Local | S3 | GCS | HTTP | SFTP | SSH (casync protocol) |
-| --- | :---: | :---: | :---: | :---: | :---: | :---: |
-| Read chunks | yes | yes | yes | yes | yes | yes |
-| Write chunks | yes | yes | yes | yes | yes | no |
-| Use as cache | yes | yes | yes | yes | yes | no |
-| Prune | yes | yes | yes | no | yes | no |
-| Verify | yes | no | no | no | no | no |
+| Operation | Local | S3 | GCS | HTTP | SFTP | SSH (casync protocol) | OCI registry |
+| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| Read chunks | yes | yes | yes | yes | yes | yes | yes |
+| Write chunks | yes | yes | yes | yes | yes | no | yes |
+| Use as cache | yes | yes | yes | yes | yes | no | yes |
+| Prune | yes | yes | yes | no | yes | no | no |
+| Verify | yes | no | no | no | no | no | no |
 
 ### Store Architecture
 
@@ -271,7 +271,9 @@ OCI registries can be used to store chunks, using [ORAS](https://oras.land/docs/
 oci+https://ghcr.io/myuser/repo
 ```
 
-Since the OCI specification identifies blobs by SHA256 digest, OCI stores require desync to run with `--digest=sha256` instead of the default SHA512/256. Chunks are stored as blobs whose digest is the chunk ID. Registries verify that uploaded content matches the declared digest, so chunks are always stored uncompressed in OCI stores, regardless of the `uncompressed` store option. Credentials are provided via the `oci-credentials` section of the config file (see [Configuration](#configuration)).
+Every chunk is stored as its own artifact: a blob holding the chunk data (compressed unless the store is configured with `uncompressed`), referenced by a small manifest that is tagged with the chunk ID. Since the chunk ID appears only in the tag, the store works with desync's default SHA512/256 digest algorithm as well as SHA256, and the tagged manifest protects the chunk from registry garbage collection of unreferenced blobs. Reading a chunk takes two requests (manifest, then blob) and writing takes three, so combining a registry store with a local cache is recommended more than for most other store types.
+
+Credentials are looked up in this order: the `DESYNC_OCI_USERNAME` and `DESYNC_OCI_PASSWORD` environment variables, the `oci-credentials` section of the config file (see [Configuration](#configuration)), and finally the Docker credential store — registries logged into with `docker login` or `oras login` work without any desync configuration.
 
 </details>
 
@@ -477,6 +479,7 @@ Not all options apply to all commands.
 | `CASYNC_SSH_PATH` | Overrides the default `ssh` command when connecting to remote SSH or SFTP chunk stores. |
 | `CASYNC_REMOTE_PATH` | Defines the command to run on the chunk store when using SSH. Default: `casync`. |
 | `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_SESSION_TOKEN`, `S3_REGION` | S3 store credentials when using a single store. If `S3_ACCESS_KEY` and `S3_SECRET_KEY` are not defined, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` are also considered. These take precedence over config file values. |
+| `DESYNC_OCI_USERNAME`, `DESYNC_OCI_PASSWORD` | OCI registry store credentials. These take precedence over config file values and the Docker credential store. |
 | `DESYNC_PROGRESSBAR_ENABLED` | Enables the progress bar if set to any non-empty value. By default, the progress bar is only shown when STDERR is a terminal. |
 | `DESYNC_ENABLE_PARSABLE_PROGRESS` | Prints operation name, completion percentage, and estimated remaining time to STDERR. Similar to the default progress bar but without the visual bar. |
 | `DESYNC_HTTP_AUTH` | Sets the expected `Authorization` header value from clients when using `chunk-server` or `index-server`. Needs the full string including type and encoding, e.g. `"Basic dXNlcjpwYXNzd29yZAo="`. Command-line values take precedence. |
@@ -511,7 +514,7 @@ This can be combined with store failover by providing the same syntax as used in
 
 - **`s3-credentials`** — Credentials for S3 stores. The key must be the URL scheme and host used for the store, excluding the path, but including the port if used in the store URL. Keys can contain glob patterns (`*`, `?`, `[…]`). See [filepath.Match](https://pkg.go.dev/path/filepath#Match) for wildcard details. Standard [AWS credentials files](https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html) are also supported.
 
-- **`oci-credentials`** — Credentials for OCI registry stores. The key must be the registry host and repository path, excluding the URL scheme, e.g. `ghcr.io/myuser/repo`.
+- **`oci-credentials`** — Credentials for OCI registry stores. The key must be the registry host and repository path, excluding the URL scheme, e.g. `ghcr.io/myuser/repo`. Keys can contain glob patterns. If no entry matches and no credentials are set in the environment, the Docker credential store is used, so registries logged into with `docker login` or `oras login` are picked up automatically.
 
 - **`store-options`** — Per-store customization of compression, timeouts, retry behavior, and keys. Not all options apply to every store type. The store location in the command line must match the key exactly for options to apply. Glob patterns are also supported; a config file where more than one key matches a single store is considered invalid.
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ An OCI store supports reading, writing, pruning, and use as a cache, so it works
 
 #### How chunks are stored
 
-Every chunk is stored as its own small OCI artifact consisting of a blob holding the chunk data — compressed with zstd unless the store is configured with `uncompressed` — and a manifest referencing that blob, tagged with the chunk ID in hex. A chunk artifact looks like this in the registry:
+Every chunk is stored as its own small OCI artifact consisting of a blob holding the chunk data — compressed and/or encrypted according to the store options — and a manifest referencing that blob. The manifest is tagged with the chunk ID in hex followed by the storage extension, the same naming used for chunk files in other stores, e.g. `<id>.cacnk` for a compressed store or `<id>.cacnk.xchacha20-poly1305-<keyid>` for a compressed and encrypted one (see [Chunk Encryption](#chunk-encryption)). Chunks in different formats or with different encryption keys can therefore coexist in one repository, and `prune` only considers chunks matching the store's own configuration. A chunk artifact looks like this in the registry:
 
 ```json
 {
@@ -303,7 +303,7 @@ Every chunk is stored as its own small OCI artifact consisting of a blob holding
 
 This layout has a few important properties:
 
-- The chunk ID appears only in the tag, never as a blob digest. OCI blob digests must be SHA256, so this is what allows the store to work with desync's default SHA512/256 digest algorithm and lets it be combined freely with other stores, caches, and existing indexes.
+- The chunk ID appears only in the tag, never as a blob digest. OCI blob digests must be SHA256, so this is what allows the store to work with desync's default SHA512/256 digest algorithm and lets it be combined freely with other stores, caches, and existing indexes. It is also what makes encryption possible: the registry digests and verifies the ciphertext.
 - Registries garbage-collect blobs that are not referenced by a manifest (and some, like ghcr.io, won't serve them at all). The tagged manifest keeps every chunk referenced and therefore safe.
 - Identical chunks pushed again reuse the same blob — registries deduplicate blobs by digest within a repository.
 

--- a/README.md
+++ b/README.md
@@ -265,17 +265,121 @@ s3+https://example.com/bucket/prefix?lookup=auto
 <details>
 <summary><h3>OCI Registry Stores</h3></summary>
 
-OCI registries can be used to store chunks, using [ORAS](https://oras.land/docs/) to treat the registry as content-addressable storage. Use the `oci+https` scheme when pointing at OCI stores. If the store does not support TLS, use `oci+http` instead.
+OCI container registries (ghcr.io, Docker Hub, Harbor, [zot](https://zothub.io), the [distribution registry](https://github.com/distribution/distribution), ...) can be used as chunk stores. Registries are widely available, often free or low cost, and typically sit behind a CDN, which makes them an attractive way to distribute chunks publicly without running any server infrastructure. Use the `oci+https` scheme when pointing at a registry, or `oci+http` for registries without TLS. The URL contains the registry host followed by the repository name, which must be lowercase:
 
 ```text
-oci+https://ghcr.io/myuser/repo
+oci+https://ghcr.io/myuser/mystore
+oci+http://127.0.0.1:5000/test/store
 ```
 
-Every chunk is stored as its own artifact: a blob holding the chunk data (compressed unless the store is configured with `uncompressed`), referenced by a small manifest that is tagged with the chunk ID. Since the chunk ID appears only in the tag, the store works with desync's default SHA512/256 digest algorithm as well as SHA256, and the tagged manifest protects the chunk from registry garbage collection of unreferenced blobs. Reading a chunk takes two requests (manifest, then blob) and writing takes three, so combining a registry store with a local cache is recommended more than for most other store types.
+An OCI store supports reading, writing, pruning, and use as a cache, so it works with `make`, `extract`, `chop`, `cache`, `info`, `prune` and every other command that takes a `-s` store. Note that index files (`.caibx`/`.caidx`) cannot be stored in a registry, only chunks — distribute the index via an [index store](#remote-indexes) or any other file transfer.
 
-`prune` deletes the manifests of unwanted chunks, only touching tags that parse as chunk IDs, so other artifacts can share the repository. Reclaiming the space held by the unreferenced blobs is left to the registry's own garbage collection. Note that manifest deletion is not supported by every registry: the distribution registry requires it to be enabled (`REGISTRY_STORAGE_DELETE_ENABLED=true`) and GitHub's ghcr.io only supports deletion through the GitHub Packages API, not the registry API.
+#### How chunks are stored
 
-Credentials are looked up in this order: the `DESYNC_OCI_USERNAME` and `DESYNC_OCI_PASSWORD` environment variables, the `oci-credentials` section of the config file (see [Configuration](#configuration)), and finally the Docker credential store — registries logged into with `docker login` or `oras login` work without any desync configuration.
+Every chunk is stored as its own small OCI artifact consisting of a blob holding the chunk data — compressed with zstd unless the store is configured with `uncompressed` — and a manifest referencing that blob, tagged with the chunk ID in hex. A chunk artifact looks like this in the registry:
+
+```json
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "artifactType": "application/vnd.desync.chunk.v1",
+  "config": {
+    "mediaType": "application/vnd.oci.empty.v1+json",
+    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+    "size": 2
+  },
+  "layers": [
+    {
+      "mediaType": "application/octet-stream",
+      "digest": "sha256:759129e4f837302163925898441ed7a7ce728e9340dc20c1109f7461a878dc39",
+      "size": 34806
+    }
+  ],
+  "annotations": {
+    "org.opencontainers.image.title": "cf16af015e294eb73277987c0f08f9c8157cb05425e52f5e8023749ac1279948.cacnk"
+  }
+}
+```
+
+This layout has a few important properties:
+
+- The chunk ID appears only in the tag, never as a blob digest. OCI blob digests must be SHA256, so this is what allows the store to work with desync's default SHA512/256 digest algorithm and lets it be combined freely with other stores, caches, and existing indexes.
+- Registries garbage-collect blobs that are not referenced by a manifest (and some, like ghcr.io, won't serve them at all). The tagged manifest keeps every chunk referenced and therefore safe.
+- Identical chunks pushed again reuse the same blob — registries deduplicate blobs by digest within a repository.
+
+Be aware that registry UIs show one tag (or "package version") per chunk, so a store with many chunks makes for a noisy listing. Using a repository dedicated to the chunk store is recommended, although unrelated artifacts sharing the repository are safe, even from `prune`.
+
+Reading a chunk takes two requests (manifest by tag, then blob), an existence check takes one, and writing takes three. desync requests chunks concurrently, which hides much of the added round-trip latency, but combining a registry store with a local cache (`-c`) is still more worthwhile than for most other store types.
+
+#### Authentication
+
+Credentials are looked up in the following order, first match wins:
+
+1. The `DESYNC_OCI_USERNAME` and `DESYNC_OCI_PASSWORD` environment variables. Convenient in CI, e.g. with the ephemeral `GITHUB_TOKEN` in GitHub Actions.
+2. The `oci-credentials` section of the config file (see [Configuration](#configuration)), keyed by host and repository with glob support.
+3. The Docker credential store. If you're logged in with `docker login ghcr.io` or `oras login ghcr.io`, desync picks those credentials up without any configuration.
+
+Anonymous access works for public repositories, so extracting from a public store needs no credentials at all. For ghcr.io, pushing requires a token with the `write:packages` scope, and note that new ghcr.io packages default to private visibility.
+
+#### Store options
+
+The usual [store options](#configuration-reference) apply, keyed by the full store URL: `uncompressed` to store chunks in plain form, `timeout`, `error-retry`, `error-retry-base-interval`, `trust-insecure`, and `ca-cert`/`client-cert`/`client-key` for custom or mutual TLS.
+
+```json
+{
+  "store-options": {
+    "oci+https://registry.internal/desync/store": {
+      "uncompressed": true,
+      "error-retry": 2,
+      "ca-cert": "/path/to/internal-ca.crt"
+    }
+  }
+}
+```
+
+#### Pruning
+
+`desync prune` deletes the manifests of all chunks not referenced by the given indexes. Only tags that parse as chunk IDs are considered. Reclaiming the space held by the then-unreferenced blobs is left to the registry's own garbage collection. Manifest deletion is not supported by every registry: the distribution registry requires it to be enabled with `REGISTRY_STORAGE_DELETE_ENABLED=true`, and ghcr.io only supports deletion through the GitHub Packages API, not the registry API — for ghcr.io, use a cleanup action for untagged/unwanted versions instead.
+
+#### Examples
+
+Publish a file to ghcr.io, using credentials from a previous `docker login`:
+
+```sh
+desync make -s oci+https://ghcr.io/myuser/mystore file.iso.caibx file.iso
+```
+
+Reassemble the file on another machine, keeping a local cache of chunks:
+
+```sh
+desync extract -s oci+https://ghcr.io/myuser/mystore -c /var/tmp/cache file.iso.caibx file.iso
+```
+
+The same, in CI with credentials from the environment:
+
+```sh
+DESYNC_OCI_USERNAME=myuser DESYNC_OCI_PASSWORD=$GITHUB_TOKEN \
+  desync make -s oci+https://ghcr.io/myuser/mystore file.iso.caibx file.iso
+```
+
+See how much of an updated image is already covered by the chunks in the registry:
+
+```sh
+desync info -s oci+https://ghcr.io/myuser/mystore file-v2.iso.caibx
+```
+
+Remove all chunks no longer referenced by the current set of indexes:
+
+```sh
+desync prune -s oci+https://registry.internal/desync/store file-v2.iso.caibx
+```
+
+Run a local throwaway registry for testing:
+
+```sh
+podman run -d --rm -p 5000:5000 -e REGISTRY_STORAGE_DELETE_ENABLED=true docker.io/library/registry:2
+desync make -s oci+http://127.0.0.1:5000/test/store file.iso.caibx file.iso
+```
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ catar archives can also be extracted to GNU tar archive streams. All files in th
 | Read chunks | yes | yes | yes | yes | yes | yes | yes |
 | Write chunks | yes | yes | yes | yes | yes | no | yes |
 | Use as cache | yes | yes | yes | yes | yes | no | yes |
-| Prune | yes | yes | yes | no | yes | no | no |
+| Prune | yes | yes | yes | no | yes | no | yes |
 | Verify | yes | no | no | no | no | no | no |
 
 ### Store Architecture
@@ -272,6 +272,8 @@ oci+https://ghcr.io/myuser/repo
 ```
 
 Every chunk is stored as its own artifact: a blob holding the chunk data (compressed unless the store is configured with `uncompressed`), referenced by a small manifest that is tagged with the chunk ID. Since the chunk ID appears only in the tag, the store works with desync's default SHA512/256 digest algorithm as well as SHA256, and the tagged manifest protects the chunk from registry garbage collection of unreferenced blobs. Reading a chunk takes two requests (manifest, then blob) and writing takes three, so combining a registry store with a local cache is recommended more than for most other store types.
+
+`prune` deletes the manifests of unwanted chunks, only touching tags that parse as chunk IDs, so other artifacts can share the repository. Reclaiming the space held by the unreferenced blobs is left to the registry's own garbage collection. Note that manifest deletion is not supported by every registry: the distribution registry requires it to be enabled (`REGISTRY_STORAGE_DELETE_ENABLED=true`) and GitHub's ghcr.io only supports deletion through the GitHub Packages API, not the registry API.
 
 Credentials are looked up in this order: the `DESYNC_OCI_USERNAME` and `DESYNC_OCI_PASSWORD` environment variables, the `oci-credentials` section of the config file (see [Configuration](#configuration)), and finally the Docker credential store — registries logged into with `docker login` or `oras login` work without any desync configuration.
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ OCI registries can be used to store chunks, using [ORAS](https://oras.land/docs/
 oci+https://ghcr.io/myuser/repo
 ```
 
-Since the OCI specification identifies blobs by SHA256 digest, OCI stores require desync to run with `--digest=sha256` instead of the default SHA512/256. Credentials are provided via the `oci-credentials` section of the config file (see [Configuration](#configuration)).
+Since the OCI specification identifies blobs by SHA256 digest, OCI stores require desync to run with `--digest=sha256` instead of the default SHA512/256. Chunks are stored as blobs whose digest is the chunk ID. Registries verify that uploaded content matches the declared digest, so chunks are always stored uncompressed in OCI stores, regardless of the `uncompressed` store option. Credentials are provided via the `oci-credentials` section of the config file (see [Configuration](#configuration)).
 
 </details>
 

--- a/cmd/desync/config.go
+++ b/cmd/desync/config.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -18,6 +19,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2/registry/remote/auth"
+	orascreds "oras.land/oras-go/v2/registry/remote/credentials"
 )
 
 // S3Creds holds credentials or references to an S3 credentials file.
@@ -84,19 +86,56 @@ func (c Config) GetS3CredentialsFor(u *url.URL) (*credentials.Credentials, strin
 	return creds, region
 }
 
-// GetOCICredentialsFor attempts to find creds and region for an OCI location in the config.
-func (c Config) GetOCICredentialsFor(u *url.URL) auth.CredentialFunc {
-	key := u.Host + u.Path
-	credsConfig, ok := c.OCICredentials[key]
-	if !ok {
-		return nil
+// GetOCICredentialsFor attempts to find credentials for an OCI location in the
+// environment and the config (the environment takes precedence). The config is
+// keyed by registry host and repository path, e.g. "ghcr.io/user/repo", and keys
+// can contain glob patterns. If nothing matches, the Docker credential store is
+// used, so registries logged into with "docker login" or "oras login" work
+// without desync configuration.
+func (c Config) GetOCICredentialsFor(u *url.URL) (auth.CredentialFunc, error) {
+	staticCredentials := func(username, secret string) auth.CredentialFunc {
+		return func(ctx context.Context, hostport string) (auth.Credential, error) {
+			return auth.Credential{
+				Username: username,
+				Password: secret,
+			}, nil
+		}
 	}
-	return func(ctx context.Context, hostport string) (auth.Credential, error) {
-		return auth.Credential{
-			Username: credsConfig.Username,
-			Password: credsConfig.Secret,
-		}, nil
+
+	if username := os.Getenv("DESYNC_OCI_USERNAME"); username != "" {
+		return staticCredentials(username, os.Getenv("DESYNC_OCI_PASSWORD")), nil
 	}
+
+	location := strings.TrimSuffix(u.Host+u.Path, "/")
+	var (
+		credsConfig OCICreds
+		found       bool
+	)
+	for k, v := range c.OCICredentials {
+		// Config keys are always slash-separated, so match with path.Match
+		// rather than filepath.Match, whose separator is OS-dependent.
+		match, err := path.Match(strings.TrimSuffix(k, "/"), location)
+		if err != nil {
+			return nil, err
+		}
+		if match {
+			if found {
+				return nil, fmt.Errorf("multiple oci-credentials entries match the location %q", location)
+			}
+			found = true
+			credsConfig = v
+		}
+	}
+	if found {
+		return staticCredentials(credsConfig.Username, credsConfig.Secret), nil
+	}
+
+	store, err := orascreds.NewStoreFromDocker(orascreds.StoreOptions{})
+	if err != nil {
+		// No usable Docker config, connect anonymously
+		return nil, nil
+	}
+	return orascreds.Credential(store), nil
 }
 
 // GetStoreOptionsFor returns optional config options for a specific store. Note that

--- a/cmd/desync/config.go
+++ b/cmd/desync/config.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -88,10 +87,10 @@ func (c Config) GetS3CredentialsFor(u *url.URL) (*credentials.Credentials, strin
 
 // GetOCICredentialsFor attempts to find credentials for an OCI location in the
 // environment and the config (the environment takes precedence). The config is
-// keyed by registry host and repository path, e.g. "ghcr.io/user/repo", and keys
-// can contain glob patterns. If nothing matches, the Docker credential store is
-// used, so registries logged into with "docker login" or "oras login" work
-// without desync configuration.
+// keyed by the store URL, e.g. "oci+https://ghcr.io/user/repo", and keys can
+// contain glob patterns, just like store-options keys. If nothing matches, the
+// Docker credential store is used, so registries logged into with
+// "docker login" or "oras login" work without desync configuration.
 func (c Config) GetOCICredentialsFor(u *url.URL) (auth.CredentialFunc, error) {
 	staticCredentials := func(username, secret string) auth.CredentialFunc {
 		return func(ctx context.Context, hostport string) (auth.Credential, error) {
@@ -106,19 +105,13 @@ func (c Config) GetOCICredentialsFor(u *url.URL) (auth.CredentialFunc, error) {
 		return staticCredentials(username, os.Getenv("DESYNC_OCI_PASSWORD")), nil
 	}
 
-	location := strings.TrimSuffix(u.Host+u.Path, "/")
+	location := u.String()
 	var (
 		credsConfig OCICreds
 		found       bool
 	)
 	for k, v := range c.OCICredentials {
-		// Config keys are always slash-separated, so match with path.Match
-		// rather than filepath.Match, whose separator is OS-dependent.
-		match, err := path.Match(strings.TrimSuffix(k, "/"), location)
-		if err != nil {
-			return nil, err
-		}
-		if match {
+		if locationMatch(k, location) {
 			if found {
 				return nil, fmt.Errorf("multiple oci-credentials entries match the location %q", location)
 			}
@@ -132,8 +125,10 @@ func (c Config) GetOCICredentialsFor(u *url.URL) (auth.CredentialFunc, error) {
 
 	store, err := orascreds.NewStoreFromDocker(orascreds.StoreOptions{})
 	if err != nil {
-		// No usable Docker config, connect anonymously
-		return nil, nil
+		// An absent Docker config simply yields an empty credential store,
+		// so an error here means the config exists but is unusable. Report
+		// it rather than silently degrading to anonymous access.
+		return nil, fmt.Errorf("failed to load docker credential config: %w", err)
 	}
 	return orascreds.Credential(store), nil
 }

--- a/cmd/desync/config.go
+++ b/cmd/desync/config.go
@@ -101,8 +101,16 @@ func (c Config) GetOCICredentialsFor(u *url.URL) (auth.CredentialFunc, error) {
 		}
 	}
 
-	if username := os.Getenv("DESYNC_OCI_USERNAME"); username != "" {
-		return staticCredentials(username, os.Getenv("DESYNC_OCI_PASSWORD")), nil
+	username, password := os.Getenv("DESYNC_OCI_USERNAME"), os.Getenv("DESYNC_OCI_PASSWORD")
+	if username == "" && password != "" {
+		// Some registries take a token as the password with any username, so
+		// setting only the password is an easy mistake to make. Say so here
+		// rather than let it fall through to the credential store and surface
+		// later as an unexplained 401 from the registry.
+		return nil, errors.New("DESYNC_OCI_PASSWORD is set without DESYNC_OCI_USERNAME")
+	}
+	if username != "" {
+		return staticCredentials(username, password), nil
 	}
 
 	credsConfig, found, err := matchConfigEntry(c.OCICredentials, u.String(), "oci-credentials")
@@ -113,6 +121,12 @@ func (c Config) GetOCICredentialsFor(u *url.URL) (auth.CredentialFunc, error) {
 		return staticCredentials(credsConfig.Username, credsConfig.Secret), nil
 	}
 
+	if !dockerConfigLocatable() {
+		// Without a config path there is nothing to load, and public
+		// repositories need no credentials at all. Anonymous access keeps
+		// those working where reporting an error would not.
+		return staticCredentials("", ""), nil
+	}
 	store, err := orascreds.NewStoreFromDocker(orascreds.StoreOptions{})
 	if err != nil {
 		// An absent Docker config simply yields an empty credential store,
@@ -121,6 +135,18 @@ func (c Config) GetOCICredentialsFor(u *url.URL) (auth.CredentialFunc, error) {
 		return nil, fmt.Errorf("failed to load docker credential config: %w", err)
 	}
 	return orascreds.Credential(store), nil
+}
+
+// dockerConfigLocatable reports whether the Docker config path can be
+// determined at all. The credential store resolves it from DOCKER_CONFIG or
+// the home directory, and neither is guaranteed to be set: containers running
+// as an arbitrary uid, systemd units and cron jobs routinely have no HOME.
+func dockerConfigLocatable() bool {
+	if os.Getenv("DOCKER_CONFIG") != "" {
+		return true
+	}
+	_, err := os.UserHomeDir()
+	return err == nil
 }
 
 // matchConfigEntry finds the entry of a config section whose key, possibly a

--- a/cmd/desync/config.go
+++ b/cmd/desync/config.go
@@ -105,19 +105,9 @@ func (c Config) GetOCICredentialsFor(u *url.URL) (auth.CredentialFunc, error) {
 		return staticCredentials(username, os.Getenv("DESYNC_OCI_PASSWORD")), nil
 	}
 
-	location := u.String()
-	var (
-		credsConfig OCICreds
-		found       bool
-	)
-	for k, v := range c.OCICredentials {
-		if locationMatch(k, location) {
-			if found {
-				return nil, fmt.Errorf("multiple oci-credentials entries match the location %q", location)
-			}
-			found = true
-			credsConfig = v
-		}
+	credsConfig, found, err := matchConfigEntry(c.OCICredentials, u.String(), "oci-credentials")
+	if err != nil {
+		return nil, err
 	}
 	if found {
 		return staticCredentials(credsConfig.Username, credsConfig.Secret), nil
@@ -133,20 +123,33 @@ func (c Config) GetOCICredentialsFor(u *url.URL) (auth.CredentialFunc, error) {
 	return orascreds.Credential(store), nil
 }
 
+// matchConfigEntry finds the entry of a config section whose key, possibly a
+// glob pattern, matches the store location. An error is returned if more than
+// one entry matches; section names the config section in that error.
+func matchConfigEntry[V any](section map[string]V, location, sectionName string) (match V, found bool, err error) {
+	for k, v := range section {
+		if locationMatch(k, location) {
+			if found {
+				return match, false, fmt.Errorf("multiple %s entries match the location %q", sectionName, location)
+			}
+			found = true
+			match = v
+		}
+	}
+	return match, found, nil
+}
+
 // GetStoreOptionsFor returns optional config options for a specific store. Note that
 // an error will be returned if the location string matches multiple entries in the
 // config file.
 func (c Config) GetStoreOptionsFor(location string) (options desync.StoreOptions, err error) {
-	found := false
 	options = desync.NewStoreOptionsWithDefaults()
-	for k, v := range c.StoreOptions {
-		if locationMatch(k, location) {
-			if found {
-				return options, fmt.Errorf("multiple configuration entries match the location %q", location)
-			}
-			found = true
-			options = v
-		}
+	opt, found, err := matchConfigEntry(c.StoreOptions, location, "store-options")
+	if err != nil {
+		return options, err
+	}
+	if found {
+		options = opt
 	}
 	options.EncryptionKey = encryptionKeyFallback(options.Encryption, options.EncryptionKey)
 	return options, nil

--- a/cmd/desync/config_test.go
+++ b/cmd/desync/config_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -47,4 +49,63 @@ func TestConfigFileMultipleMatches(t *testing.T) {
 	// provided location
 	_, err := cfg.GetStoreOptionsFor("/path/to/store")
 	require.Error(t, err)
+}
+
+func TestGetOCICredentials(t *testing.T) {
+	// Make sure credentials aren't picked up from the environment or the
+	// user's Docker config
+	t.Setenv("DESYNC_OCI_USERNAME", "")
+	t.Setenv("DOCKER_CONFIG", t.TempDir())
+
+	config := Config{OCICredentials: map[string]OCICreds{
+		"ghcr.io/user/repo":  {Username: "user", Secret: "secret"},
+		"registry.io/*/repo": {Username: "wildcard", Secret: "secret"},
+	}}
+
+	tests := map[string]struct {
+		location string
+		username string
+	}{
+		"exact match": {"oci+https://ghcr.io/user/repo", "user"},
+		"glob match":  {"oci+https://registry.io/anything/repo", "wildcard"},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			u, err := url.Parse(test.location)
+			require.NoError(t, err)
+			credFunc, err := config.GetOCICredentialsFor(u)
+			require.NoError(t, err)
+			require.NotNil(t, credFunc)
+			cred, err := credFunc(context.Background(), "")
+			require.NoError(t, err)
+			require.Equal(t, test.username, cred.Username)
+		})
+	}
+
+	// A location without a match should fall back to the Docker credential
+	// store without error
+	u, err := url.Parse("oci+https://other.example.com/some/repo")
+	require.NoError(t, err)
+	_, err = config.GetOCICredentialsFor(u)
+	require.NoError(t, err)
+
+	// Multiple matching config entries are invalid
+	multi := Config{OCICredentials: map[string]OCICreds{
+		"ghcr.io/user/repo": {Username: "a"},
+		"ghcr.io/*/repo":    {Username: "b"},
+	}}
+	u, err = url.Parse("oci+https://ghcr.io/user/repo")
+	require.NoError(t, err)
+	_, err = multi.GetOCICredentialsFor(u)
+	require.Error(t, err)
+
+	// Credentials in the environment take precedence over the config
+	t.Setenv("DESYNC_OCI_USERNAME", "envuser")
+	t.Setenv("DESYNC_OCI_PASSWORD", "envpass")
+	credFunc, err := config.GetOCICredentialsFor(u)
+	require.NoError(t, err)
+	cred, err := credFunc(context.Background(), "")
+	require.NoError(t, err)
+	require.Equal(t, "envuser", cred.Username)
+	require.Equal(t, "envpass", cred.Password)
 }

--- a/cmd/desync/config_test.go
+++ b/cmd/desync/config_test.go
@@ -58,16 +58,20 @@ func TestGetOCICredentials(t *testing.T) {
 	t.Setenv("DOCKER_CONFIG", t.TempDir())
 
 	config := Config{OCICredentials: map[string]OCICreds{
-		"ghcr.io/user/repo":  {Username: "user", Secret: "secret"},
-		"registry.io/*/repo": {Username: "wildcard", Secret: "secret"},
+		"oci+https://ghcr.io/user/repo":  {Username: "user", Secret: "secret"},
+		"oci+https://registry.io/*/repo": {Username: "wildcard", Secret: "secret"},
+		// A malformed glob pattern never matches but must not break the
+		// lookup for other locations
+		"oci+https://bad.example.com/[repo": {Username: "broken"},
 	}}
 
 	tests := map[string]struct {
 		location string
 		username string
 	}{
-		"exact match": {"oci+https://ghcr.io/user/repo", "user"},
-		"glob match":  {"oci+https://registry.io/anything/repo", "wildcard"},
+		"exact match":          {"oci+https://ghcr.io/user/repo", "user"},
+		"glob match":           {"oci+https://registry.io/anything/repo", "wildcard"},
+		"trailing slash match": {"oci+https://ghcr.io/user/repo/", "user"},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -91,13 +95,24 @@ func TestGetOCICredentials(t *testing.T) {
 
 	// Multiple matching config entries are invalid
 	multi := Config{OCICredentials: map[string]OCICreds{
-		"ghcr.io/user/repo": {Username: "a"},
-		"ghcr.io/*/repo":    {Username: "b"},
+		"oci+https://ghcr.io/user/repo": {Username: "a"},
+		"oci+https://ghcr.io/*/repo":    {Username: "b"},
 	}}
 	u, err = url.Parse("oci+https://ghcr.io/user/repo")
 	require.NoError(t, err)
 	_, err = multi.GetOCICredentialsFor(u)
 	require.Error(t, err)
+
+	// A Docker config that exists but can't be parsed is an error, not a
+	// silent fallback to anonymous access
+	brokenDocker := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(brokenDocker, "config.json"), []byte("not json"), 0600))
+	t.Setenv("DOCKER_CONFIG", brokenDocker)
+	unmatched, err := url.Parse("oci+https://other.example.com/some/repo")
+	require.NoError(t, err)
+	_, err = config.GetOCICredentialsFor(unmatched)
+	require.Error(t, err)
+	t.Setenv("DOCKER_CONFIG", t.TempDir())
 
 	// Credentials in the environment take precedence over the config
 	t.Setenv("DESYNC_OCI_USERNAME", "envuser")

--- a/cmd/desync/config_test.go
+++ b/cmd/desync/config_test.go
@@ -55,6 +55,7 @@ func TestGetOCICredentials(t *testing.T) {
 	// Make sure credentials aren't picked up from the environment or the
 	// user's Docker config
 	t.Setenv("DESYNC_OCI_USERNAME", "")
+	t.Setenv("DESYNC_OCI_PASSWORD", "")
 	t.Setenv("DOCKER_CONFIG", t.TempDir())
 
 	config := Config{OCICredentials: map[string]OCICreds{
@@ -123,4 +124,41 @@ func TestGetOCICredentials(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "envuser", cred.Username)
 	require.Equal(t, "envpass", cred.Password)
+}
+
+// Registries that take a token as the password accept it with any username,
+// which makes setting only DESYNC_OCI_PASSWORD an easy mistake. It has to be
+// reported here, or the variable is ignored and the registry answers with a
+// 401 that points at nothing.
+func TestGetOCICredentialsPasswordWithoutUsername(t *testing.T) {
+	t.Setenv("DESYNC_OCI_USERNAME", "")
+	t.Setenv("DESYNC_OCI_PASSWORD", "token")
+
+	u, err := url.Parse("oci+https://ghcr.io/user/repo")
+	require.NoError(t, err)
+	_, err = Config{}.GetOCICredentialsFor(u)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "DESYNC_OCI_USERNAME")
+}
+
+// The Docker config path can only be resolved from DOCKER_CONFIG or a home
+// directory, and containers running as an arbitrary uid, systemd units and
+// cron jobs have neither. Public repositories need no credentials at all, so
+// that has to degrade to anonymous access instead of failing the operation.
+func TestGetOCICredentialsWithoutDockerConfigPath(t *testing.T) {
+	t.Setenv("DESYNC_OCI_USERNAME", "")
+	t.Setenv("DESYNC_OCI_PASSWORD", "")
+	t.Setenv("DOCKER_CONFIG", "")
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+
+	u, err := url.Parse("oci+https://ghcr.io/public/repo")
+	require.NoError(t, err)
+	credFunc, err := Config{}.GetOCICredentialsFor(u)
+	require.NoError(t, err)
+	require.NotNil(t, credFunc)
+	cred, err := credFunc(context.Background(), "")
+	require.NoError(t, err)
+	require.Empty(t, cred.Username)
+	require.Empty(t, cred.Password)
 }

--- a/cmd/desync/store.go
+++ b/cmd/desync/store.go
@@ -149,6 +149,12 @@ func storeFromLocation(location string, cmdOpt cmdStoreOptions) (desync.Store, e
 		if err != nil {
 			return nil, err
 		}
+	case "oci+https", "oci+http":
+		creds := cfg.GetOCICredentialsFor(loc)
+		s, err = desync.NewOCIStore(loc, creds, opt)
+		if err != nil {
+			return nil, err
+		}
 	default:
 		local, err := desync.NewLocalStore(location, opt)
 		if err != nil {

--- a/cmd/desync/store.go
+++ b/cmd/desync/store.go
@@ -253,6 +253,8 @@ func indexStoreFromLocation(location string, cmdOpt cmdStoreOptions) (desync.Ind
 	switch loc.Scheme {
 	case "ssh":
 		return nil, "", errors.New("Index storage is not supported by ssh remote stores")
+	case "oci+https", "oci+http":
+		return nil, "", errors.New("Index storage is not supported by oci registry stores")
 	case "sftp":
 		s, err = desync.NewSFTPIndexStore(&p, opt)
 		if err != nil {

--- a/cmd/desync/store.go
+++ b/cmd/desync/store.go
@@ -150,7 +150,10 @@ func storeFromLocation(location string, cmdOpt cmdStoreOptions) (desync.Store, e
 			return nil, err
 		}
 	case "oci+https", "oci+http":
-		creds := cfg.GetOCICredentialsFor(loc)
+		creds, err := cfg.GetOCICredentialsFor(loc)
+		if err != nil {
+			return nil, err
+		}
 		s, err = desync.NewOCIStore(loc, creds, opt)
 		if err != nil {
 			return nil, err

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/hanwen/go-fuse/v2 v2.2.0
 	github.com/klauspost/compress v1.16.4
 	github.com/minio/minio-go/v6 v6.0.57
+	github.com/opencontainers/go-digest v1.0.0
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/sftp v1.13.5
 	github.com/pkg/xattr v0.4.9
@@ -25,6 +27,7 @@ require (
 	golang.org/x/term v0.43.0
 	google.golang.org/api v0.267.0
 	gopkg.in/cheggaaa/pb.v1 v1.0.28
+	oras.land/oras-go/v2 v2.6.1
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/hanwen/go-fuse/v2 v2.2.0
 	github.com/klauspost/compress v1.16.4
 	github.com/minio/minio-go/v6 v6.0.57
-	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/sftp v1.13.5
@@ -67,6 +66,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,10 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
+github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.5 h1:a3RLUqkyjYRtBTZJZ1VRrKbN3zhuPLlUc3sphVz81go=
@@ -249,3 +253,5 @@ gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+oras.land/oras-go/v2 v2.6.1 h1:bonOEkjLfp8tt6qXWRRWP6p1F+9octchOf2EqnWB4Zs=
+oras.land/oras-go/v2 v2.6.1/go.mod h1:dhtFrFOuZuDtAVeZ9FUnaa5zfzplG3ZnFX9/uH1J/Yk=

--- a/oci.go
+++ b/oci.go
@@ -1,0 +1,136 @@
+package desync
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/errdef"
+	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/retry"
+)
+
+var _ WriteStore = OCIStore{}
+
+// OCIStore operates on chunks in an Open Container Image registry.
+type OCIStore struct {
+	repo       *remote.Repository
+	location   string
+	opt        StoreOptions
+	converters Converters
+}
+
+// NewOCIStore initializes a new Open Registry As Storage backend.
+func NewOCIStore(u *url.URL, creds auth.CredentialFunc, opt StoreOptions) (OCIStore, error) {
+	// The OCI spec does not support desync's default hash algorithm (SHA512/256), so we must
+	// be using SHA256 only.
+	if Digest.Algorithm() != crypto.SHA256 {
+		return OCIStore{}, errors.New("OCI stores only support SHA256, use --digest=sha256")
+	}
+
+	repo, err := remote.NewRepository(u.Host + u.Path)
+	if err != nil {
+		return OCIStore{}, fmt.Errorf("failed to initialize oci registry store: %w", err)
+	}
+	baseTransport := http.DefaultTransport.(*http.Transport).Clone()
+	baseTransport.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: opt.TrustInsecure,
+	}
+	client := &auth.Client{
+		Client: &http.Client{
+			Transport: retry.NewTransport(baseTransport),
+		},
+		Credential: creds,
+	}
+	client.SetUserAgent("desync")
+	repo.Client = client
+	repo.PlainHTTP = strings.HasSuffix(u.Scheme, "-http")
+	s := OCIStore{
+		repo:     repo,
+		location: u.String(),
+		opt:      opt,
+	}
+	return s, nil
+}
+
+func (s OCIStore) String() string {
+	return s.location
+}
+
+// Close the store. NOP operation but needed to implement the store interface.
+func (s OCIStore) Close() error { return nil }
+
+// GetChunk reads and returns one chunk from the store
+func (s OCIStore) GetChunk(id ChunkID) (*Chunk, error) {
+	descriptor, err := s.repo.Blobs().Resolve(context.Background(), ociReference(id))
+	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return nil, ChunkMissing{id}
+		}
+		return nil, err
+	}
+	r, err := s.repo.Fetch(context.Background(), descriptor)
+	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return nil, ChunkMissing{id}
+		}
+		return nil, err
+	}
+	defer r.Close()
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	return NewChunkFromStorage(id, b, s.converters, s.opt.SkipVerify)
+}
+
+// StoreChunk adds a new chunk to the store.
+func (s OCIStore) StoreChunk(chunk *Chunk) error {
+	b, err := chunk.Data()
+	if err != nil {
+		return err
+	}
+	b, err = s.converters.toStorage(b)
+	if err != nil {
+		return err
+	}
+	descriptor := ociDescriptorForChunk(chunk.ID())
+	descriptor.Size = int64(len(b))
+	return s.repo.Push(context.Background(), descriptor, bytes.NewReader(b))
+}
+
+// HasChunk returns true if the chunk is in the store.
+func (s OCIStore) HasChunk(id ChunkID) (bool, error) {
+	return s.repo.Exists(context.Background(), ociDescriptorForChunk(id))
+}
+
+// RemoveChunk deletes a chunk, typically an invalid one, from the store.
+// Used when verifying and repairing caches.
+func (s OCIStore) RemoveChunk(id ChunkID) error {
+	err := s.repo.Delete(context.Background(), ociDescriptorForChunk(id))
+	if errors.Is(err, errdef.ErrNotFound) {
+		return ChunkMissing{id}
+	}
+	return err
+}
+
+func ociDescriptorForChunk(id ChunkID) ocispec.Descriptor {
+	return ocispec.Descriptor{
+		Digest:    digest.Digest(ociReference(id)),
+		MediaType: "application/vnd.oci.image.layer.v1.tar+zstd",
+	}
+}
+
+func ociReference(id ChunkID) string {
+	return "sha256:" + id.String()
+}

--- a/oci.go
+++ b/oci.go
@@ -31,18 +31,24 @@ var _ WriteStore = OCIStore{}
 var _ PruneStore = OCIStore{}
 
 // OCIStore operates on chunks in an OCI registry. Every chunk is stored as its
-// own artifact: a blob holding the chunk in storage format (compressed unless
-// configured otherwise), referenced by a minimal image manifest that is tagged
-// with the chunk ID in hex. The tag is the only place the chunk ID appears, so
-// any chunk digest algorithm works, including the default SHA512/256 which OCI
-// blob digests could not represent. The manifest also keeps the blob referenced,
-// protecting it from registry garbage collection of unreferenced blobs.
+// own artifact: a blob holding the chunk in storage format (compressed and/or
+// encrypted as configured), referenced by a minimal image manifest that is
+// tagged with the chunk ID in hex followed by the storage extension, the same
+// naming used for chunk files in other stores. The tag is the only place the
+// chunk ID appears, so any chunk digest algorithm works, including the default
+// SHA512/256 which OCI blob digests could not represent, and chunks in
+// different storage formats or with different encryption keys can coexist in
+// one repository. The manifest also keeps the blob referenced, protecting it
+// from registry garbage collection of unreferenced blobs.
 type OCIStore struct {
 	repo         *remote.Repository
 	location     string
 	opt          StoreOptions
 	converters   Converters
 	configPushed *atomic.Bool
+
+	// Chunk tag extension, derived from the converters at construction
+	extension string
 }
 
 // NewOCIStore initializes a store using an OCI registry as backend.
@@ -114,18 +120,30 @@ func NewOCIStore(u *url.URL, creds auth.CredentialFunc, opt StoreOptions) (OCISt
 	repo.Client = client
 	repo.PlainHTTP = u.Scheme == "oci+http"
 
+	converters, err := opt.StorageConverters()
+	if err != nil {
+		return OCIStore{}, err
+	}
 	s := OCIStore{
 		repo:         repo,
 		location:     u.String(),
 		opt:          opt,
-		converters:   opt.converters(),
+		converters:   converters,
 		configPushed: &atomic.Bool{},
+		extension:    converters.storageExtension(),
 	}
 	return s, nil
 }
 
 func (s OCIStore) String() string {
 	return s.location
+}
+
+// tagFromID returns the manifest tag for a chunk, the hex ID followed by
+// the storage extension. Both are well within the OCI tag grammar and
+// length limit.
+func (s OCIStore) tagFromID(id ChunkID) string {
+	return id.String() + s.extension
 }
 
 // Close the store. NOP operation but needed to implement the store interface.
@@ -158,7 +176,7 @@ func (s OCIStore) GetChunk(id ChunkID) (*Chunk, error) {
 
 // HasChunk returns true if the chunk is in the store.
 func (s OCIStore) HasChunk(id ChunkID) (bool, error) {
-	_, err := s.repo.Resolve(context.Background(), id.String())
+	_, err := s.repo.Resolve(context.Background(), s.tagFromID(id))
 	switch {
 	case err == nil:
 		return true, nil
@@ -174,11 +192,7 @@ func (s OCIStore) HasChunk(id ChunkID) (bool, error) {
 func (s OCIStore) StoreChunk(chunk *Chunk) error {
 	ctx := context.Background()
 	id := chunk.ID()
-	b, err := chunk.Data()
-	if err != nil {
-		return err
-	}
-	b, err = s.converters.toStorage(b)
+	b, err := chunk.Storage(s.converters)
 	if err != nil {
 		return err
 	}
@@ -201,7 +215,7 @@ func (s OCIStore) StoreChunk(chunk *Chunk) error {
 		ArtifactType: OCIChunkArtifactType,
 		Config:       config,
 		Layers:       []ocispec.Descriptor{blobDesc},
-		Annotations:  map[string]string{ocispec.AnnotationTitle: id.String() + ".cacnk"},
+		Annotations:  map[string]string{ocispec.AnnotationTitle: s.tagFromID(id)},
 	}
 	mb, err := json.Marshal(manifest)
 	if err != nil {
@@ -212,7 +226,7 @@ func (s OCIStore) StoreChunk(chunk *Chunk) error {
 		Digest:    digest.FromBytes(mb),
 		Size:      int64(len(mb)),
 	}
-	return s.repo.Manifests().PushReference(ctx, manifestDesc, bytes.NewReader(mb), id.String())
+	return s.repo.Manifests().PushReference(ctx, manifestDesc, bytes.NewReader(mb), s.tagFromID(id))
 }
 
 // RemoveChunk deletes a chunk, typically an invalid one, from the store.
@@ -220,7 +234,7 @@ func (s OCIStore) StoreChunk(chunk *Chunk) error {
 // the blob is left for the registry's garbage collection.
 func (s OCIStore) RemoveChunk(id ChunkID) error {
 	ctx := context.Background()
-	desc, err := s.repo.Resolve(ctx, id.String())
+	desc, err := s.repo.Resolve(ctx, s.tagFromID(id))
 	if err != nil {
 		if errors.Is(err, errdef.ErrNotFound) {
 			return ChunkMissing{id}
@@ -231,10 +245,11 @@ func (s OCIStore) RemoveChunk(id ChunkID) error {
 }
 
 // Prune removes any chunks from the store that are not referenced in the
-// list of chunks. Only tags that parse as chunk IDs are considered, other
-// artifacts sharing the repository are left alone. Just the chunk manifests
-// are deleted, reclaiming the space of the now unreferenced blobs is left
-// to the registry's garbage collection.
+// list of chunks. Only tags matching the store's chunk naming, the ID
+// followed by the storage extension, are considered. Other artifacts and
+// chunks in different storage formats sharing the repository are left
+// alone. Just the chunk manifests are deleted, reclaiming the space of the
+// now unreferenced blobs is left to the registry's garbage collection.
 func (s OCIStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 	return s.repo.Tags(ctx, "", func(tags []string) error {
 		for _, tag := range tags {
@@ -245,14 +260,14 @@ func (s OCIStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 			default:
 			}
 
-			id, err := ChunkIDFromString(tag)
-			if err != nil {
+			id, ok := chunkIDFromFilename(tag, s.extension)
+			if !ok {
 				continue
 			}
 
 			// Drop the chunk if it's not on the list
 			if _, ok := ids[id]; !ok {
-				if err = s.RemoveChunk(id); err != nil && !errors.Is(err, ChunkMissing{id}) {
+				if err := s.RemoveChunk(id); err != nil && !errors.Is(err, ChunkMissing{id}) {
 					return err
 				}
 			}
@@ -264,7 +279,7 @@ func (s OCIStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 // resolveChunkBlob fetches the chunk's manifest by tag and returns the
 // descriptor of the blob holding the chunk data.
 func (s OCIStore) resolveChunkBlob(ctx context.Context, id ChunkID) (ocispec.Descriptor, error) {
-	_, r, err := s.repo.FetchReference(ctx, id.String())
+	_, r, err := s.repo.FetchReference(ctx, s.tagFromID(id))
 	if err != nil {
 		if errors.Is(err, errdef.ErrNotFound) {
 			return ocispec.Descriptor{}, ChunkMissing{id}

--- a/oci.go
+++ b/oci.go
@@ -3,15 +3,13 @@ package desync
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
-	"os"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -26,6 +24,21 @@ import (
 
 // OCIChunkArtifactType identifies desync chunk artifacts in an OCI registry.
 const OCIChunkArtifactType = "application/vnd.desync.chunk.v1"
+
+// maxOCIChunkBlobSize caps the blob size accepted from a chunk manifest. Far
+// above any real chunk, it only stops a corrupt or malicious manifest from
+// driving a huge or invalid allocation before the blob is even fetched.
+const maxOCIChunkBlobSize = 1 << 30
+
+// retryPredicate retries any transport error, matching the error-retry
+// behavior of the other network stores. Response codes are left to the
+// default predicate, which retries 408, 429, and 5xx.
+func retryPredicate(resp *http.Response, err error) (bool, error) {
+	if err != nil {
+		return true, nil
+	}
+	return retry.DefaultPredicate(resp, nil)
+}
 
 var _ WriteStore = OCIStore{}
 var _ PruneStore = OCIStore{}
@@ -56,43 +69,29 @@ func NewOCIStore(u *url.URL, creds auth.CredentialFunc, opt StoreOptions) (OCISt
 	if u.Scheme != "oci+https" && u.Scheme != "oci+http" {
 		return OCIStore{}, fmt.Errorf("unsupported scheme %s, expected oci+https or oci+http", u.Scheme)
 	}
-	repo, err := remote.NewRepository(u.Host + u.Path)
+	repo, err := remote.NewRepository(strings.TrimSuffix(u.Host+u.Path, "/"))
 	if err != nil {
 		return OCIStore{}, fmt.Errorf("failed to initialize oci registry store: %w", err)
 	}
+	// Chunk manifests never carry a subject, so the client-side referrers
+	// indexing oras-go falls back to on registries without referrers support
+	// can never have anything to do. Declaring the capability stops it from
+	// fetching every manifest ahead of a delete just to look for a subject.
+	repo.SetReferrersCapability(true)
 
-	// Build a TLS client config
-	tlsConfig := &tls.Config{InsecureSkipVerify: opt.TrustInsecure}
-
-	// Add client key/cert if provided
-	if opt.ClientCert != "" && opt.ClientKey != "" {
-		certificate, err := tls.LoadX509KeyPair(opt.ClientCert, opt.ClientKey)
-		if err != nil {
-			return OCIStore{}, fmt.Errorf("failed to load client certificate from %s", opt.ClientCert)
-		}
-		tlsConfig.Certificates = []tls.Certificate{certificate}
-	}
-
-	// Load custom CA set if provided
-	if opt.CACert != "" {
-		certPool := x509.NewCertPool()
-		b, err := os.ReadFile(opt.CACert)
-		if err != nil {
-			return OCIStore{}, err
-		}
-		if ok := certPool.AppendCertsFromPEM(b); !ok {
-			return OCIStore{}, errors.New("no CA certificates found in ca-cert file")
-		}
-		tlsConfig.RootCAs = certPool
+	tlsConfig, err := opt.tlsClientConfig()
+	if err != nil {
+		return OCIStore{}, err
 	}
 
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSClientConfig = tlsConfig
+	transport.MaxIdleConnsPerHost = opt.N
 
 	var rt http.RoundTripper = transport
 	if opt.ErrorRetry > 0 {
 		policy := &retry.GenericPolicy{
-			Retryable: retry.DefaultPredicate,
+			Retryable: retryPredicate,
 			Backoff: func(attempt int, resp *http.Response) time.Duration {
 				return time.Duration(attempt+1) * opt.ErrorRetryBaseInterval
 			},
@@ -102,17 +101,8 @@ func NewOCIStore(u *url.URL, creds auth.CredentialFunc, opt StoreOptions) (OCISt
 		rt = &retry.Transport{Base: transport, Policy: func() retry.Policy { return policy }}
 	}
 
-	// If no timeout was given in config (set to 0), then use 1 minute. If timeout is negative, use 0 to
-	// set an infinite timeout.
-	timeout := opt.Timeout
-	if timeout == 0 {
-		timeout = time.Minute
-	} else if timeout < 0 {
-		timeout = 0
-	}
-
 	client := &auth.Client{
-		Client:     &http.Client{Transport: rt, Timeout: timeout},
+		Client:     &http.Client{Transport: rt, Timeout: opt.effectiveTimeout()},
 		Cache:      auth.NewCache(),
 		Credential: creds,
 	}
@@ -204,7 +194,7 @@ func (s OCIStore) StoreChunk(chunk *Chunk) error {
 		Digest:    digest.FromBytes(b),
 		Size:      int64(len(b)),
 	}
-	if err := s.repo.Blobs().Push(ctx, blobDesc, bytes.NewReader(b)); err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+	if err := s.repo.Blobs().Push(ctx, blobDesc, bytes.NewReader(b)); err != nil {
 		return err
 	}
 	config := ocispec.DescriptorEmptyJSON
@@ -230,15 +220,14 @@ func (s OCIStore) StoreChunk(chunk *Chunk) error {
 }
 
 // RemoveChunk deletes a chunk, typically an invalid one, from the store.
-// Used when verifying and repairing caches. Only the manifest is deleted,
-// the blob is left for the registry's garbage collection.
+// Used when verifying and repairing caches. Only manifests carrying the
+// desync chunk artifact type are deleted; a tag that names any other kind
+// of artifact reports the chunk as missing instead. The blob is left for
+// the registry's garbage collection.
 func (s OCIStore) RemoveChunk(id ChunkID) error {
 	ctx := context.Background()
-	desc, err := s.repo.Resolve(ctx, s.tagFromID(id))
+	_, desc, err := s.fetchChunkManifest(ctx, id)
 	if err != nil {
-		if errors.Is(err, errdef.ErrNotFound) {
-			return ChunkMissing{id}
-		}
 		return err
 	}
 	return s.repo.Manifests().Delete(ctx, desc)
@@ -246,10 +235,12 @@ func (s OCIStore) RemoveChunk(id ChunkID) error {
 
 // Prune removes any chunks from the store that are not referenced in the
 // list of chunks. Only tags matching the store's chunk naming, the ID
-// followed by the storage extension, are considered. Other artifacts and
-// chunks in different storage formats sharing the repository are left
-// alone. Just the chunk manifests are deleted, reclaiming the space of the
-// now unreferenced blobs is left to the registry's garbage collection.
+// followed by the storage extension, are considered, and of those only
+// manifests carrying the desync chunk artifact type are deleted. Other
+// artifacts and chunks in different storage formats sharing the repository
+// are left alone, even ones under a chunk-ID-shaped tag. Just the chunk
+// manifests are deleted, reclaiming the space of the now unreferenced blobs
+// is left to the registry's garbage collection.
 func (s OCIStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 	return s.repo.Tags(ctx, "", func(tags []string) error {
 		for _, tag := range tags {
@@ -279,46 +270,60 @@ func (s OCIStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 // resolveChunkBlob fetches the chunk's manifest by tag and returns the
 // descriptor of the blob holding the chunk data.
 func (s OCIStore) resolveChunkBlob(ctx context.Context, id ChunkID) (ocispec.Descriptor, error) {
-	_, r, err := s.repo.FetchReference(ctx, s.tagFromID(id))
+	manifest, _, err := s.fetchChunkManifest(ctx, id)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	if len(manifest.Layers) != 1 {
+		return ocispec.Descriptor{}, fmt.Errorf("manifest for chunk %s in %s references %d blobs, expected exactly one", id.String(), s, len(manifest.Layers))
+	}
+	blobDesc := manifest.Layers[0]
+	if blobDesc.Size < 0 || blobDesc.Size > maxOCIChunkBlobSize {
+		return ocispec.Descriptor{}, fmt.Errorf("manifest for chunk %s in %s references a blob of invalid size %d", id.String(), s, blobDesc.Size)
+	}
+	return blobDesc, nil
+}
+
+// fetchChunkManifest fetches the manifest tagged for the chunk and returns it
+// along with its own descriptor. A tag that doesn't exist, or one that names
+// a manifest without the desync chunk artifact type, resolves to ChunkMissing:
+// the tag alone can't be trusted, an unrelated artifact sharing the repository
+// may sit under a chunk-ID-shaped tag, especially when the storage extension
+// is empty (uncompressed, unencrypted stores).
+func (s OCIStore) fetchChunkManifest(ctx context.Context, id ChunkID) (ocispec.Manifest, ocispec.Descriptor, error) {
+	desc, r, err := s.repo.FetchReference(ctx, s.tagFromID(id))
 	if err != nil {
 		if errors.Is(err, errdef.ErrNotFound) {
-			return ocispec.Descriptor{}, ChunkMissing{id}
+			return ocispec.Manifest{}, ocispec.Descriptor{}, ChunkMissing{id}
 		}
-		return ocispec.Descriptor{}, err
+		return ocispec.Manifest{}, ocispec.Descriptor{}, err
 	}
 	defer r.Close()
 	mb, err := io.ReadAll(r)
 	if err != nil {
-		return ocispec.Descriptor{}, err
+		return ocispec.Manifest{}, ocispec.Descriptor{}, err
 	}
 	var manifest ocispec.Manifest
 	if err := json.Unmarshal(mb, &manifest); err != nil {
-		return ocispec.Descriptor{}, fmt.Errorf("invalid manifest for chunk %s in %s: %w", id, s, err)
+		return ocispec.Manifest{}, ocispec.Descriptor{}, fmt.Errorf("invalid manifest for chunk %s in %s: %w", id.String(), s, err)
 	}
-	if len(manifest.Layers) != 1 {
-		return ocispec.Descriptor{}, fmt.Errorf("manifest for chunk %s in %s references %d blobs, expected exactly one", id, s, len(manifest.Layers))
+	if manifest.ArtifactType != OCIChunkArtifactType {
+		return ocispec.Manifest{}, ocispec.Descriptor{}, ChunkMissing{id}
 	}
-	return manifest.Layers[0], nil
+	return manifest, desc, nil
 }
 
 // ensureConfigBlob uploads the shared empty config blob that every chunk
-// manifest references. It only needs to exist once per repository, so the
-// check-and-push runs once per store instance.
+// manifest references. Registries accept re-pushes of existing blobs, so
+// the push is simply skipped once it has succeeded for this store instance.
 func (s OCIStore) ensureConfigBlob(ctx context.Context) error {
 	if s.configPushed.Load() {
 		return nil
 	}
 	desc := ocispec.DescriptorEmptyJSON
 	desc.Data = nil
-	exists, err := s.repo.Blobs().Exists(ctx, desc)
-	if err != nil {
+	if err := s.repo.Blobs().Push(ctx, desc, bytes.NewReader(ocispec.DescriptorEmptyJSON.Data)); err != nil {
 		return err
-	}
-	if !exists {
-		err := s.repo.Blobs().Push(ctx, desc, bytes.NewReader(ocispec.DescriptorEmptyJSON.Data))
-		if err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
-			return err
-		}
 	}
 	s.configPushed.Store(true)
 	return nil

--- a/oci.go
+++ b/oci.go
@@ -3,15 +3,20 @@ package desync
 import (
 	"bytes"
 	"context"
-	"crypto"
 	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"sync/atomic"
+	"time"
 
 	"github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry/remote"
@@ -19,48 +24,101 @@ import (
 	"oras.land/oras-go/v2/registry/remote/retry"
 )
 
+// OCIChunkArtifactType identifies desync chunk artifacts in an OCI registry.
+const OCIChunkArtifactType = "application/vnd.desync.chunk.v1"
+
 var _ WriteStore = OCIStore{}
 
-// OCIStore operates on chunks in an Open Container Image registry. Chunks are
-// stored as plain blobs whose digest is the chunk ID. Since registries verify
-// that uploaded content matches the declared digest, chunks are always stored
-// uncompressed, regardless of the store's compression options.
+// OCIStore operates on chunks in an OCI registry. Every chunk is stored as its
+// own artifact: a blob holding the chunk in storage format (compressed unless
+// configured otherwise), referenced by a minimal image manifest that is tagged
+// with the chunk ID in hex. The tag is the only place the chunk ID appears, so
+// any chunk digest algorithm works, including the default SHA512/256 which OCI
+// blob digests could not represent. The manifest also keeps the blob referenced,
+// protecting it from registry garbage collection of unreferenced blobs.
 type OCIStore struct {
-	repo     *remote.Repository
-	location string
-	opt      StoreOptions
+	repo         *remote.Repository
+	location     string
+	opt          StoreOptions
+	converters   Converters
+	configPushed *atomic.Bool
 }
 
-// NewOCIStore initializes a new Open Registry As Storage backend.
+// NewOCIStore initializes a store using an OCI registry as backend.
 func NewOCIStore(u *url.URL, creds auth.CredentialFunc, opt StoreOptions) (OCIStore, error) {
-	// The OCI spec does not support desync's default hash algorithm (SHA512/256), so we must
-	// be using SHA256 only.
-	if Digest.Algorithm() != crypto.SHA256 {
-		return OCIStore{}, errors.New("OCI stores only support SHA256, use --digest=sha256")
+	if u.Scheme != "oci+https" && u.Scheme != "oci+http" {
+		return OCIStore{}, fmt.Errorf("unsupported scheme %s, expected oci+https or oci+http", u.Scheme)
 	}
-
 	repo, err := remote.NewRepository(u.Host + u.Path)
 	if err != nil {
 		return OCIStore{}, fmt.Errorf("failed to initialize oci registry store: %w", err)
 	}
-	baseTransport := http.DefaultTransport.(*http.Transport).Clone()
-	baseTransport.TLSClientConfig = &tls.Config{
-		InsecureSkipVerify: opt.TrustInsecure,
+
+	// Build a TLS client config
+	tlsConfig := &tls.Config{InsecureSkipVerify: opt.TrustInsecure}
+
+	// Add client key/cert if provided
+	if opt.ClientCert != "" && opt.ClientKey != "" {
+		certificate, err := tls.LoadX509KeyPair(opt.ClientCert, opt.ClientKey)
+		if err != nil {
+			return OCIStore{}, fmt.Errorf("failed to load client certificate from %s", opt.ClientCert)
+		}
+		tlsConfig.Certificates = []tls.Certificate{certificate}
 	}
+
+	// Load custom CA set if provided
+	if opt.CACert != "" {
+		certPool := x509.NewCertPool()
+		b, err := os.ReadFile(opt.CACert)
+		if err != nil {
+			return OCIStore{}, err
+		}
+		if ok := certPool.AppendCertsFromPEM(b); !ok {
+			return OCIStore{}, errors.New("no CA certificates found in ca-cert file")
+		}
+		tlsConfig.RootCAs = certPool
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
+
+	var rt http.RoundTripper = transport
+	if opt.ErrorRetry > 0 {
+		policy := &retry.GenericPolicy{
+			Retryable: retry.DefaultPredicate,
+			Backoff: func(attempt int, resp *http.Response) time.Duration {
+				return time.Duration(attempt+1) * opt.ErrorRetryBaseInterval
+			},
+			MaxWait:  time.Duration(opt.ErrorRetry) * opt.ErrorRetryBaseInterval,
+			MaxRetry: opt.ErrorRetry,
+		}
+		rt = &retry.Transport{Base: transport, Policy: func() retry.Policy { return policy }}
+	}
+
+	// If no timeout was given in config (set to 0), then use 1 minute. If timeout is negative, use 0 to
+	// set an infinite timeout.
+	timeout := opt.Timeout
+	if timeout == 0 {
+		timeout = time.Minute
+	} else if timeout < 0 {
+		timeout = 0
+	}
+
 	client := &auth.Client{
-		Client: &http.Client{
-			Transport: retry.NewTransport(baseTransport),
-		},
+		Client:     &http.Client{Transport: rt, Timeout: timeout},
 		Cache:      auth.NewCache(),
 		Credential: creds,
 	}
 	client.SetUserAgent("desync")
 	repo.Client = client
 	repo.PlainHTTP = u.Scheme == "oci+http"
+
 	s := OCIStore{
-		repo:     repo,
-		location: u.String(),
-		opt:      opt,
+		repo:         repo,
+		location:     u.String(),
+		opt:          opt,
+		converters:   opt.converters(),
+		configPushed: &atomic.Bool{},
 	}
 	return s, nil
 }
@@ -72,56 +130,149 @@ func (s OCIStore) String() string {
 // Close the store. NOP operation but needed to implement the store interface.
 func (s OCIStore) Close() error { return nil }
 
-// GetChunk reads and returns one chunk from the store
+// GetChunk reads and returns one chunk from the store. The chunk's manifest is
+// looked up by tag, then the blob it references is fetched.
 func (s OCIStore) GetChunk(id ChunkID) (*Chunk, error) {
-	descriptor, r, err := s.repo.Blobs().FetchReference(context.Background(), ociReference(id))
+	ctx := context.Background()
+	blobDesc, err := s.resolveChunkBlob(ctx, id)
 	if err != nil {
+		return nil, err
+	}
+	r, err := s.repo.Blobs().Fetch(ctx, blobDesc)
+	if err != nil {
+		// A manifest that references a blob the registry no longer has is
+		// treated like a missing chunk so other stores can be tried.
 		if errors.Is(err, errdef.ErrNotFound) {
 			return nil, ChunkMissing{id}
 		}
 		return nil, err
 	}
 	defer r.Close()
-	b := make([]byte, descriptor.Size)
+	b := make([]byte, blobDesc.Size)
 	if _, err := io.ReadFull(r, b); err != nil {
 		return nil, err
 	}
-	return NewChunkFromStorage(id, b, nil, s.opt.SkipVerify)
-}
-
-// StoreChunk adds a new chunk to the store.
-func (s OCIStore) StoreChunk(chunk *Chunk) error {
-	b, err := chunk.Data()
-	if err != nil {
-		return err
-	}
-	descriptor := ociDescriptorForChunk(chunk.ID())
-	descriptor.Size = int64(len(b))
-	return s.repo.Push(context.Background(), descriptor, bytes.NewReader(b))
+	return NewChunkFromStorage(id, b, s.converters, s.opt.SkipVerify)
 }
 
 // HasChunk returns true if the chunk is in the store.
 func (s OCIStore) HasChunk(id ChunkID) (bool, error) {
-	return s.repo.Exists(context.Background(), ociDescriptorForChunk(id))
+	_, err := s.repo.Resolve(context.Background(), id.String())
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, errdef.ErrNotFound):
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+// StoreChunk adds a new chunk to the store. The chunk data is pushed as a blob,
+// then referenced by a manifest tagged with the chunk ID.
+func (s OCIStore) StoreChunk(chunk *Chunk) error {
+	ctx := context.Background()
+	id := chunk.ID()
+	b, err := chunk.Data()
+	if err != nil {
+		return err
+	}
+	b, err = s.converters.toStorage(b)
+	if err != nil {
+		return err
+	}
+	if err := s.ensureConfigBlob(ctx); err != nil {
+		return err
+	}
+	blobDesc := ocispec.Descriptor{
+		MediaType: "application/octet-stream",
+		Digest:    digest.FromBytes(b),
+		Size:      int64(len(b)),
+	}
+	if err := s.repo.Blobs().Push(ctx, blobDesc, bytes.NewReader(b)); err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+		return err
+	}
+	config := ocispec.DescriptorEmptyJSON
+	config.Data = nil
+	manifest := ocispec.Manifest{
+		Versioned:    specs.Versioned{SchemaVersion: 2},
+		MediaType:    ocispec.MediaTypeImageManifest,
+		ArtifactType: OCIChunkArtifactType,
+		Config:       config,
+		Layers:       []ocispec.Descriptor{blobDesc},
+		Annotations:  map[string]string{ocispec.AnnotationTitle: id.String() + ".cacnk"},
+	}
+	mb, err := json.Marshal(manifest)
+	if err != nil {
+		return err
+	}
+	manifestDesc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    digest.FromBytes(mb),
+		Size:      int64(len(mb)),
+	}
+	return s.repo.Manifests().PushReference(ctx, manifestDesc, bytes.NewReader(mb), id.String())
 }
 
 // RemoveChunk deletes a chunk, typically an invalid one, from the store.
-// Used when verifying and repairing caches.
+// Used when verifying and repairing caches. Only the manifest is deleted,
+// the blob is left for the registry's garbage collection.
 func (s OCIStore) RemoveChunk(id ChunkID) error {
-	err := s.repo.Delete(context.Background(), ociDescriptorForChunk(id))
-	if errors.Is(err, errdef.ErrNotFound) {
-		return ChunkMissing{id}
+	ctx := context.Background()
+	desc, err := s.repo.Resolve(ctx, id.String())
+	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return ChunkMissing{id}
+		}
+		return err
 	}
-	return err
+	return s.repo.Manifests().Delete(ctx, desc)
 }
 
-func ociDescriptorForChunk(id ChunkID) ocispec.Descriptor {
-	return ocispec.Descriptor{
-		Digest:    digest.Digest(ociReference(id)),
-		MediaType: "application/vnd.oci.image.layer.v1.tar+zstd",
+// resolveChunkBlob fetches the chunk's manifest by tag and returns the
+// descriptor of the blob holding the chunk data.
+func (s OCIStore) resolveChunkBlob(ctx context.Context, id ChunkID) (ocispec.Descriptor, error) {
+	_, r, err := s.repo.FetchReference(ctx, id.String())
+	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return ocispec.Descriptor{}, ChunkMissing{id}
+		}
+		return ocispec.Descriptor{}, err
 	}
+	defer r.Close()
+	mb, err := io.ReadAll(r)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	var manifest ocispec.Manifest
+	if err := json.Unmarshal(mb, &manifest); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("invalid manifest for chunk %s in %s: %w", id, s, err)
+	}
+	if len(manifest.Layers) != 1 {
+		return ocispec.Descriptor{}, fmt.Errorf("manifest for chunk %s in %s references %d blobs, expected exactly one", id, s, len(manifest.Layers))
+	}
+	return manifest.Layers[0], nil
 }
 
-func ociReference(id ChunkID) string {
-	return "sha256:" + id.String()
+// ensureConfigBlob uploads the shared empty config blob that every chunk
+// manifest references. It only needs to exist once per repository, so the
+// check-and-push runs once per store instance.
+func (s OCIStore) ensureConfigBlob(ctx context.Context) error {
+	if s.configPushed.Load() {
+		return nil
+	}
+	desc := ocispec.DescriptorEmptyJSON
+	desc.Data = nil
+	exists, err := s.repo.Blobs().Exists(ctx, desc)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		err := s.repo.Blobs().Push(ctx, desc, bytes.NewReader(ocispec.DescriptorEmptyJSON.Data))
+		if err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+			return err
+		}
+	}
+	s.configPushed.Store(true)
+	return nil
 }

--- a/oci.go
+++ b/oci.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -22,12 +21,14 @@ import (
 
 var _ WriteStore = OCIStore{}
 
-// OCIStore operates on chunks in an Open Container Image registry.
+// OCIStore operates on chunks in an Open Container Image registry. Chunks are
+// stored as plain blobs whose digest is the chunk ID. Since registries verify
+// that uploaded content matches the declared digest, chunks are always stored
+// uncompressed, regardless of the store's compression options.
 type OCIStore struct {
-	repo       *remote.Repository
-	location   string
-	opt        StoreOptions
-	converters Converters
+	repo     *remote.Repository
+	location string
+	opt      StoreOptions
 }
 
 // NewOCIStore initializes a new Open Registry As Storage backend.
@@ -50,11 +51,12 @@ func NewOCIStore(u *url.URL, creds auth.CredentialFunc, opt StoreOptions) (OCISt
 		Client: &http.Client{
 			Transport: retry.NewTransport(baseTransport),
 		},
+		Cache:      auth.NewCache(),
 		Credential: creds,
 	}
 	client.SetUserAgent("desync")
 	repo.Client = client
-	repo.PlainHTTP = strings.HasSuffix(u.Scheme, "-http")
+	repo.PlainHTTP = u.Scheme == "oci+http"
 	s := OCIStore{
 		repo:     repo,
 		location: u.String(),
@@ -72,14 +74,7 @@ func (s OCIStore) Close() error { return nil }
 
 // GetChunk reads and returns one chunk from the store
 func (s OCIStore) GetChunk(id ChunkID) (*Chunk, error) {
-	descriptor, err := s.repo.Blobs().Resolve(context.Background(), ociReference(id))
-	if err != nil {
-		if errors.Is(err, errdef.ErrNotFound) {
-			return nil, ChunkMissing{id}
-		}
-		return nil, err
-	}
-	r, err := s.repo.Fetch(context.Background(), descriptor)
+	descriptor, r, err := s.repo.Blobs().FetchReference(context.Background(), ociReference(id))
 	if err != nil {
 		if errors.Is(err, errdef.ErrNotFound) {
 			return nil, ChunkMissing{id}
@@ -87,20 +82,16 @@ func (s OCIStore) GetChunk(id ChunkID) (*Chunk, error) {
 		return nil, err
 	}
 	defer r.Close()
-	b, err := io.ReadAll(r)
-	if err != nil {
+	b := make([]byte, descriptor.Size)
+	if _, err := io.ReadFull(r, b); err != nil {
 		return nil, err
 	}
-	return NewChunkFromStorage(id, b, s.converters, s.opt.SkipVerify)
+	return NewChunkFromStorage(id, b, nil, s.opt.SkipVerify)
 }
 
 // StoreChunk adds a new chunk to the store.
 func (s OCIStore) StoreChunk(chunk *Chunk) error {
 	b, err := chunk.Data()
-	if err != nil {
-		return err
-	}
-	b, err = s.converters.toStorage(b)
 	if err != nil {
 		return err
 	}

--- a/oci.go
+++ b/oci.go
@@ -28,6 +28,7 @@ import (
 const OCIChunkArtifactType = "application/vnd.desync.chunk.v1"
 
 var _ WriteStore = OCIStore{}
+var _ PruneStore = OCIStore{}
 
 // OCIStore operates on chunks in an OCI registry. Every chunk is stored as its
 // own artifact: a blob holding the chunk in storage format (compressed unless
@@ -227,6 +228,37 @@ func (s OCIStore) RemoveChunk(id ChunkID) error {
 		return err
 	}
 	return s.repo.Manifests().Delete(ctx, desc)
+}
+
+// Prune removes any chunks from the store that are not referenced in the
+// list of chunks. Only tags that parse as chunk IDs are considered, other
+// artifacts sharing the repository are left alone. Just the chunk manifests
+// are deleted, reclaiming the space of the now unreferenced blobs is left
+// to the registry's garbage collection.
+func (s OCIStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
+	return s.repo.Tags(ctx, "", func(tags []string) error {
+		for _, tag := range tags {
+			// See if we're meant to stop
+			select {
+			case <-ctx.Done():
+				return Interrupted{}
+			default:
+			}
+
+			id, err := ChunkIDFromString(tag)
+			if err != nil {
+				continue
+			}
+
+			// Drop the chunk if it's not on the list
+			if _, ok := ids[id]; !ok {
+				if err = s.RemoveChunk(id); err != nil && !errors.Is(err, ChunkMissing{id}) {
+					return err
+				}
+			}
+		}
+		return nil
+	})
 }
 
 // resolveChunkBlob fetches the chunk's manifest by tag and returns the

--- a/oci.go
+++ b/oci.go
@@ -31,6 +31,13 @@ const OCIChunkArtifactType = "application/vnd.desync.chunk.v1"
 // driving a huge or invalid allocation before the blob is even fetched.
 const maxOCIChunkBlobSize = 1 << 30
 
+// ociTagListPageSize bounds the tag listing used by Prune. Without it oras
+// sends no page size and registries answer with the complete tag list, which
+// it then reads under a 4MB metadata limit. A chunk tag costs about 72 bytes
+// there, so a store of more than roughly 57k chunks - well under 4GB at the
+// default chunk size - would fail to prune at all.
+const ociTagListPageSize = 1000
+
 // retryPredicate retries any transport error, matching the error-retry
 // behavior of the other network stores. Response codes are left to the
 // default predicate, which retries 408, 429, and 5xx.
@@ -95,6 +102,7 @@ func NewOCIStore(u *url.URL, creds auth.CredentialFunc, opt StoreOptions) (OCISt
 	// can never have anything to do. Declaring the capability stops it from
 	// fetching every manifest ahead of a delete just to look for a subject.
 	repo.SetReferrersCapability(true)
+	repo.TagListPageSize = ociTagListPageSize
 
 	tlsConfig, err := opt.tlsClientConfig()
 	if err != nil {

--- a/oci.go
+++ b/oci.go
@@ -10,12 +10,13 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"sync/atomic"
+	"sync"
 	"time"
 
-	"github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sync/errgroup"
+	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
@@ -40,8 +41,17 @@ func retryPredicate(resp *http.Response, err error) (bool, error) {
 	return retry.DefaultPredicate(resp, nil)
 }
 
-var _ WriteStore = OCIStore{}
 var _ PruneStore = OCIStore{}
+
+// ociEmptyConfig is the config descriptor shared by all chunk manifests: the
+// spec's empty-JSON descriptor with the inline Data payload stripped so it is
+// never serialized into manifests. The payload itself is pushed as a regular
+// blob by ensureConfigBlob.
+var ociEmptyConfig = func() ocispec.Descriptor {
+	d := ocispec.DescriptorEmptyJSON
+	d.Data = nil
+	return d
+}()
 
 // OCIStore operates on chunks in an OCI registry. Every chunk is stored as its
 // own artifact: a blob holding the chunk in storage format (compressed and/or
@@ -54,14 +64,21 @@ var _ PruneStore = OCIStore{}
 // one repository. The manifest also keeps the blob referenced, protecting it
 // from registry garbage collection of unreferenced blobs.
 type OCIStore struct {
-	repo         *remote.Repository
-	location     string
-	opt          StoreOptions
-	converters   Converters
-	configPushed *atomic.Bool
+	repo       *remote.Repository
+	location   string
+	opt        StoreOptions
+	converters Converters
+	config     *ociConfigBlobState
 
 	// Chunk tag extension, derived from the converters at construction
 	extension string
+}
+
+// ociConfigBlobState tracks whether the shared empty config blob is known to
+// exist in the registry. Shared by all copies of a store value.
+type ociConfigBlobState struct {
+	mu     sync.Mutex
+	pushed bool
 }
 
 // NewOCIStore initializes a store using an OCI registry as backend.
@@ -115,12 +132,12 @@ func NewOCIStore(u *url.URL, creds auth.CredentialFunc, opt StoreOptions) (OCISt
 		return OCIStore{}, err
 	}
 	s := OCIStore{
-		repo:         repo,
-		location:     u.String(),
-		opt:          opt,
-		converters:   converters,
-		configPushed: &atomic.Bool{},
-		extension:    converters.storageExtension(),
+		repo:       repo,
+		location:   u.String(),
+		opt:        opt,
+		converters: converters,
+		config:     &ociConfigBlobState{},
+		extension:  converters.storageExtension(),
 	}
 	return s, nil
 }
@@ -143,9 +160,16 @@ func (s OCIStore) Close() error { return nil }
 // looked up by tag, then the blob it references is fetched.
 func (s OCIStore) GetChunk(id ChunkID) (*Chunk, error) {
 	ctx := context.Background()
-	blobDesc, err := s.resolveChunkBlob(ctx, id)
+	manifest, _, err := s.fetchChunkManifest(ctx, id)
 	if err != nil {
 		return nil, err
+	}
+	if len(manifest.Layers) != 1 {
+		return nil, fmt.Errorf("manifest for chunk %s in %s references %d blobs, expected exactly one", id.String(), s, len(manifest.Layers))
+	}
+	blobDesc := manifest.Layers[0]
+	if blobDesc.Size < 0 || blobDesc.Size > maxOCIChunkBlobSize {
+		return nil, fmt.Errorf("manifest for chunk %s in %s references a blob of invalid size %d", id.String(), s, blobDesc.Size)
 	}
 	r, err := s.repo.Blobs().Fetch(ctx, blobDesc)
 	if err != nil {
@@ -164,13 +188,15 @@ func (s OCIStore) GetChunk(id ChunkID) (*Chunk, error) {
 	return NewChunkFromStorage(id, b, s.converters, s.opt.SkipVerify)
 }
 
-// HasChunk returns true if the chunk is in the store.
+// HasChunk returns true if the chunk is in the store. Like all other chunk
+// operations it goes through fetchChunkManifest, so a foreign artifact under
+// a chunk-ID-shaped tag doesn't count as the chunk being present.
 func (s OCIStore) HasChunk(id ChunkID) (bool, error) {
-	_, err := s.repo.Resolve(context.Background(), s.tagFromID(id))
+	_, _, err := s.fetchChunkManifest(context.Background(), id)
 	switch {
 	case err == nil:
 		return true, nil
-	case errors.Is(err, errdef.ErrNotFound):
+	case errors.Is(err, ChunkMissing{id}):
 		return false, nil
 	default:
 		return false, err
@@ -189,34 +215,25 @@ func (s OCIStore) StoreChunk(chunk *Chunk) error {
 	if err := s.ensureConfigBlob(ctx); err != nil {
 		return err
 	}
-	blobDesc := ocispec.Descriptor{
-		MediaType: "application/octet-stream",
-		Digest:    digest.FromBytes(b),
-		Size:      int64(len(b)),
-	}
+	blobDesc := content.NewDescriptorFromBytes("application/octet-stream", b)
 	if err := s.repo.Blobs().Push(ctx, blobDesc, bytes.NewReader(b)); err != nil {
 		return err
 	}
-	config := ocispec.DescriptorEmptyJSON
-	config.Data = nil
+	tag := s.tagFromID(id)
 	manifest := ocispec.Manifest{
 		Versioned:    specs.Versioned{SchemaVersion: 2},
 		MediaType:    ocispec.MediaTypeImageManifest,
 		ArtifactType: OCIChunkArtifactType,
-		Config:       config,
+		Config:       ociEmptyConfig,
 		Layers:       []ocispec.Descriptor{blobDesc},
-		Annotations:  map[string]string{ocispec.AnnotationTitle: s.tagFromID(id)},
+		Annotations:  map[string]string{ocispec.AnnotationTitle: tag},
 	}
 	mb, err := json.Marshal(manifest)
 	if err != nil {
 		return err
 	}
-	manifestDesc := ocispec.Descriptor{
-		MediaType: ocispec.MediaTypeImageManifest,
-		Digest:    digest.FromBytes(mb),
-		Size:      int64(len(mb)),
-	}
-	return s.repo.Manifests().PushReference(ctx, manifestDesc, bytes.NewReader(mb), s.tagFromID(id))
+	manifestDesc := content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, mb)
+	return s.repo.Manifests().PushReference(ctx, manifestDesc, bytes.NewReader(mb), tag)
 }
 
 // RemoveChunk deletes a chunk, typically an invalid one, from the store.
@@ -242,11 +259,16 @@ func (s OCIStore) RemoveChunk(id ChunkID) error {
 // manifests are deleted, reclaiming the space of the now unreferenced blobs
 // is left to the registry's garbage collection.
 func (s OCIStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
-	return s.repo.Tags(ctx, "", func(tags []string) error {
+	// Each removal costs two network round-trips and they are independent of
+	// each other, so fan them out while the tag listing stays sequential. The
+	// group context also stops the listing once a removal has failed.
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(max(s.opt.N, 1))
+	tagsErr := s.repo.Tags(ctx, "", func(tags []string) error {
 		for _, tag := range tags {
 			// See if we're meant to stop
 			select {
-			case <-ctx.Done():
+			case <-gctx.Done():
 				return Interrupted{}
 			default:
 			}
@@ -258,30 +280,20 @@ func (s OCIStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 
 			// Drop the chunk if it's not on the list
 			if _, ok := ids[id]; !ok {
-				if err := s.RemoveChunk(id); err != nil && !errors.Is(err, ChunkMissing{id}) {
-					return err
-				}
+				g.Go(func() error {
+					if err := s.RemoveChunk(id); err != nil && !errors.Is(err, ChunkMissing{id}) {
+						return err
+					}
+					return nil
+				})
 			}
 		}
 		return nil
 	})
-}
-
-// resolveChunkBlob fetches the chunk's manifest by tag and returns the
-// descriptor of the blob holding the chunk data.
-func (s OCIStore) resolveChunkBlob(ctx context.Context, id ChunkID) (ocispec.Descriptor, error) {
-	manifest, _, err := s.fetchChunkManifest(ctx, id)
-	if err != nil {
-		return ocispec.Descriptor{}, err
+	if err := g.Wait(); err != nil {
+		return err
 	}
-	if len(manifest.Layers) != 1 {
-		return ocispec.Descriptor{}, fmt.Errorf("manifest for chunk %s in %s references %d blobs, expected exactly one", id.String(), s, len(manifest.Layers))
-	}
-	blobDesc := manifest.Layers[0]
-	if blobDesc.Size < 0 || blobDesc.Size > maxOCIChunkBlobSize {
-		return ocispec.Descriptor{}, fmt.Errorf("manifest for chunk %s in %s references a blob of invalid size %d", id.String(), s, blobDesc.Size)
-	}
-	return blobDesc, nil
+	return tagsErr
 }
 
 // fetchChunkManifest fetches the manifest tagged for the chunk and returns it
@@ -313,18 +325,26 @@ func (s OCIStore) fetchChunkManifest(ctx context.Context, id ChunkID) (ocispec.M
 	return manifest, desc, nil
 }
 
-// ensureConfigBlob uploads the shared empty config blob that every chunk
-// manifest references. Registries accept re-pushes of existing blobs, so
-// the push is simply skipped once it has succeeded for this store instance.
+// ensureConfigBlob makes sure the shared empty config blob that every chunk
+// manifest references exists in the registry, pushing it if the registry
+// doesn't have it yet. The mutex single-flights the check, so of any number
+// of concurrent writers only the first talks to the registry, and later
+// calls return without network I/O once it has succeeded.
 func (s OCIStore) ensureConfigBlob(ctx context.Context) error {
-	if s.configPushed.Load() {
+	s.config.mu.Lock()
+	defer s.config.mu.Unlock()
+	if s.config.pushed {
 		return nil
 	}
-	desc := ocispec.DescriptorEmptyJSON
-	desc.Data = nil
-	if err := s.repo.Blobs().Push(ctx, desc, bytes.NewReader(ocispec.DescriptorEmptyJSON.Data)); err != nil {
+	exists, err := s.repo.Blobs().Exists(ctx, ociEmptyConfig)
+	if err != nil {
 		return err
 	}
-	s.configPushed.Store(true)
+	if !exists {
+		if err := s.repo.Blobs().Push(ctx, ociEmptyConfig, bytes.NewReader(ocispec.DescriptorEmptyJSON.Data)); err != nil {
+			return err
+		}
+	}
+	s.config.pushed = true
 	return nil
 }

--- a/oci_test.go
+++ b/oci_test.go
@@ -206,14 +206,44 @@ func TestOCIStoreRoundtrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, data, b)
 
-	// The chunk's manifest must be tagged with the chunk ID to be protected
-	// from registry garbage collection, and the blob must hold the chunk in
-	// compressed form
+	// The chunk's manifest must be tagged with the chunk ID and storage
+	// extension to be protected from registry garbage collection, and the
+	// blob must hold the chunk in compressed form
 	reg.mu.Lock()
 	defer reg.mu.Unlock()
-	assert.Contains(t, reg.manifests, id.String())
+	assert.Contains(t, reg.manifests, id.String()+".cacnk")
 	compressed := fmt.Sprintf("sha256:%x", sha256.Sum256(data))
 	assert.NotContains(t, reg.blobs, compressed, "chunk blob should be compressed")
+}
+
+// Encrypted chunks use the same tag naming as chunk files in other stores,
+// with the algorithm and key ID in the extension, so chunks with different
+// keys or formats can coexist in one repository.
+func TestOCIStoreEncrypted(t *testing.T) {
+	s, reg := newTestOCIStore(t, StoreOptions{Encryption: true, EncryptionKey: testEncryptionKey})
+
+	data := []byte("some chunk data")
+	chunk := NewChunk(data)
+	id := chunk.ID()
+	require.NoError(t, s.StoreChunk(chunk))
+
+	got, err := s.GetChunk(id)
+	require.NoError(t, err)
+	b, err := got.Data()
+	require.NoError(t, err)
+	assert.Equal(t, data, b)
+
+	// The manifest tag has to carry the algorithm and key ID
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+	var tags []string
+	for k := range reg.manifests {
+		if strings.HasPrefix(k, id.String()) {
+			tags = append(tags, k)
+		}
+	}
+	require.Len(t, tags, 1)
+	assert.Regexp(t, `\.cacnk\.xchacha20-poly1305-[0-9a-f]{8}$`, tags[0])
 }
 
 func TestOCIStoreUncompressed(t *testing.T) {
@@ -267,9 +297,15 @@ func TestOCIStorePrune(t *testing.T) {
 		digest:    fmt.Sprintf("sha256:%x", sha256.Sum256(foreignContent)),
 		content:   foreignContent,
 	}
+	// Also add a chunk in a different storage format, a bare chunk-ID tag as
+	// used by an uncompressed, unencrypted store. Pruning this compressed
+	// store must not touch chunks in other formats.
+	otherFormat := NewChunk([]byte("other format chunk"))
+	otherFormatID := otherFormat.ID()
 	reg.mu.Lock()
 	reg.manifests["latest"] = foreign
 	reg.manifests[foreign.digest] = foreign
+	reg.manifests[otherFormatID.String()] = foreign
 	reg.mu.Unlock()
 
 	// Prune everything but the first chunk
@@ -288,6 +324,7 @@ func TestOCIStorePrune(t *testing.T) {
 	reg.mu.Lock()
 	defer reg.mu.Unlock()
 	assert.Contains(t, reg.manifests, "latest")
+	assert.Contains(t, reg.manifests, otherFormatID.String(), "chunk in a different storage format was pruned")
 }
 
 func TestOCIStoreInvalidChunk(t *testing.T) {

--- a/oci_test.go
+++ b/oci_test.go
@@ -1,0 +1,137 @@
+package desync
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func withSHA256Digest(t *testing.T) {
+	t.Helper()
+	prev := Digest
+	Digest = SHA256{}
+	t.Cleanup(func() { Digest = prev })
+}
+
+func TestOCIStoreRequiresSHA256(t *testing.T) {
+	u, err := url.Parse("oci+https://registry.example.com/user/repo")
+	require.NoError(t, err)
+
+	// The default digest algorithm (SHA512/256) is not supported by OCI registries
+	_, err = NewOCIStore(u, nil, StoreOptions{})
+	require.Error(t, err)
+
+	withSHA256Digest(t)
+	_, err = NewOCIStore(u, nil, StoreOptions{})
+	require.NoError(t, err)
+}
+
+func TestOCIStorePlainHTTP(t *testing.T) {
+	withSHA256Digest(t)
+
+	tests := map[string]struct {
+		url       string
+		plainHTTP bool
+	}{
+		"https": {"oci+https://registry.example.com/user/repo", false},
+		"http":  {"oci+http://127.0.0.1:5000/user/repo", true},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			u, err := url.Parse(test.url)
+			require.NoError(t, err)
+			s, err := NewOCIStore(u, nil, StoreOptions{})
+			require.NoError(t, err)
+			require.Equal(t, test.plainHTTP, s.repo.PlainHTTP)
+		})
+	}
+}
+
+// testOCIRegistry implements just enough of the OCI distribution API to
+// serve as a blob store for a single repository named "user/repo".
+type testOCIRegistry struct {
+	mu    sync.Mutex
+	blobs map[string][]byte
+}
+
+func (reg *testOCIRegistry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+	const blobPath = "/v2/user/repo/blobs/"
+	const uploadPath = "/v2/user/repo/blobs/uploads/"
+	switch {
+	case (r.Method == http.MethodGet || r.Method == http.MethodHead) && len(r.URL.Path) > len(blobPath) && r.URL.Path[:len(blobPath)] == blobPath:
+		b, ok := reg.blobs[r.URL.Path[len(blobPath):]]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Length", strconv.Itoa(len(b)))
+		w.Header().Set("Content-Type", "application/octet-stream")
+		if r.Method == http.MethodGet {
+			w.Write(b)
+		}
+	case r.Method == http.MethodPost && r.URL.Path == uploadPath:
+		w.Header().Set("Location", uploadPath+"session")
+		w.WriteHeader(http.StatusAccepted)
+	case r.Method == http.MethodPut && r.URL.Path == uploadPath+"session":
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		d := r.URL.Query().Get("digest")
+		if fmt.Sprintf("sha256:%x", sha256.Sum256(b)) != d {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		reg.blobs[d] = b
+		w.WriteHeader(http.StatusCreated)
+	default:
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+func TestOCIStoreRoundtrip(t *testing.T) {
+	withSHA256Digest(t)
+
+	srv := httptest.NewServer(&testOCIRegistry{blobs: make(map[string][]byte)})
+	defer srv.Close()
+
+	u, err := url.Parse("oci+" + srv.URL + "/user/repo")
+	require.NoError(t, err)
+	s, err := NewOCIStore(u, nil, StoreOptions{})
+	require.NoError(t, err)
+
+	data := []byte("some chunk data")
+	chunk := NewChunk(data)
+
+	// The chunk shouldn't be there yet
+	hasChunk, err := s.HasChunk(chunk.ID())
+	require.NoError(t, err)
+	assert.False(t, hasChunk)
+	_, err = s.GetChunk(chunk.ID())
+	require.ErrorIs(t, err, ChunkMissing{chunk.ID()})
+
+	// Store it, then read it back
+	require.NoError(t, s.StoreChunk(chunk))
+
+	hasChunk, err = s.HasChunk(chunk.ID())
+	require.NoError(t, err)
+	assert.True(t, hasChunk)
+
+	got, err := s.GetChunk(chunk.ID())
+	require.NoError(t, err)
+	b, err := got.Data()
+	require.NoError(t, err)
+	assert.Equal(t, data, b)
+}

--- a/oci_test.go
+++ b/oci_test.go
@@ -13,7 +13,9 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,8 +31,9 @@ func TestOCIStoreScheme(t *testing.T) {
 		url       string
 		plainHTTP bool
 	}{
-		"https": {"oci+https://registry.example.com/user/repo", false},
-		"http":  {"oci+http://127.0.0.1:5000/user/repo", true},
+		"https":          {"oci+https://registry.example.com/user/repo", false},
+		"http":           {"oci+http://127.0.0.1:5000/user/repo", true},
+		"trailing slash": {"oci+https://registry.example.com/user/repo/", false},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -327,6 +330,53 @@ func TestOCIStorePrune(t *testing.T) {
 	assert.Contains(t, reg.manifests, otherFormatID.String(), "chunk in a different storage format was pruned")
 }
 
+// With an uncompressed, unencrypted store the tag extension is empty, so any
+// 64-hex-character tag parses as a chunk ID. Chunks are told apart from
+// foreign artifacts by the manifest's artifact type, so prune, remove, and
+// reads must all leave a foreign artifact under a chunk-ID-shaped tag alone.
+func TestOCIStorePruneForeignArtifact(t *testing.T) {
+	s, reg := newTestOCIStore(t, StoreOptions{Uncompressed: true})
+
+	keep := NewChunk([]byte("chunk to keep"))
+	drop := NewChunk([]byte("chunk to prune"))
+	require.NoError(t, s.StoreChunk(keep))
+	require.NoError(t, s.StoreChunk(drop))
+
+	// A foreign image tagged with a 64-hex string, as CI systems do when
+	// tagging by commit or content hash
+	foreignContent := []byte(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json"}`)
+	foreign := testOCIManifest{
+		mediaType: "application/vnd.oci.image.manifest.v1+json",
+		digest:    fmt.Sprintf("sha256:%x", sha256.Sum256(foreignContent)),
+		content:   foreignContent,
+	}
+	hexTag := strings.Repeat("0123", 16)
+	foreignID, err := ChunkIDFromString(hexTag)
+	require.NoError(t, err)
+	reg.mu.Lock()
+	reg.manifests[hexTag] = foreign
+	reg.manifests[foreign.digest] = foreign
+	reg.mu.Unlock()
+
+	// The foreign artifact must not be mistaken for a stored chunk
+	_, err = s.GetChunk(foreignID)
+	require.ErrorIs(t, err, ChunkMissing{foreignID})
+	require.ErrorIs(t, s.RemoveChunk(foreignID), ChunkMissing{foreignID})
+
+	require.NoError(t, s.Prune(context.Background(), map[ChunkID]struct{}{keep.ID(): {}}))
+
+	hasChunk, err := s.HasChunk(keep.ID())
+	require.NoError(t, err)
+	assert.True(t, hasChunk)
+	hasChunk, err = s.HasChunk(drop.ID())
+	require.NoError(t, err)
+	assert.False(t, hasChunk)
+
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+	assert.Contains(t, reg.manifests, hexTag, "foreign artifact with a chunk-ID-shaped tag was pruned")
+}
+
 func TestOCIStoreInvalidChunk(t *testing.T) {
 	s, reg := newTestOCIStore(t, StoreOptions{Uncompressed: true})
 
@@ -344,4 +394,61 @@ func TestOCIStoreInvalidChunk(t *testing.T) {
 	_, err := s.GetChunk(chunk.ID())
 	var invalid ChunkInvalid
 	require.ErrorAs(t, err, &invalid)
+}
+
+// A corrupt or malicious manifest declaring a negative or absurd blob size
+// must produce an error, not a panic or a huge allocation.
+func TestOCIStoreInvalidBlobSize(t *testing.T) {
+	s, reg := newTestOCIStore(t, StoreOptions{Uncompressed: true})
+
+	chunk := NewChunk([]byte("some chunk data"))
+	id := chunk.ID()
+	require.NoError(t, s.StoreChunk(chunk))
+
+	for name, size := range map[string]int64{"negative": -1, "huge": 1 << 60} {
+		t.Run(name, func(t *testing.T) {
+			manifest := fmt.Sprintf(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","artifactType":%q,"config":{"mediaType":"application/vnd.oci.empty.v1+json","digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","size":2},"layers":[{"mediaType":"application/octet-stream","digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","size":%d}]}`, OCIChunkArtifactType, size)
+			m := testOCIManifest{
+				mediaType: "application/vnd.oci.image.manifest.v1+json",
+				digest:    fmt.Sprintf("sha256:%x", sha256.Sum256([]byte(manifest))),
+				content:   []byte(manifest),
+			}
+			reg.mu.Lock()
+			reg.manifests[id.String()] = m
+			reg.manifests[m.digest] = m
+			reg.mu.Unlock()
+
+			_, err := s.GetChunk(id)
+			require.ErrorContains(t, err, "invalid size")
+		})
+	}
+}
+
+// Transient network errors like a dropped connection are retried when
+// error-retry is configured, matching the other network stores.
+func TestOCIStoreRetry(t *testing.T) {
+	reg := newTestOCIRegistry()
+	var dropped atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Drop the very first connection without a response
+		if dropped.CompareAndSwap(false, true) {
+			conn, _, err := w.(http.Hijacker).Hijack()
+			if err == nil {
+				conn.Close()
+			}
+			return
+		}
+		reg.ServeHTTP(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse("oci+" + srv.URL + "/user/repo")
+	require.NoError(t, err)
+	s, err := NewOCIStore(u, nil, StoreOptions{ErrorRetry: 2, ErrorRetryBaseInterval: time.Millisecond})
+	require.NoError(t, err)
+
+	hasChunk, err := s.HasChunk(NewChunk([]byte("some chunk data")).ID())
+	require.NoError(t, err)
+	assert.False(t, hasChunk)
+	assert.True(t, dropped.Load())
 }

--- a/oci_test.go
+++ b/oci_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 
@@ -15,28 +16,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func withSHA256Digest(t *testing.T) {
-	t.Helper()
-	prev := Digest
-	Digest = SHA256{}
-	t.Cleanup(func() { Digest = prev })
-}
-
-func TestOCIStoreRequiresSHA256(t *testing.T) {
-	u, err := url.Parse("oci+https://registry.example.com/user/repo")
+func TestOCIStoreScheme(t *testing.T) {
+	u, err := url.Parse("https://registry.example.com/user/repo")
 	require.NoError(t, err)
-
-	// The default digest algorithm (SHA512/256) is not supported by OCI registries
 	_, err = NewOCIStore(u, nil, StoreOptions{})
 	require.Error(t, err)
-
-	withSHA256Digest(t)
-	_, err = NewOCIStore(u, nil, StoreOptions{})
-	require.NoError(t, err)
-}
-
-func TestOCIStorePlainHTTP(t *testing.T) {
-	withSHA256Digest(t)
 
 	tests := map[string]struct {
 		url       string
@@ -56,11 +40,27 @@ func TestOCIStorePlainHTTP(t *testing.T) {
 	}
 }
 
-// testOCIRegistry implements just enough of the OCI distribution API to
-// serve as a blob store for a single repository named "user/repo".
+// testOCIManifest is a manifest held by testOCIRegistry, stored under both its
+// tag and its digest.
+type testOCIManifest struct {
+	mediaType string
+	digest    string
+	content   []byte
+}
+
+// testOCIRegistry implements just enough of the OCI distribution API to serve
+// as a chunk store for a single repository named "user/repo".
 type testOCIRegistry struct {
-	mu    sync.Mutex
-	blobs map[string][]byte
+	mu        sync.Mutex
+	blobs     map[string][]byte
+	manifests map[string]testOCIManifest
+}
+
+func newTestOCIRegistry() *testOCIRegistry {
+	return &testOCIRegistry{
+		blobs:     make(map[string][]byte),
+		manifests: make(map[string]testOCIManifest),
+	}
 }
 
 func (reg *testOCIRegistry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -68,9 +68,12 @@ func (reg *testOCIRegistry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer reg.mu.Unlock()
 	const blobPath = "/v2/user/repo/blobs/"
 	const uploadPath = "/v2/user/repo/blobs/uploads/"
+	const manifestPath = "/v2/user/repo/manifests/"
 	switch {
-	case (r.Method == http.MethodGet || r.Method == http.MethodHead) && len(r.URL.Path) > len(blobPath) && r.URL.Path[:len(blobPath)] == blobPath:
-		b, ok := reg.blobs[r.URL.Path[len(blobPath):]]
+	case (r.Method == http.MethodGet || r.Method == http.MethodHead) && strings.HasPrefix(r.URL.Path, uploadPath):
+		w.WriteHeader(http.StatusNotFound)
+	case (r.Method == http.MethodGet || r.Method == http.MethodHead) && strings.HasPrefix(r.URL.Path, blobPath):
+		b, ok := reg.blobs[strings.TrimPrefix(r.URL.Path, blobPath)]
 		if !ok {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -96,42 +99,155 @@ func (reg *testOCIRegistry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		reg.blobs[d] = b
 		w.WriteHeader(http.StatusCreated)
+	case (r.Method == http.MethodGet || r.Method == http.MethodHead) && strings.HasPrefix(r.URL.Path, manifestPath):
+		m, ok := reg.manifests[strings.TrimPrefix(r.URL.Path, manifestPath)]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Length", strconv.Itoa(len(m.content)))
+		w.Header().Set("Content-Type", m.mediaType)
+		w.Header().Set("Docker-Content-Digest", m.digest)
+		if r.Method == http.MethodGet {
+			w.Write(m.content)
+		}
+	case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, manifestPath):
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		m := testOCIManifest{
+			mediaType: r.Header.Get("Content-Type"),
+			digest:    fmt.Sprintf("sha256:%x", sha256.Sum256(b)),
+			content:   b,
+		}
+		reg.manifests[strings.TrimPrefix(r.URL.Path, manifestPath)] = m
+		reg.manifests[m.digest] = m
+		w.Header().Set("Docker-Content-Digest", m.digest)
+		w.WriteHeader(http.StatusCreated)
+	case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, manifestPath):
+		ref := strings.TrimPrefix(r.URL.Path, manifestPath)
+		m, ok := reg.manifests[ref]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		for k, v := range reg.manifests {
+			if v.digest == m.digest {
+				delete(reg.manifests, k)
+			}
+		}
+		w.WriteHeader(http.StatusAccepted)
 	default:
 		w.WriteHeader(http.StatusNotFound)
 	}
 }
 
-func TestOCIStoreRoundtrip(t *testing.T) {
-	withSHA256Digest(t)
-
-	srv := httptest.NewServer(&testOCIRegistry{blobs: make(map[string][]byte)})
-	defer srv.Close()
+// newTestOCIStore starts a fake registry and returns a store pointed at it.
+func newTestOCIStore(t *testing.T, opt StoreOptions) (OCIStore, *testOCIRegistry) {
+	t.Helper()
+	reg := newTestOCIRegistry()
+	srv := httptest.NewServer(reg)
+	t.Cleanup(srv.Close)
 
 	u, err := url.Parse("oci+" + srv.URL + "/user/repo")
 	require.NoError(t, err)
-	s, err := NewOCIStore(u, nil, StoreOptions{})
+	s, err := NewOCIStore(u, nil, opt)
 	require.NoError(t, err)
+	return s, reg
+}
+
+// The roundtrip runs with the default SHA512/256 digest algorithm and default
+// compression. Only the tag references the chunk ID, so the store works with
+// digest algorithms that OCI blob digests can't represent.
+func TestOCIStoreRoundtrip(t *testing.T) {
+	s, reg := newTestOCIStore(t, StoreOptions{})
 
 	data := []byte("some chunk data")
 	chunk := NewChunk(data)
+	id := chunk.ID()
 
 	// The chunk shouldn't be there yet
-	hasChunk, err := s.HasChunk(chunk.ID())
+	hasChunk, err := s.HasChunk(id)
 	require.NoError(t, err)
 	assert.False(t, hasChunk)
-	_, err = s.GetChunk(chunk.ID())
-	require.ErrorIs(t, err, ChunkMissing{chunk.ID()})
+	_, err = s.GetChunk(id)
+	require.ErrorIs(t, err, ChunkMissing{id})
 
 	// Store it, then read it back
 	require.NoError(t, s.StoreChunk(chunk))
 
-	hasChunk, err = s.HasChunk(chunk.ID())
+	hasChunk, err = s.HasChunk(id)
 	require.NoError(t, err)
 	assert.True(t, hasChunk)
+
+	got, err := s.GetChunk(id)
+	require.NoError(t, err)
+	b, err := got.Data()
+	require.NoError(t, err)
+	assert.Equal(t, data, b)
+
+	// The chunk's manifest must be tagged with the chunk ID to be protected
+	// from registry garbage collection, and the blob must hold the chunk in
+	// compressed form
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+	assert.Contains(t, reg.manifests, id.String())
+	compressed := fmt.Sprintf("sha256:%x", sha256.Sum256(data))
+	assert.NotContains(t, reg.blobs, compressed, "chunk blob should be compressed")
+}
+
+func TestOCIStoreUncompressed(t *testing.T) {
+	s, reg := newTestOCIStore(t, StoreOptions{Uncompressed: true})
+
+	data := []byte("some uncompressed chunk data")
+	chunk := NewChunk(data)
+	require.NoError(t, s.StoreChunk(chunk))
 
 	got, err := s.GetChunk(chunk.ID())
 	require.NoError(t, err)
 	b, err := got.Data()
 	require.NoError(t, err)
 	assert.Equal(t, data, b)
+
+	// The blob in the registry should hold the chunk data as-is
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+	assert.Contains(t, reg.blobs, fmt.Sprintf("sha256:%x", sha256.Sum256(data)))
+}
+
+func TestOCIStoreRemoveChunk(t *testing.T) {
+	s, _ := newTestOCIStore(t, StoreOptions{})
+
+	chunk := NewChunk([]byte("some chunk data"))
+	id := chunk.ID()
+	require.NoError(t, s.StoreChunk(chunk))
+
+	require.NoError(t, s.RemoveChunk(id))
+	hasChunk, err := s.HasChunk(id)
+	require.NoError(t, err)
+	assert.False(t, hasChunk)
+
+	// Removing a chunk that isn't there reports it as missing
+	require.ErrorIs(t, s.RemoveChunk(id), ChunkMissing{id})
+}
+
+func TestOCIStoreInvalidChunk(t *testing.T) {
+	s, reg := newTestOCIStore(t, StoreOptions{Uncompressed: true})
+
+	data := []byte("some chunk data")
+	chunk := NewChunk(data)
+	require.NoError(t, s.StoreChunk(chunk))
+
+	// Corrupt the blob in the registry without changing its size
+	reg.mu.Lock()
+	key := fmt.Sprintf("sha256:%x", sha256.Sum256(data))
+	corrupted := []byte(strings.ToUpper(string(data)))
+	reg.blobs[key] = corrupted
+	reg.mu.Unlock()
+
+	_, err := s.GetChunk(chunk.ID())
+	var invalid ChunkInvalid
+	require.ErrorAs(t, err, &invalid)
 }

--- a/oci_test.go
+++ b/oci_test.go
@@ -1,12 +1,15 @@
 package desync
 
 import (
+	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -99,6 +102,21 @@ func (reg *testOCIRegistry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		reg.blobs[d] = b
 		w.WriteHeader(http.StatusCreated)
+	case r.Method == http.MethodGet && r.URL.Path == "/v2/user/repo/tags/list":
+		tags := []string{}
+		for k := range reg.manifests {
+			if !strings.HasPrefix(k, "sha256:") {
+				tags = append(tags, k)
+			}
+		}
+		sort.Strings(tags)
+		b, err := json.Marshal(map[string]any{"name": "user/repo", "tags": tags})
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(b)
 	case (r.Method == http.MethodGet || r.Method == http.MethodHead) && strings.HasPrefix(r.URL.Path, manifestPath):
 		m, ok := reg.manifests[strings.TrimPrefix(r.URL.Path, manifestPath)]
 		if !ok {
@@ -231,6 +249,45 @@ func TestOCIStoreRemoveChunk(t *testing.T) {
 
 	// Removing a chunk that isn't there reports it as missing
 	require.ErrorIs(t, s.RemoveChunk(id), ChunkMissing{id})
+}
+
+func TestOCIStorePrune(t *testing.T) {
+	s, reg := newTestOCIStore(t, StoreOptions{})
+
+	chunks := make([]*Chunk, 3)
+	for i := range chunks {
+		chunks[i] = NewChunk(fmt.Appendf(nil, "chunk data %d", i))
+		require.NoError(t, s.StoreChunk(chunks[i]))
+	}
+
+	// Add an unrelated artifact to the same repository, it should survive the prune
+	foreignContent := []byte(`{"schemaVersion":2}`)
+	foreign := testOCIManifest{
+		mediaType: "application/vnd.oci.image.manifest.v1+json",
+		digest:    fmt.Sprintf("sha256:%x", sha256.Sum256(foreignContent)),
+		content:   foreignContent,
+	}
+	reg.mu.Lock()
+	reg.manifests["latest"] = foreign
+	reg.manifests[foreign.digest] = foreign
+	reg.mu.Unlock()
+
+	// Prune everything but the first chunk
+	id := chunks[0].ID()
+	require.NoError(t, s.Prune(context.Background(), map[ChunkID]struct{}{id: {}}))
+
+	hasChunk, err := s.HasChunk(id)
+	require.NoError(t, err)
+	assert.True(t, hasChunk)
+	for _, chunk := range chunks[1:] {
+		hasChunk, err := s.HasChunk(chunk.ID())
+		require.NoError(t, err)
+		assert.False(t, hasChunk)
+	}
+
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+	assert.Contains(t, reg.manifests, "latest")
 }
 
 func TestOCIStoreInvalidChunk(t *testing.T) {

--- a/oci_test.go
+++ b/oci_test.go
@@ -46,6 +46,11 @@ func TestOCIStoreScheme(t *testing.T) {
 	}
 }
 
+// ociDigest returns the OCI digest string for the given content.
+func ociDigest(b []byte) string {
+	return fmt.Sprintf("sha256:%x", sha256.Sum256(b))
+}
+
 // testOCIManifest is a manifest held by testOCIRegistry, stored under both its
 // tag and its digest.
 type testOCIManifest struct {
@@ -99,7 +104,7 @@ func (reg *testOCIRegistry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		d := r.URL.Query().Get("digest")
-		if fmt.Sprintf("sha256:%x", sha256.Sum256(b)) != d {
+		if ociDigest(b) != d {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
@@ -140,7 +145,7 @@ func (reg *testOCIRegistry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		m := testOCIManifest{
 			mediaType: r.Header.Get("Content-Type"),
-			digest:    fmt.Sprintf("sha256:%x", sha256.Sum256(b)),
+			digest:    ociDigest(b),
 			content:   b,
 		}
 		reg.manifests[strings.TrimPrefix(r.URL.Path, manifestPath)] = m
@@ -215,7 +220,7 @@ func TestOCIStoreRoundtrip(t *testing.T) {
 	reg.mu.Lock()
 	defer reg.mu.Unlock()
 	assert.Contains(t, reg.manifests, id.String()+".cacnk")
-	compressed := fmt.Sprintf("sha256:%x", sha256.Sum256(data))
+	compressed := ociDigest(data)
 	assert.NotContains(t, reg.blobs, compressed, "chunk blob should be compressed")
 }
 
@@ -265,7 +270,7 @@ func TestOCIStoreUncompressed(t *testing.T) {
 	// The blob in the registry should hold the chunk data as-is
 	reg.mu.Lock()
 	defer reg.mu.Unlock()
-	assert.Contains(t, reg.blobs, fmt.Sprintf("sha256:%x", sha256.Sum256(data)))
+	assert.Contains(t, reg.blobs, ociDigest(data))
 }
 
 func TestOCIStoreRemoveChunk(t *testing.T) {
@@ -297,7 +302,7 @@ func TestOCIStorePrune(t *testing.T) {
 	foreignContent := []byte(`{"schemaVersion":2}`)
 	foreign := testOCIManifest{
 		mediaType: "application/vnd.oci.image.manifest.v1+json",
-		digest:    fmt.Sprintf("sha256:%x", sha256.Sum256(foreignContent)),
+		digest:    ociDigest(foreignContent),
 		content:   foreignContent,
 	}
 	// Also add a chunk in a different storage format, a bare chunk-ID tag as
@@ -347,7 +352,7 @@ func TestOCIStorePruneForeignArtifact(t *testing.T) {
 	foreignContent := []byte(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json"}`)
 	foreign := testOCIManifest{
 		mediaType: "application/vnd.oci.image.manifest.v1+json",
-		digest:    fmt.Sprintf("sha256:%x", sha256.Sum256(foreignContent)),
+		digest:    ociDigest(foreignContent),
 		content:   foreignContent,
 	}
 	hexTag := strings.Repeat("0123", 16)
@@ -386,7 +391,7 @@ func TestOCIStoreInvalidChunk(t *testing.T) {
 
 	// Corrupt the blob in the registry without changing its size
 	reg.mu.Lock()
-	key := fmt.Sprintf("sha256:%x", sha256.Sum256(data))
+	key := ociDigest(data)
 	corrupted := []byte(strings.ToUpper(string(data)))
 	reg.blobs[key] = corrupted
 	reg.mu.Unlock()
@@ -410,7 +415,7 @@ func TestOCIStoreInvalidBlobSize(t *testing.T) {
 			manifest := fmt.Sprintf(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","artifactType":%q,"config":{"mediaType":"application/vnd.oci.empty.v1+json","digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","size":2},"layers":[{"mediaType":"application/octet-stream","digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","size":%d}]}`, OCIChunkArtifactType, size)
 			m := testOCIManifest{
 				mediaType: "application/vnd.oci.image.manifest.v1+json",
-				digest:    fmt.Sprintf("sha256:%x", sha256.Sum256([]byte(manifest))),
+				digest:    ociDigest([]byte(manifest)),
 				content:   []byte(manifest),
 			}
 			reg.mu.Lock()

--- a/oci_test.go
+++ b/oci_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -59,12 +60,21 @@ type testOCIManifest struct {
 	content   []byte
 }
 
+// testOCITagPageSize is the number of tags the fake registry serves per
+// listing page. Registries are free to return fewer tags than asked for, and
+// keeping this well below what any test stores exercises the client's
+// pagination on every prune.
+const testOCITagPageSize = 2
+
 // testOCIRegistry implements just enough of the OCI distribution API to serve
 // as a chunk store for a single repository named "user/repo".
 type testOCIRegistry struct {
 	mu        sync.Mutex
 	blobs     map[string][]byte
 	manifests map[string]testOCIManifest
+
+	// Page sizes the client asked for, one entry per tag listing request
+	tagListPageSizes []string
 }
 
 func newTestOCIRegistry() *testOCIRegistry {
@@ -111,6 +121,7 @@ func (reg *testOCIRegistry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		reg.blobs[d] = b
 		w.WriteHeader(http.StatusCreated)
 	case r.Method == http.MethodGet && r.URL.Path == "/v2/user/repo/tags/list":
+		reg.tagListPageSizes = append(reg.tagListPageSizes, r.URL.Query().Get("n"))
 		tags := []string{}
 		for k := range reg.manifests {
 			if !strings.HasPrefix(k, "sha256:") {
@@ -118,6 +129,23 @@ func (reg *testOCIRegistry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		sort.Strings(tags)
+		// Serve the listing one page at a time, pointing at the next page with
+		// a Link header as the distribution spec does.
+		if last := r.URL.Query().Get("last"); last != "" {
+			i := sort.SearchStrings(tags, last)
+			if i < len(tags) && tags[i] == last {
+				i++
+			}
+			tags = tags[i:]
+		}
+		if len(tags) > testOCITagPageSize {
+			tags = tags[:testOCITagPageSize]
+			next := *r.URL
+			q := next.Query()
+			q.Set("last", tags[len(tags)-1])
+			next.RawQuery = q.Encode()
+			w.Header().Set("Link", `<`+next.String()+`>; rel="next"`)
+		}
 		b, err := json.Marshal(map[string]any{"name": "user/repo", "tags": tags})
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
@@ -333,6 +361,41 @@ func TestOCIStorePrune(t *testing.T) {
 	defer reg.mu.Unlock()
 	assert.Contains(t, reg.manifests, "latest")
 	assert.Contains(t, reg.manifests, otherFormatID.String(), "chunk in a different storage format was pruned")
+}
+
+// Prune has to page through the tag listing. Without a page size the client
+// asks for every tag in one response, and oras reads that under a 4MB
+// metadata limit a store of a few tens of thousands of chunks already blows
+// past, making prune fail outright rather than return partial results.
+func TestOCIStorePruneTagPagination(t *testing.T) {
+	s, reg := newTestOCIStore(t, StoreOptions{})
+
+	chunks := make([]*Chunk, testOCITagPageSize*3)
+	for i := range chunks {
+		chunks[i] = NewChunk(fmt.Appendf(nil, "paginated chunk data %d", i))
+		require.NoError(t, s.StoreChunk(chunks[i]))
+	}
+
+	// Prune everything but the first chunk, which spans several tag pages
+	id := chunks[0].ID()
+	require.NoError(t, s.Prune(context.Background(), map[ChunkID]struct{}{id: {}}))
+
+	reg.mu.Lock()
+	pageSizes := slices.Clone(reg.tagListPageSizes)
+	reg.mu.Unlock()
+	assert.Greater(t, len(pageSizes), 1, "tag listing wasn't paginated")
+	for _, n := range pageSizes {
+		assert.Equal(t, strconv.Itoa(ociTagListPageSize), n, "client asked for an unbounded tag listing")
+	}
+
+	hasChunk, err := s.HasChunk(id)
+	require.NoError(t, err)
+	assert.True(t, hasChunk)
+	for _, chunk := range chunks[1:] {
+		hasChunk, err := s.HasChunk(chunk.ID())
+		require.NoError(t, err)
+		assert.False(t, hasChunk, "chunk on a later tag page survived the prune")
+	}
 }
 
 // With an uncompressed, unencrypted store the tag extension is empty, so any

--- a/remotehttp.go
+++ b/remotehttp.go
@@ -2,17 +2,13 @@ package desync
 
 import (
 	"bytes"
-	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"path"
 	"strings"
 	"time"
-
-	"crypto/x509"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -48,29 +44,9 @@ func NewRemoteHTTPStoreBase(location *url.URL, opt StoreOptions) (*RemoteHTTPBas
 		location.Path = location.Path + "/"
 	}
 
-	// Build a TLS client config
-	tlsConfig := &tls.Config{InsecureSkipVerify: opt.TrustInsecure}
-
-	// Add client key/cert if provided
-	if opt.ClientCert != "" && opt.ClientKey != "" {
-		certificate, err := tls.LoadX509KeyPair(opt.ClientCert, opt.ClientKey)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load client certificate from %s", opt.ClientCert)
-		}
-		tlsConfig.Certificates = []tls.Certificate{certificate}
-	}
-
-	// Load custom CA set if provided
-	if opt.CACert != "" {
-		certPool := x509.NewCertPool()
-		b, err := os.ReadFile(opt.CACert)
-		if err != nil {
-			return nil, err
-		}
-		if ok := certPool.AppendCertsFromPEM(b); !ok {
-			return nil, errors.New("no CA certificates found in ca-cert file")
-		}
-		tlsConfig.RootCAs = certPool
+	tlsConfig, err := opt.tlsClientConfig()
+	if err != nil {
+		return nil, err
 	}
 
 	tr := &http.Transport{
@@ -82,15 +58,7 @@ func NewRemoteHTTPStoreBase(location *url.URL, opt StoreOptions) (*RemoteHTTPBas
 		ForceAttemptHTTP2:   true,
 	}
 
-	// If no timeout was given in config (set to 0), then use 1 minute. If timeout is negative, use 0 to
-	// set an infinite timeout.
-	timeout := opt.Timeout
-	if timeout == 0 {
-		timeout = time.Minute
-	} else if timeout < 0 {
-		timeout = 0
-	}
-	client := &http.Client{Transport: tr, Timeout: timeout}
+	client := &http.Client{Transport: tr, Timeout: opt.effectiveTimeout()}
 
 	converters, err := opt.StorageConverters()
 	if err != nil {

--- a/store.go
+++ b/store.go
@@ -2,11 +2,14 @@ package desync
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"time"
 )
 
@@ -176,4 +179,47 @@ func (o StoreOptions) ValidateIndexOptions() error {
 		return errors.New("encryption is not supported by index stores")
 	}
 	return nil
+}
+
+// tlsClientConfig builds the TLS client configuration for network stores from
+// the trust, client certificate, and CA options.
+func (o StoreOptions) tlsClientConfig() (*tls.Config, error) {
+	tlsConfig := &tls.Config{InsecureSkipVerify: o.TrustInsecure}
+
+	// Add client key/cert if provided
+	if o.ClientCert != "" && o.ClientKey != "" {
+		certificate, err := tls.LoadX509KeyPair(o.ClientCert, o.ClientKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client certificate from %s: %w", o.ClientCert, err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{certificate}
+	}
+
+	// Load custom CA set if provided
+	if o.CACert != "" {
+		certPool := x509.NewCertPool()
+		b, err := os.ReadFile(o.CACert)
+		if err != nil {
+			return nil, err
+		}
+		if ok := certPool.AppendCertsFromPEM(b); !ok {
+			return nil, errors.New("no CA certificates found in ca-cert file")
+		}
+		tlsConfig.RootCAs = certPool
+	}
+	return tlsConfig, nil
+}
+
+// effectiveTimeout returns the HTTP client timeout for a network store. If no
+// timeout was given in config (set to 0), then use 1 minute. If timeout is
+// negative, use 0 to set an infinite timeout.
+func (o StoreOptions) effectiveTimeout() time.Duration {
+	switch {
+	case o.Timeout == 0:
+		return time.Minute
+	case o.Timeout < 0:
+		return 0
+	default:
+		return o.Timeout
+	}
 }


### PR DESCRIPTION
Adds support for using OCI container registries (ghcr.io, Docker Hub, Harbor, zot, distribution, ...) as chunk stores, addressing #253. Registries are widely available, often free or low cost, and typically CDN-backed, making them an attractive way to distribute chunks publicly without running any server infrastructure.

A registry store is used like any other store with the new `oci+https` (or `oci+http`) scheme and supports reading, writing, pruning, and use as a cache:

```sh
desync make -s oci+https://ghcr.io/myuser/mystore file.iso.caibx file.iso
desync extract -s oci+https://ghcr.io/myuser/mystore -c /var/tmp/cache file.iso.caibx file.iso
```

## Design

Every chunk is stored as its own OCI artifact: a blob holding the chunk data (zstd-compressed unless the store is configured with `uncompressed`), referenced by a minimal image manifest with artifact type `application/vnd.desync.chunk.v1` that is **tagged with the chunk ID in hex**.

The chunk ID appearing only in the tag — never as a blob digest — is the key design point, and differs from the earlier draft of this PR which stored bare blobs whose digest was the chunk ID. The rework has these consequences:

- **Default digest algorithm works.** OCI blob digests must be SHA256, which previously forced `--digest=sha256` and made OCI stores incompatible with every store and index using desync's default SHA512/256. With the chunk ID in the tag, both algorithms work and OCI stores compose freely with other stores and caches.
- **Compression works.** Registries verify that uploaded content matches the declared digest, so bare blobs could only ever hold uncompressed data. With the digest decoupled from the chunk ID, chunks are stored compressed by default like in every other store type.
- **Chunks are safe from garbage collection.** Registries GC blobs that aren't referenced by a manifest, and some (ghcr.io) won't even serve unreferenced blobs — the earlier bare-blob approach didn't reliably work there at all. Tagged manifests keep every chunk referenced.

The cost is one extra round trip per read (manifest by tag, then blob; writes take three requests) and one tag per chunk in registry UIs, so a dedicated repository is recommended. Unrelated artifacts sharing the repository are safe, including from `prune`, which only touches tags that parse as chunk IDs.

`prune` deletes the manifests of unreferenced chunks; reclaiming blob space is left to the registry's own garbage collection. Manifest deletion must be supported and enabled on the registry (distribution: `REGISTRY_STORAGE_DELETE_ENABLED=true`; ghcr.io only deletes via the GitHub Packages API).

## Authentication

Credentials are resolved in order: `DESYNC_OCI_USERNAME`/`DESYNC_OCI_PASSWORD` environment variables (convenient in CI), the new `oci-credentials` config section (keyed by host/repository, glob patterns supported), and finally the Docker credential store — registries logged into with `docker login` or `oras login` work with zero desync configuration. Anonymous access works for public repositories.

The standard store options (`uncompressed`, `timeout`, `error-retry`, `error-retry-base-interval`, `trust-insecure`, `ca-cert`, `client-cert`/`client-key`) are all wired up.

## Trying it out locally

No credentials or external services needed — a throwaway registry container is enough:

```sh
# Start a local registry (with deletes enabled so prune works too)
podman run -d --rm --name registry -p 5000:5000 \
  -e REGISTRY_STORAGE_DELETE_ENABLED=true docker.io/library/registry:2

# Chunk a file and store the chunks in the registry
desync make -s oci+http://127.0.0.1:5000/test/store file.iso.caibx file.iso

# The chunks are visible as tagged artifacts in the registry
curl -s http://127.0.0.1:5000/v2/test/store/tags/list | jq .

# Reassemble the file from the registry
desync extract -s oci+http://127.0.0.1:5000/test/store file.iso.caibx restored.iso
cmp file.iso restored.iso

# Drop all chunks not referenced by the index
desync prune -s oci+http://127.0.0.1:5000/test/store file.iso.caibx
```

(`docker` works the same as `podman` here.)

## Testing

- Unit tests run against a minimal in-process OCI registry covering roundtrips with the default SHA512/256 digest, compressed and uncompressed stores, missing chunks, corrupted chunk detection, remove, prune (including foreign artifacts surviving), plain-HTTP scheme handling, and credential resolution.
- Verified end-to-end against a real distribution registry (`registry:2`): `make`/`extract`/`info`/`prune` round trips with the default digest algorithm, byte-identical extraction, cache composition, and prune removing exactly the unreferenced chunks while other indexes keep extracting.

Not included: `verify` support (the command is currently local-store only, and verifying a registry store means downloading it in full) — possible follow-up if there's demand.

Closes #253
