### PR TITLE
Confine catar extraction to the target root (symlink-safe)

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -70,6 +70,36 @@ func NewArchiveDecoder(r io.Reader) ArchiveDecoder {
 	return ArchiveDecoder{d: NewFormatDecoder(r), dir: "."}
 }
 
+// safeComponent validates a single path component as it appears in a catar
+// FormatFilename element. casync filenames are always a single, non-empty
+// path component. Anything else (empty, ".", "..", containing a path
+// separator, or absolute) is rejected so that a crafted archive cannot place
+// or traverse entries outside the extraction root - this catches the
+// embedded-slash trick (e.g. "evil/passwd") regardless of the writer in use.
+func safeComponent(name string) error {
+	switch name {
+	case "", ".", "..":
+		return InvalidFormat{Msg: fmt.Sprintf("invalid filename %q in archive", name)}
+	}
+	if strings.ContainsRune(name, '/') || strings.ContainsRune(name, '\\') {
+		return InvalidFormat{Msg: fmt.Sprintf("filename %q contains a path separator", name)}
+	}
+	if path.IsAbs(name) || filepath.IsAbs(name) {
+		return InvalidFormat{Msg: fmt.Sprintf("absolute filename %q in archive", name)}
+	}
+	return nil
+}
+
+// confined reports whether p, the cumulative path of an archive entry, stays
+// within the archive root (".").
+func confined(p string) bool {
+	if path.IsAbs(p) {
+		return false
+	}
+	c := path.Clean(p)
+	return c == "." || (c != ".." && !strings.HasPrefix(c, "../"))
+}
+
 // Next returns a node from an archive, or nil if the end is reached. If NodeFile
 // is returned, the caller should read the file body before calling Next() again
 // as that invalidates the reader.
@@ -143,6 +173,9 @@ loop:
 				a.last = c
 				break loop
 			}
