### PR TITLE
Avoid leaking backend error details in HTTP responses

### DIFF
--- a/httphandler.go
+++ b/httphandler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"path"
 	"strings"
 
@@ -66,7 +67,8 @@ func (h HTTPHandler) get(id ChunkID, w http.ResponseWriter) {
 func (h HTTPHandler) head(id ChunkID, w http.ResponseWriter) {
 	hasChunk, err := h.s.HasChunk(id)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		fmt.Fprintf(os.Stderr, "failed to check chunk %s: %s\n", id, err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 	if hasChunk {
@@ -85,16 +87,16 @@ func (h HTTPHandler) put(id ChunkID, w http.ResponseWriter, r *http.Request) {
 	// The upstream store needs to support writing as well
 	s, ok := h.s.(WriteStore)
 	if !ok {
-		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(w, "upstream chunk store '%s' does not support writing\n", h.s)
+		fmt.Fprintf(os.Stderr, "upstream chunk store '%s' does not support writing\n", h.s)
+		http.Error(w, "upstream chunk store does not support writing", http.StatusBadRequest)
 		return
 	}
 
 	// Read the raw chunk data into memory
 	b := new(bytes.Buffer)
 	if _, err := io.Copy(b, r.Body); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintln(w, err)
+		fmt.Fprintf(os.Stderr, "failed to read chunk %s from client: %s\n", id, err)
+		http.Error(w, "failed to read request body", http.StatusInternalServerError)
 		return
 	}
 
@@ -107,7 +109,8 @@ func (h HTTPHandler) put(id ChunkID, w http.ResponseWriter, r *http.Request) {
 
 	// Store it upstream
 	if err := s.StoreChunk(chunk); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		fmt.Fprintf(os.Stderr, "failed to store chunk %s: %s\n", id, err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 	w.WriteHeader(http.StatusOK)

--- a/httphandlerbase.go
+++ b/httphandlerbase.go
@@ -24,20 +24,17 @@ func (h HTTPHandlerBase) get(id string, b []byte, err error, w http.ResponseWrit
 		w.WriteHeader(http.StatusNotFound)
 		fmt.Fprintf(w, "%s %s not found", h.handlerType, id)
 	default:
-		w.WriteHeader(http.StatusInternalServerError)
-		msg := fmt.Sprintf("failed to retrieve %s %s:%s", h.handlerType, id, err)
-		fmt.Fprintln(w, msg)
-		fmt.Fprintln(os.Stderr, msg)
+		fmt.Fprintf(os.Stderr, "failed to retrieve %s %s: %s\n", h.handlerType, id, err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
 	}
 }
 
 func (h HTTPHandlerBase) validateWritable(storeName string, w http.ResponseWriter, r *http.Request) error {
 	// Make sure writing was enabled for this server
 	if !h.writable {
-		w.WriteHeader(http.StatusBadRequest)
-		msg := fmt.Sprintf("writing to upstream %s store '%s' is not enabled", h.handlerType, storeName)
-		fmt.Fprintln(w, msg)
-		return errors.New(msg)
+		msg := fmt.Sprintf("writing to upstream %s store is not enabled", h.handlerType)
+		http.Error(w, msg, http.StatusBadRequest)
+		return errors.Errorf("writing to upstream %s store '%s' is not enabled", h.handlerType, storeName)
 	}
 	return nil
 }

--- a/httpindexhandler.go
+++ b/httpindexhandler.go
@@ -44,17 +44,18 @@ func (h HTTPIndexHandler) get(indexName string, w http.ResponseWriter) {
 	idx, err := h.s.GetIndex(indexName)
 	if err != nil {
 		if os.IsNotExist(err) {
-			w.WriteHeader(http.StatusNotFound)
-		} else {
-			w.WriteHeader(http.StatusBadRequest)
+			http.Error(w, "index not found", http.StatusNotFound)
+			return
 		}
-		fmt.Fprintln(w, err)
+		fmt.Fprintf(os.Stderr, "failed to retrieve index %s: %s\n", indexName, err)
+		http.Error(w, "failed to retrieve index", http.StatusBadRequest)
 		return
 	}
 	b := new(bytes.Buffer)
 	_, err = idx.WriteTo(b)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		fmt.Fprintf(os.Stderr, "failed to serialize index %s: %s\n", indexName, err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 	h.HTTPHandlerBase.get(indexName, b.Bytes(), err, w)
@@ -78,8 +79,8 @@ func (h HTTPIndexHandler) put(indexName string, w http.ResponseWriter, r *http.R
 	// The upstream store needs to support writing as well
 	s, ok := h.s.(IndexWriteStore)
 	if !ok {
-		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(w, "upstream index store '%s' does not support writing\n", h.s)
+		fmt.Fprintf(os.Stderr, "upstream index store '%s' does not support writing\n", h.s)
+		http.Error(w, "upstream index store does not support writing", http.StatusBadRequest)
 		return
 	}
 
@@ -92,8 +93,8 @@ func (h HTTPIndexHandler) put(indexName string, w http.ResponseWriter, r *http.R
 
 	// Store it upstream
 	if err := s.StoreIndex(indexName, idx); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintln(w, err)
+		fmt.Fprintf(os.Stderr, "failed to store index %s: %s\n", indexName, err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary

The chunk-server and index-server HTTP handlers echoed raw upstream-store errors and store identifiers into response bodies. On an Internet-exposed server that leaks backend detail to clients:

- Backend errors from S3/SFTP/GCS/local stores (which can contain bucket names, hostnames, filesystem paths, or occasionally signed URLs) were written to the response body on 5xx and some 4xx paths.
- The upstream store URI was written to the body of ``writing to upstream ... is not enabled`` and ``upstream ... does not support writing`` responses.

## Changes

All error paths that previously emitted backend-derived text to the client now:

- log the full error to stderr (so operators retain diagnostics), and
- return a generic message to the client.

Client-input errors remain intact since they describe the caller's own request:

- chunk hash-mismatch from ``NewChunkFromStorage`` (PUT chunk)
- ``invalid index: ...`` from ``IndexFromReader`` (PUT index)
- URL-shape validation errors from ``idFromPath``

Status codes are preserved; only the response body is changed. The returned ``error`` from ``validateWritable`` still contains the store identifier for the server-side caller, but the HTTP response no longer does.

Existing ``chunk-server`` / ``index-server`` tests pass unchanged.