### PR TITLE
Reject --client-ca when --mutual-tls is not set

### DIFF
--- a/cmd/desync/options.go
+++ b/cmd/desync/options.go
@@ -95,6 +95,9 @@ func (o cmdServerOptions) validate() error {
 			return errors.New("--client-ca requires --cert and --key (TLS must be enabled)")
 		}
 	}
+	if o.clientCA != "" && !o.mutualTLS {
+		return errors.New("--client-ca requires --mutual-tls (otherwise client certificates are not verified)")
+	}
 	return nil
 }
 

--- a/cmd/desync/options_test.go
+++ b/cmd/desync/options_test.go
@@ -108,11 +108,12 @@ func TestServerOptionsValidate(t *testing.T) {
 		{"no TLS, no mTLS", cmdServerOptions{}, ""},
 		{"TLS only", cmdServerOptions{cert: "c", key: "k"}, ""},
 		{"TLS with mutualTLS", cmdServerOptions{cert: "c", key: "k", mutualTLS: true}, ""},
-		{"TLS with clientCA", cmdServerOptions{cert: "c", key: "k", clientCA: "ca"}, ""},
+		{"TLS with mutualTLS and clientCA", cmdServerOptions{cert: "c", key: "k", mutualTLS: true, clientCA: "ca"}, ""},
 		{"key without cert", cmdServerOptions{key: "k"}, "--key and --cert"},
 		{"cert without key", cmdServerOptions{cert: "c"}, "--key and --cert"},
 		{"mutualTLS without TLS", cmdServerOptions{mutualTLS: true}, "--mutual-tls requires"},
-		{"clientCA without TLS", cmdServerOptions{clientCA: "ca"}, "--client-ca requires"},
+		{"clientCA without TLS", cmdServerOptions{clientCA: "ca"}, "--client-ca requires --cert"},
+		{"clientCA without mutualTLS", cmdServerOptions{cert: "c", key: "k", clientCA: "ca"}, "--client-ca requires --mutual-tls"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			err := test.opt.validate()


### PR DESCRIPTION
## Summary

Passing `--client-ca` to `chunk-server` / `index-server` without also passing `--mutual-tls` configures the server's `tls.Config.ClientCAs` pool but leaves `ClientAuth` at its default `NoClientCert`. The CA pool is therefore never consulted and any client (including one with no certificate) can connect — even though an operator who provided a `--client-ca` reasonably expects access to be restricted to clients holding a cert from that CA.

This change makes `cmdServerOptions.validate()` reject the combination at startup, in the same spirit as #330 which rejects `--mutual-tls` / `--client-ca` when TLS itself is not enabled.

- `cmd/desync/options.go` — return an error when `clientCA` is set and `mutualTLS` is false.
- `cmd/desync/options_test.go` — replace the previously-permitted `clientCA` without `mutualTLS` case with one that pairs them, and add a new negative case for the rejected combination.