+			if err := safeComponent(d.Name); err != nil {
+				return nil, err
+			}
 			name = d.Name
 		case FormatGoodbye: // This will effectively be a "cd .."
 			if entry != nil {
@@ -161,6 +194,9 @@ loop:
 	// If it doesn't have a payload or is a device/symlink, it must be a directory
 	if payload == nil && device == nil && symlink == nil {
 		a.dir = path.Join(a.dir, name)
+		if !confined(a.dir) {
+			return nil, InvalidFormat{Msg: fmt.Sprintf("entry %q escapes the archive root", a.dir)}
+		}
 		return NodeDirectory{
 			Name:   a.dir,
 			UID:    entry.UID,
@@ -171,10 +207,15 @@ loop:
 		}, nil
 	}
 
+	p := path.Join(a.dir, name)
+	if !confined(p) {
+		return nil, InvalidFormat{Msg: fmt.Sprintf("entry %q escapes the archive root", p)}
+	}
+
 	// Regular file
 	if payload != nil {
 		return NodeFile{
-			Name:   path.Join(a.dir, name),
+			Name:   p,
 			UID:    entry.UID,
 			GID:    entry.GID,
 			Mode:   entry.Mode,
@@ -188,7 +229,7 @@ loop:
 	// Device
 	if device != nil {
 		return NodeDevice{
-			Name:   path.Join(a.dir, name),
+			Name:   p,
 			UID:    entry.UID,
 			GID:    entry.GID,
 			Mode:   entry.Mode,
@@ -202,7 +243,7 @@ loop:
 	// Symlink
 	if symlink != nil {
 		return NodeSymlink{
-			Name:   path.Join(a.dir, name),
+			Name:   p,
 			UID:    entry.UID,
 			GID:    entry.GID,
 			Mode:   entry.Mode,

--- a/archive_escape_test.go
+++ b/archive_escape_test.go
@@ -1,0 +1,86 @@
+package desync
+
+import (
+	"bytes"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestSafeComponent(t *testing.T) {
+	valid := []string{"file", "dir1", "a.b", "..foo", "foo..", "name with space"}
+	for _, n := range valid {
+		if err := safeComponent(n); err != nil {
+			t.Errorf("safeComponent(%q) = %v, want nil", n, err)
+		}
+	}
+	invalid := []string{"", ".", "..", "evil/passwd", "a/b", "/abs", `a\b`, `\abs`}
+	for _, n := range invalid {
+		if err := safeComponent(n); err == nil {
+			t.Errorf("safeComponent(%q) = nil, want error", n)
+		}
+	}
+}
+
+func TestConfined(t *testing.T) {
+	in := []string{".", "a", "a/b", "a/../b", "./a"}
+	for _, p := range in {
+		if !confined(p) {
+			t.Errorf("confined(%q) = false, want true", p)
+		}
+	}
+	out := []string{"..", "../x", "a/../..", "/abs", "/"}
+	for _, p := range out {
+		if confined(p) {
+			t.Errorf("confined(%q) = true, want false", p)
+		}
+	}
+}
+
+// TestArchiveDecoderRejectsEmbeddedSlash verifies the decoder rejects a
+// FormatFilename whose name embeds a path separator (e.g. "evil/passwd"), the
+// trick used to write through a previously-planted symlink. This protects
+// every FilesystemWriter, including TarWriter which would otherwise forward
+// the poisoned name into a produced tar.
+func TestArchiveDecoderRejectsEmbeddedSlash(t *testing.T) {
+	var buf bytes.Buffer
+	enc := NewFormatEncoder(&buf)
+
+	entry := FormatEntry{
+		FormatHeader: FormatHeader{Size: 64, Type: CaFormatEntry},
+		FeatureFlags: TarFeatureFlags,
+		Mode:         os.ModeDir | 0755,
+		MTime:        time.Unix(0, 0),
+	}
+	if _, err := enc.Encode(entry); err != nil {
+		t.Fatal(err)
+	}
+	name := "evil/passwd"
+	fn := FormatFilename{
+		FormatHeader: FormatHeader{Size: uint64(16 + len(name) + 1), Type: CaFormatFilename},
+		Name:         name,
+	}
+	if _, err := enc.Encode(fn); err != nil {
+		t.Fatal(err)
+	}
+
+	d := NewArchiveDecoder(&buf)
+
+	// First node is the (unnamed) root directory.
+	v, err := d.Next()
+	if err != nil {
+		t.Fatalf("decoding root: %v", err)
+	}
+	if _, ok := v.(NodeDirectory); !ok {
+		t.Fatalf("expected NodeDirectory, got %T", v)
+	}
+
+	// The embedded-slash filename must be rejected.
+	_, err = d.Next()
+	if err == nil {
+		t.Fatal("expected error for embedded-slash filename, got nil")
+	}
+	if _, ok := err.(InvalidFormat); !ok {
+		t.Fatalf("expected InvalidFormat, got %T: %v", err, err)
+	}
+}

--- a/cmd/desync/untar.go
+++ b/cmd/desync/untar.go
@@ -71,7 +71,9 @@ func runUntar(ctx context.Context, opt untarOptions, args []string) error {
 	)
 	switch opt.outFormat {
 	case "disk": // Local filesystem
-		fs = desync.NewLocalFS(target, opt.LocalFSOptions)
+		lfs := desync.NewLocalFS(target, opt.LocalFSOptions)
+		defer lfs.Close()
+		fs = lfs
 	case "gnu-tar": // GNU tar, either file or STDOUT
 		var w *os.File
 		if target == "-" {

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.47.0
 	golang.org/x/sync v0.19.0
-	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/sys v0.42.0
 	google.golang.org/api v0.267.0
 	gopkg.in/cheggaaa/pb.v1 v1.0.28
 )

--- a/localfs.go
+++ b/localfs.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -21,6 +20,14 @@ type LocalFS struct {
 	once    sync.Once
 	entries chan walkEntry
 	sErr    error
+
+	// Writer side. All write/metadata operations are performed through an
+	// os.Root handle which confines them to Root and refuses to follow any
+	// symlink (planted by the archive itself) that would escape it.
+	wonce    sync.Once
+	wroot    *os.Root
+	wErr     error
+	rootReal string
 }
 
 // LocalFSOptions influence the behavior of the filesystem when reading from or writing to it.
@@ -42,18 +49,54 @@ type LocalFSOptions struct {
 var _ FilesystemWriter = &LocalFS{}
 var _ FilesystemReader = &LocalFS{}
 
+// writeRoot lazily creates the extraction root directory and opens an os.Root
+// handle anchored to it. Every write/metadata operation goes through the
+// returned handle so that no path component (including symlinks created earlier
+// by the same archive) can be used to escape Root. The handle is opened only
+// once; the result (or error) is cached for the lifetime of the LocalFS.
+func (fs *LocalFS) writeRoot() (*os.Root, error) {
+	fs.wonce.Do(func() {
+		if err := os.MkdirAll(fs.Root, 0777); err != nil {
+			fs.wErr = err
+			return
+		}
+		// Resolved real path of the root, used for the rare symlink/device
+		// xattr fallback that has no fd-based equivalent.
+		if real, err := filepath.EvalSymlinks(fs.Root); err == nil {
+			fs.rootReal = real
+		} else {
+			fs.rootReal = fs.Root
+		}
+		fs.wroot, fs.wErr = os.OpenRoot(fs.Root)
+	})
+	return fs.wroot, fs.wErr
+}
+
+// Close releases the os.Root handle used for writing. It is safe to call even
+// if no write operation was ever performed.
+func (fs *LocalFS) Close() error {
+	if fs.wroot != nil {
+		return fs.wroot.Close()
+	}
+	return nil
+}
+
 func (fs *LocalFS) CreateDir(n NodeDirectory) error {
-	dst := filepath.Join(fs.Root, n.Name)
+	r, err := fs.writeRoot()
+	if err != nil {
+		return err
+	}
 
 	// Let's see if there is a dir with the same name already
-	if info, err := os.Lstat(dst); err == nil {
+	if info, err := r.Lstat(n.Name); err == nil {
 		if !info.IsDir() {
-			return fmt.Errorf("%s exists and is not a directory", dst)
+			return fmt.Errorf("%s exists and is not a directory", n.Name)
 		}
 	} else {
 		// Stat error'ed out, presumably because the dir doesn't exist. Create it.
-		if err := os.Mkdir(dst, 0777); err != nil {
-			return err
+		// (n.Name == "." is the extraction root itself, which already exists.)
+		if err := r.Mkdir(n.Name, 0777); err != nil {
+			return fmt.Errorf("%s: %w", n.Name, err)
 		}
 	}
 
@@ -64,18 +107,21 @@ func (fs *LocalFS) CreateDir(n NodeDirectory) error {
 	if n.MTime == time.Unix(0, 0) {
 		return nil
 	}
-	return os.Chtimes(dst, n.MTime, n.MTime)
+	return r.Chtimes(n.Name, n.MTime, n.MTime)
 }
 
 func (fs *LocalFS) CreateFile(n NodeFile) error {
-	dst := filepath.Join(fs.Root, n.Name)
-
-	if err := os.RemoveAll(dst); err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	f, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
+	r, err := fs.writeRoot()
 	if err != nil {
 		return err
+	}
+
+	if err := r.RemoveAll(n.Name); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("%s: %w", n.Name, err)
+	}
+	f, err := r.OpenFile(n.Name, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
+	if err != nil {
+		return fmt.Errorf("%s: %w", n.Name, err)
 	}
 	defer f.Close()
 	if _, err = io.Copy(f, n.Data); err != nil {
@@ -89,17 +135,24 @@ func (fs *LocalFS) CreateFile(n NodeFile) error {
 	if n.MTime == time.Unix(0, 0) {
 		return nil
 	}
-	return os.Chtimes(dst, n.MTime, n.MTime)
+	return r.Chtimes(n.Name, n.MTime, n.MTime)
 }
 
 func (fs *LocalFS) CreateSymlink(n NodeSymlink) error {
-	dst := filepath.Join(fs.Root, n.Name)
-
-	if err := syscall.Unlink(dst); err != nil && !os.IsNotExist(err) {
+	r, err := fs.writeRoot()
+	if err != nil {
 		return err
 	}
-	if err := os.Symlink(n.Target, dst); err != nil {
-		return err
+
+	if err := r.Remove(n.Name); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("%s: %w", n.Name, err)
+	}
+	// The target is stored verbatim (an archive may legitimately contain
+	// absolute or relative symlinks, same as GNU tar/casync). It is never
+	// followed during extraction: subsequent operations go through os.Root,
+	// which refuses to traverse a symlink that escapes the root.
+	if err := r.Symlink(n.Target, n.Name); err != nil {
+		return fmt.Errorf("%s: %w", n.Name, err)
 	}
 
 	if err := fs.SetSymlinkPermissions(n); err != nil {

--- a/localfs_escape_test.go
+++ b/localfs_escape_test.go
@@ -1,0 +1,121 @@
+//go:build !windows
+
+package desync
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newTestLocalFS(root string) *LocalFS {
+	// NoSameOwner/NoSamePermissions keep the tests runnable as a non-root
+	// user; the escape protection under test lives in the os.Root-backed
+	// Create* methods, not in the permission handling.
+	return NewLocalFS(root, LocalFSOptions{NoSameOwner: true, NoSamePermissions: true})
+}
+
+// TestLocalFSSymlinkWriteEscape reproduces the reported attack: an archive
+// plants a symlink inside the extraction root pointing outside it, then a
+// later entry with a clean name ("evil/passwd", no "..") writes through it.
+// The write must be refused and the out-of-root file left untouched.
+func TestLocalFSSymlinkWriteEscape(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	sentinel := filepath.Join(outside, "passwd")
+	const orig = "original-contents\n"
+	if err := os.WriteFile(sentinel, []byte(orig), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := newTestLocalFS(root)
+	defer fs.Close()
+
+	if err := fs.CreateSymlink(NodeSymlink{Name: "evil", Target: outside}); err != nil {
+		t.Fatalf("CreateSymlink: %v", err)
+	}
+
+	if err := fs.CreateFile(NodeFile{Name: "evil/passwd", Data: strings.NewReader("PWNED")}); err == nil {
+		t.Fatal("CreateFile through escaping symlink succeeded, want error")
+	}
+
+	got, err := os.ReadFile(sentinel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != orig {
+		t.Fatalf("file outside root was modified: got %q, want %q", got, orig)
+	}
+}
+
+// TestLocalFSLexicalEscape covers the plain ".." traversal at the LocalFS
+// layer (independent of the decoder hardening).
+func TestLocalFSLexicalEscape(t *testing.T) {
+	root := t.TempDir()
+	fs := newTestLocalFS(root)
+	defer fs.Close()
+
+	if err := fs.CreateFile(NodeFile{Name: "../escape", Data: strings.NewReader("x")}); err == nil {
+		t.Error("CreateFile(../escape) succeeded, want error")
+	}
+	if err := fs.CreateDir(NodeDirectory{Name: "../evildir"}); err == nil {
+		t.Error("CreateDir(../evildir) succeeded, want error")
+	}
+	if _, err := os.Lstat(filepath.Join(filepath.Dir(root), "escape")); !os.IsNotExist(err) {
+		t.Errorf("escape file created outside root: err=%v", err)
+	}
+}
+
+// TestLocalFSAbsoluteSymlinkTargetVerbatim confirms an absolute symlink target
+// is created verbatim (legitimate, matches GNU tar/casync) but cannot be
+// followed during extraction.
+func TestLocalFSAbsoluteSymlinkTargetVerbatim(t *testing.T) {
+	root := t.TempDir()
+	fs := newTestLocalFS(root)
+	defer fs.Close()
+
+	if err := fs.CreateSymlink(NodeSymlink{Name: "abs", Target: "/etc"}); err != nil {
+		t.Fatalf("CreateSymlink: %v", err)
+	}
+	tgt, err := os.Readlink(filepath.Join(root, "abs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tgt != "/etc" {
+		t.Fatalf("symlink target = %q, want /etc (verbatim)", tgt)
+	}
+
+	if err := fs.CreateFile(NodeFile{Name: "abs/desync-should-not-exist", Data: strings.NewReader("x")}); err == nil {
+		t.Fatal("write through absolute symlink succeeded, want error")
+	}
+	if _, err := os.Lstat("/etc/desync-should-not-exist"); !os.IsNotExist(err) {
+		t.Fatalf("file created under /etc: err=%v", err)
+	}
+}
+
+// TestLocalFSBenignRelativeSymlink is a regression guard: a relative symlink
+// that stays within the root must still be followed so legitimate archives
+// continue to extract correctly.
+func TestLocalFSBenignRelativeSymlink(t *testing.T) {
+	root := t.TempDir()
+	fs := newTestLocalFS(root)
+	defer fs.Close()
+
+	if err := fs.CreateDir(NodeDirectory{Name: "sub"}); err != nil {
+		t.Fatalf("CreateDir: %v", err)
+	}
+	if err := fs.CreateSymlink(NodeSymlink{Name: "link", Target: "sub"}); err != nil {
+		t.Fatalf("CreateSymlink: %v", err)
+	}
+	if err := fs.CreateFile(NodeFile{Name: "link/g", Data: strings.NewReader("hello")}); err != nil {
+		t.Fatalf("CreateFile through in-root symlink: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(root, "sub", "g"))
+	if err != nil {
+		t.Fatalf("expected file via in-root symlink: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("content = %q, want hello", got)
+	}
+}

--- a/localfs_mknod_linux.go
+++ b/localfs_mknod_linux.go
@@ -1,0 +1,24 @@
+//go:build linux
+
+package desync
+
+import (
+	"os"
+	"path"
+
+	"golang.org/x/sys/unix"
+)
+
+// createDeviceNode creates a device node confined to the extraction root.
+// The parent directory is opened through the os.Root handle (which refuses to
+// traverse any symlink escaping the root) and the node is created relative to
+// that directory fd with a base name that has no path separators, so it
+// cannot escape Root.
+func (fs *LocalFS) createDeviceNode(r *os.Root, n NodeDevice) error {
+	df, err := r.Open(path.Dir(n.Name))
+	if err != nil {
+		return err
+	}
+	defer df.Close()
+	return unix.Mknodat(int(df.Fd()), path.Base(n.Name), FilemodeToStatMode(n.Mode)|0666, int(mkdev(n.Major, n.Minor)))
+}

--- a/localfs_mknod_other.go
+++ b/localfs_mknod_other.go
@@ -1,0 +1,28 @@
+//go:build !linux && !windows
+
+package desync
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+// createDeviceNode creates a device node confined to the extraction root.
+// Darwin (and other non-Linux Unix) has no mknodat(2), so the parent
+// directory is first resolved through the os.Root handle - which refuses to
+// traverse any symlink that escapes the root - to validate confinement, and
+// the node is then created on the corresponding real path. Extraction is
+// single-threaded, so there is no concurrent attacker able to swap a
+// component between this check and the mknod call.
+func (fs *LocalFS) createDeviceNode(r *os.Root, n NodeDevice) error {
+	df, err := r.Open(path.Dir(n.Name))
+	if err != nil {
+		return err
+	}
+	df.Close()
+	dst := filepath.Join(fs.rootReal, n.Name)
+	return unix.Mknod(dst, FilemodeToStatMode(n.Mode)|0666, int(mkdev(n.Major, n.Minor)))
+}

--- a/localfs_other.go
+++ b/localfs_other.go
@@ -4,6 +4,7 @@
 package desync
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -11,8 +12,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/pkg/xattr"
+	"golang.org/x/sys/unix"
 )
 
 // NewLocalFS initializes a new instance of a local filesystem that
@@ -25,26 +26,61 @@ func NewLocalFS(root string, opts LocalFSOptions) *LocalFS {
 	}
 }
 
+// setXattrs applies extended attributes to a regular file or directory using
+// an fd opened through the root handle, so that no symlink in the path can be
+// followed.
+func setXattrs(r *os.Root, name string, xattrs Xattrs) error {
+	if len(xattrs) == 0 {
+		return nil
+	}
+	f, err := r.Open(name)
+	if err != nil {
+		return fmt.Errorf("%s: %w", name, err)
+	}
+	defer f.Close()
+	for key, value := range xattrs {
+		if err := xattr.FSet(f, key, []byte(value)); err != nil {
+			return fmt.Errorf("%s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// setXattrsNoFollow applies extended attributes to a symlink or device node.
+// There is no fd-based equivalent for these, so a path under the resolved real
+// root is used. All intermediate components were created by us through the
+// root handle and are therefore confined to it.
+func (fs *LocalFS) setXattrsNoFollow(name string, xattrs Xattrs) error {
+	if len(xattrs) == 0 {
+		return nil
+	}
+	dst := filepath.Join(fs.rootReal, name)
+	for key, value := range xattrs {
+		if err := xattr.LSet(dst, key, []byte(value)); err != nil {
+			return fmt.Errorf("%s: %w", name, err)
+		}
+	}
+	return nil
+}
+
 func (fs *LocalFS) SetDirPermissions(n NodeDirectory) error {
-	dst := filepath.Join(fs.Root, n.Name)
+	r, err := fs.writeRoot()
+	if err != nil {
+		return err
+	}
 
 	// The dir exists now, fix the UID/GID if needed
 	if !fs.opts.NoSameOwner {
-		if err := os.Chown(dst, n.UID, n.GID); err != nil {
-			return err
+		if err := r.Chown(n.Name, n.UID, n.GID); err != nil {
+			return fmt.Errorf("%s: %w", n.Name, err)
 		}
-
-		if n.Xattrs != nil {
-			for key, value := range n.Xattrs {
-				if err := xattr.LSet(dst, key, []byte(value)); err != nil {
-					return err
-				}
-			}
+		if err := setXattrs(r, n.Name, n.Xattrs); err != nil {
+			return err
 		}
 	}
 	if !fs.opts.NoSamePermissions {
-		if err := syscall.Chmod(dst, FilemodeToStatMode(n.Mode)); err != nil {
-			return err
+		if err := r.Chmod(n.Name, n.Mode); err != nil {
+			return fmt.Errorf("%s: %w", n.Name, err)
 		}
 	}
 
@@ -52,24 +88,22 @@ func (fs *LocalFS) SetDirPermissions(n NodeDirectory) error {
 }
 
 func (fs *LocalFS) SetFilePermissions(n NodeFile) error {
-	dst := filepath.Join(fs.Root, n.Name)
+	r, err := fs.writeRoot()
+	if err != nil {
+		return err
+	}
 
 	if !fs.opts.NoSameOwner {
-		if err := os.Chown(dst, n.UID, n.GID); err != nil {
-			return err
+		if err := r.Chown(n.Name, n.UID, n.GID); err != nil {
+			return fmt.Errorf("%s: %w", n.Name, err)
 		}
-
-		if n.Xattrs != nil {
-			for key, value := range n.Xattrs {
-				if err := xattr.LSet(dst, key, []byte(value)); err != nil {
-					return err
-				}
-			}
+		if err := setXattrs(r, n.Name, n.Xattrs); err != nil {
+			return err
 		}
 	}
 	if !fs.opts.NoSamePermissions {
-		if err := syscall.Chmod(dst, FilemodeToStatMode(n.Mode)); err != nil {
-			return err
+		if err := r.Chmod(n.Name, n.Mode); err != nil {
+			return fmt.Errorf("%s: %w", n.Name, err)
 		}
 	}
 
@@ -77,23 +111,21 @@ func (fs *LocalFS) SetFilePermissions(n NodeFile) error {
 }
 
 func (fs *LocalFS) SetSymlinkPermissions(n NodeSymlink) error {
-	dst := filepath.Join(fs.Root, n.Name)
+	r, err := fs.writeRoot()
+	if err != nil {
+		return err
+	}
 
 	// TODO: On Linux, the permissions of the link don't matter so we don't
 	// set them here. But they do matter somewhat on Mac, so should probably
 	// add some Mac-specific logic for that here.
 	// fchmodat() with flag AT_SYMLINK_NOFOLLOW
 	if !fs.opts.NoSameOwner {
-		if err := os.Lchown(dst, n.UID, n.GID); err != nil {
-			return err
+		if err := r.Lchown(n.Name, n.UID, n.GID); err != nil {
+			return fmt.Errorf("%s: %w", n.Name, err)
 		}
-
-		if n.Xattrs != nil {
-			for key, value := range n.Xattrs {
-				if err := xattr.LSet(dst, key, []byte(value)); err != nil {
-					return err
-				}
-			}
+		if err := fs.setXattrsNoFollow(n.Name, n.Xattrs); err != nil {
+			return err
 		}
 	}
 
@@ -101,36 +133,46 @@ func (fs *LocalFS) SetSymlinkPermissions(n NodeSymlink) error {
 }
 
 func (fs *LocalFS) CreateDevice(n NodeDevice) error {
-	dst := filepath.Join(fs.Root, n.Name)
-
-	if err := syscall.Unlink(dst); err != nil && !os.IsNotExist(err) {
+	r, err := fs.writeRoot()
+	if err != nil {
 		return err
 	}
-	if err := syscall.Mknod(dst, FilemodeToStatMode(n.Mode)|0666, int(mkdev(n.Major, n.Minor))); err != nil {
-		return errors.Wrapf(err, "mknod %s", dst)
-	}
-	if !fs.opts.NoSameOwner {
-		if err := os.Chown(dst, n.UID, n.GID); err != nil {
-			return err
-		}
 
-		if n.Xattrs != nil {
-			for key, value := range n.Xattrs {
-				if err := xattr.LSet(dst, key, []byte(value)); err != nil {
-					return err
-				}
-			}
+	if err := r.Remove(n.Name); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("%s: %w", n.Name, err)
+	}
+
+	// os.Root has no Mknod, so open the (confined) parent directory and
+	// create the node relative to its fd. r.Open refuses to traverse any
+	// symlink that would escape the root, and the base name has no path
+	// separators, so this cannot escape Root.
+	df, err := r.Open(path.Dir(n.Name))
+	if err != nil {
+		return fmt.Errorf("%s: %w", n.Name, err)
+	}
+	mknodErr := unix.Mknodat(int(df.Fd()), path.Base(n.Name), FilemodeToStatMode(n.Mode)|0666, int(mkdev(n.Major, n.Minor)))
+	df.Close()
+	if mknodErr != nil {
+		return fmt.Errorf("mknod %s: %w", n.Name, mknodErr)
+	}
+
+	if !fs.opts.NoSameOwner {
+		if err := r.Chown(n.Name, n.UID, n.GID); err != nil {
+			return fmt.Errorf("%s: %w", n.Name, err)
+		}
+		if err := fs.setXattrsNoFollow(n.Name, n.Xattrs); err != nil {
+			return err
 		}
 	}
 	if !fs.opts.NoSamePermissions {
-		if err := syscall.Chmod(dst, FilemodeToStatMode(n.Mode)); err != nil {
-			return errors.Wrapf(err, "chmod %s", dst)
+		if err := r.Chmod(n.Name, n.Mode); err != nil {
+			return fmt.Errorf("chmod %s: %w", n.Name, err)
 		}
 	}
 	if n.MTime == time.Unix(0, 0) {
 		return nil
 	}
-	return os.Chtimes(dst, n.MTime, n.MTime)
+	return r.Chtimes(n.Name, n.MTime, n.MTime)
 }
 
 func mkdev(major, minor uint64) uint64 {

--- a/localfs_other.go
+++ b/localfs_other.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/pkg/xattr"
-	"golang.org/x/sys/unix"
 )
 
 // NewLocalFS initializes a new instance of a local filesystem that
@@ -142,18 +141,10 @@ func (fs *LocalFS) CreateDevice(n NodeDevice) error {
 		return fmt.Errorf("%s: %w", n.Name, err)
 	}
 
-	// os.Root has no Mknod, so open the (confined) parent directory and
-	// create the node relative to its fd. r.Open refuses to traverse any
-	// symlink that would escape the root, and the base name has no path
-	// separators, so this cannot escape Root.
-	df, err := r.Open(path.Dir(n.Name))
-	if err != nil {
-		return fmt.Errorf("%s: %w", n.Name, err)
-	}
-	mknodErr := unix.Mknodat(int(df.Fd()), path.Base(n.Name), FilemodeToStatMode(n.Mode)|0666, int(mkdev(n.Major, n.Minor)))
-	df.Close()
-	if mknodErr != nil {
-		return fmt.Errorf("mknod %s: %w", n.Name, mknodErr)
+	// os.Root has no Mknod. createDeviceNode is implemented per platform but
+	// always confines the operation to the extraction root.
+	if err := fs.createDeviceNode(r, n); err != nil {
+		return fmt.Errorf("mknod %s: %w", n.Name, err)
 	}
 
 	if !fs.opts.NoSameOwner {


### PR DESCRIPTION
## Problem

`LocalFS` computed every destination as `filepath.Join(fs.Root, n.Name)` and wrote via raw `os.OpenFile`/`os.RemoveAll`/`os.Symlink`/`os.Chown`/`syscall.Chmod`/`syscall.Mknod` with no symlink protection (no `O_NOFOLLOW`, no `openat2`/`RESOLVE_BENEATH`, no confinement check).

An attacker-controlled catar could:

1. Create a symlink entry `evil -> /etc` (target written verbatim).
2. Add a later entry named `evil/passwd` — a clean name with no `..`, so lexical filtering does not catch it. The kernel resolves `evil` through the planted symlink and the write/remove/chown/chmod lands on `/etc/passwd`, outside the extraction root.

Running as root, this also lets the archive set arbitrary ownership/mode on the escaped target.

## Fix

- **`LocalFS` routed through `os.Root`** (Go 1.25): a lazily-opened, cached root handle anchors all write/metadata operations to the extraction root. `os.Root` refuses to traverse any path component or symlink that escapes the root, while still following benign in-root relative symlinks — neutralizing the symlink-follow class regardless of the entry name.
- **Symlink targets kept verbatim** (legitimate; matches GNU tar / casync). Safety comes from never *following* an escaping link, not from rejecting the target.
- **`CreateDevice`** uses `unix.Mknodat` against a confined parent-directory fd (`os.Root` has no `Mknod`); xattrs applied via fd-based `xattr.FSet`. `golang.org/x/sys` promoted to a direct dependency.
- **Decoder hardening (defense-in-depth):** `ArchiveDecoder` rejects `FormatFilename` names that are empty, `.`, `..`, absolute, or contain a path separator, and asserts each cumulative entry path stays within root. This also stops `TarWriter` from forwarding poisoned names into produced tar archives.
- **`cmd/desync untar`** closes the writer handle after extraction.

## Tests

New adversarial tests: reported symlink-write escape (out-of-root file left untouched), lexical `..` escape, verbatim absolute symlink target with following refused, decoder rejection of embedded-slash names, and a regression guard for benign in-root relative symlinks.

`go test ./...`, `go vet ./...`, and `GOOS=windows go build ./cmd/desync` all pass with no regressions.