### PR TITLE
Use constant-time compare for chunk-server auth header

### DIFF
--- a/httphandler.go
+++ b/httphandler.go
@@ -2,6 +2,7 @@ package desync
 
 import (
 	"bytes"
+	"crypto/subtle"
 	"fmt"
 	"io"
 	"net/http"
@@ -31,7 +32,7 @@ func NewHTTPHandler(s Store, writable, skipVerifyWrite bool, converters Converte
 }
 
 func (h HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if h.authorization != "" && r.Header.Get("Authorization") != h.authorization {
+	if h.authorization != "" && subtle.ConstantTimeCompare([]byte(r.Header.Get("Authorization")), []byte(h.authorization)) != 1 {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}


### PR DESCRIPTION
## Summary
- The chunk-server's `Authorization` header check in `httphandler.go` used a plain `!=` comparison, which leaks information about the configured token through timing.
- Switch to `crypto/subtle.ConstantTimeCompare` to match the check on the index-server handler (#327).