### PR TITLE
Do not call t.Fatal() from non-main goroutines

### DIFF
--- a/mount-index_linux_test.go
+++ b/mount-index_linux_test.go
@@ -55,13 +55,18 @@ func TestMountIndex(t *testing.T) {
 	}()
 
 	// Start the Fuse mount
+	c := make(chan error, 1)
 	go func() {
 		ifs := NewIndexMountFS(index, "blob1", s)
-		MountIndex(ctx, index, ifs, mnt, s, 10)
+		c <- MountIndex(ctx, index, ifs, mnt, s, 10)
 		wg.Done()
 	}()
 
-	time.Sleep(time.Second)
+	select {
+	case err = <-c:
+		t.Fatal(err)
+	case <-time.After(time.Second):
+	}
 
 	// Calculate the hash of the file in the mount point
 	b, err = ioutil.ReadFile(filepath.Join(mnt, "blob1"))


### PR DESCRIPTION
Calling `t.Fatal()` only stops the current goroutine, but not the rest. The result is different depending on a test, but in the worst case scenario (like an error in the server part of a test) the client may hang waiting indefinitely for the response, and the test ends with a panic from the test timeout, without showing the real reason for the issue.

This PR makes errors during tests more obvious, showing problems with the test environment (e.g. missing /bin/fusermount or too restrictive sandbox).