### PR TITLE
Add HTTP server timeouts to index-server and chunk-server

### DIFF
--- a/cmd/desync/indexserver.go
+++ b/cmd/desync/indexserver.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/folbricht/desync"
 	"github.com/spf13/cobra"
@@ -138,9 +139,11 @@ func serve(ctx context.Context, opt cmdServerOptions, addresses ...string) error
 	for _, addr := range addresses {
 		go func(a string) {
 			server := &http.Server{
-				Addr:      a,
-				TLSConfig: tlsConfig,
-				ErrorLog:  log.New(stderr, "", log.LstdFlags),
+				Addr:              a,
+				TLSConfig:         tlsConfig,
+				ErrorLog:          log.New(stderr, "", log.LstdFlags),
+				ReadHeaderTimeout: 30 * time.Second,
+				IdleTimeout:       120 * time.Second,
 			}
 			var err error
 			if opt.key == "" {


### PR DESCRIPTION
## Summary
- Set `ReadHeaderTimeout: 30s` and `IdleTimeout: 120s` on the `http.Server` shared by `index-server` and `chunk-server`.
- Without these, an Internet-exposed server is vulnerable to Slowloris-style header-read attacks and lets idle keep-alive connections accumulate without bound.
- `ReadTimeout` and `WriteTimeout` are intentionally left at 0 so that slow but legitimate transfers of large chunks or indexes aren't truncated.