### PR TITLE
Reject --mutual-tls and --client-ca when TLS is not enabled

### DIFF
--- a/cmd/desync/options.go
+++ b/cmd/desync/options.go
@@ -87,6 +87,14 @@ func (o cmdServerOptions) validate() error {
 	if (o.key == "") != (o.cert == "") {
 		return errors.New("--key and --cert options need to be provided together")
 	}
+	if o.key == "" {
+		if o.mutualTLS {
+			return errors.New("--mutual-tls requires --cert and --key (TLS must be enabled)")
+		}
+		if o.clientCA != "" {
+			return errors.New("--client-ca requires --cert and --key (TLS must be enabled)")
+		}
+	}
 	return nil
 }
 

--- a/cmd/desync/options_test.go
+++ b/cmd/desync/options_test.go
@@ -99,6 +99,33 @@ func TestErrorRetryOptions(t *testing.T) {
 	}
 }
 
+func TestServerOptionsValidate(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		opt     cmdServerOptions
+		wantErr string
+	}{
+		{"no TLS, no mTLS", cmdServerOptions{}, ""},
+		{"TLS only", cmdServerOptions{cert: "c", key: "k"}, ""},
+		{"TLS with mutualTLS", cmdServerOptions{cert: "c", key: "k", mutualTLS: true}, ""},
+		{"TLS with clientCA", cmdServerOptions{cert: "c", key: "k", clientCA: "ca"}, ""},
+		{"key without cert", cmdServerOptions{key: "k"}, "--key and --cert"},
+		{"cert without key", cmdServerOptions{cert: "c"}, "--key and --cert"},
+		{"mutualTLS without TLS", cmdServerOptions{mutualTLS: true}, "--mutual-tls requires"},
+		{"clientCA without TLS", cmdServerOptions{clientCA: "ca"}, "--client-ca requires"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.opt.validate()
+			if test.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), test.wantErr)
+		})
+	}
+}
+
 func TestStringOptions(t *testing.T) {
 	for _, test := range []struct {
 		name                string


### PR DESCRIPTION
## Summary

`--mutual-tls` and `--client-ca` were silently ignored by `chunk-server` and `index-server` when `--cert`/`--key` were not provided, because the TLS config is only consulted on `ListenAndServeTLS`. An operator could believe client-certificate authentication was gating access while the server was actually listening on plain HTTP.

Both flags now fail validation at startup in `cmdServerOptions.validate()` unless TLS is enabled.