### PR TITLE
Reject unsafe index names in the index server (path traversal)

### DIFF
--- a/cmd/desync/indexserver_test.go
+++ b/cmd/desync/indexserver_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -66,6 +68,50 @@ func TestIndexServerWriteCommand(t *testing.T) {
 	require.NoError(t, err)
 	resp.Body.Close()
 	require.Equal(t, http.StatusUnsupportedMediaType, resp.StatusCode)
+}
+
+// TestIndexServerPathTraversal ensures the index server rejects index names
+// derived from request paths that contain path separators. A backslash is a
+// path separator on Windows but not on POSIX; path.Base (forward-slash only)
+// leaves it intact, so without validation a payload like
+// "/..%5C..%5Cevil.caibx" would escape the store directory on a Windows host.
+// The handler-level check rejects "/" and "\" regardless of host OS, so this
+// test asserts a flat 400 (and that nothing is written outside the store) on
+// all platforms.
+func TestIndexServerPathTraversal(t *testing.T) {
+	base := t.TempDir()
+	store := filepath.Join(base, "store")
+	require.NoError(t, os.Mkdir(store, 0755))
+
+	// Sentinel path one level above the store that must never be created.
+	target := filepath.Join(base, "evil.caibx")
+
+	addr, cancel := startIndexServer(t, "-s", store, "-w")
+	defer cancel()
+
+	traversalURL := fmt.Sprintf("http://%s/..%%5C..%%5Cevil.caibx", addr)
+
+	// PUT must be rejected with 400 and must not truncate/create a file
+	// outside the store directory.
+	req, _ := http.NewRequest("PUT", traversalURL, strings.NewReader("not-a-real-index"))
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoFileExists(t, target)
+
+	// GET and HEAD must also return a flat 400, leaking no file-existence
+	// information (no 404-vs-400 oracle).
+	resp, err = http.Get(traversalURL)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	req, _ = http.NewRequest("HEAD", traversalURL, nil)
+	resp, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
 func startIndexServer(t *testing.T, args ...string) (string, context.CancelFunc) {

--- a/httpindexhandler.go
+++ b/httpindexhandler.go
@@ -26,6 +26,10 @@ func (h HTTPIndexHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	indexName := path.Base(r.URL.Path)
+	if !validIndexName(indexName) {
+		http.Error(w, "invalid index name", http.StatusBadRequest)
+		return
+	}
 
 	switch r.Method {
 	case "GET":

--- a/localindex.go
+++ b/localindex.go
@@ -4,10 +4,32 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
 )
+
+// errInvalidIndexName is returned when an index name is not safe to use as a
+// filename in a filesystem-backed index store.
+var errInvalidIndexName = errors.New("invalid index name")
+
+// validIndexName reports whether name is safe to use as an index filename in
+// filesystem-backed stores. It rejects empty names, "." and "..", names
+// containing a path separator (forward slash or backslash, regardless of the
+// host OS so a server is protected from cross-platform payloads) and names
+// that aren't local per the OS rules (e.g. Windows reserved device names or
+// volume/absolute paths). This prevents path traversal from
+// attacker-controlled index names, e.g. via the index server.
+func validIndexName(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return false
+	}
+	return filepath.IsLocal(name)
+}
 
 // LocalIndexStore is used to read/write index files on local disk
 type LocalIndexStore struct {
@@ -33,6 +55,9 @@ func NewLocalIndexStore(path string) (LocalIndexStore, error) {
 // GetIndexReader returns a reader of an index file in the store or an error if
 // the specified index file does not exist.
 func (s LocalIndexStore) GetIndexReader(name string) (rdr io.ReadCloser, e error) {
+	if !validIndexName(name) {
+		return nil, errInvalidIndexName
+	}
 	return os.Open(s.Path + name)
 }
 
@@ -52,6 +77,9 @@ func (s LocalIndexStore) GetIndex(name string) (i Index, e error) {
 
 // StoreIndex stores an index in the index store with the given name.
 func (s LocalIndexStore) StoreIndex(name string, idx Index) error {
+	if !validIndexName(name) {
+		return errInvalidIndexName
+	}
 	// Write the index to file
 	i, err := os.Create(s.Path + name)
 	if err != nil {


### PR DESCRIPTION
## Problem

`HTTPIndexHandler.ServeHTTP` derived the index name via `path.Base(r.URL.Path)` (httpindexhandler.go), which treats only `/` as a separator. `LocalIndexStore.GetIndexReader`/`StoreIndex` (localindex.go) then concatenated that name onto the store path (`os.Open`/`os.Create(s.Path + name)`) with no filtering.

On Windows `\` is a path separator, so a URL-decoded path like `/..\..\..\target` (e.g. `PUT /..%5C..%5C..%5CUsers%5Cvictim%5C.ssh%5Cauthorized_keys`) resolved **outside** the store directory:

- **PUT** truncates/creates arbitrary files on the host before writing the index body.
- **GET/HEAD** act as a file-existence oracle (404-vs-400) for arbitrary paths even on a read-only server.

Server auth is optional and off by default. `http.ServeMux`'s `cleanPath` uses forward-slash `path.Clean` and leaves backslashes intact, so the payload reaches the handler unsanitized. The chunk server is **not** affected — `idFromPath` strictly validates the `/<prefix>/<id>.ext` shape and runs `ChunkIDFromString`.

## Fix

- Add `validIndexName()`: rejects empty / `.` / `..`, any name containing `/` or `\` (both hardcoded, so a cross-platform payload is rejected regardless of host OS), and anything `filepath.IsLocal` flags (Windows reserved device names, volume/absolute paths).
- Enforce it in `HTTPIndexHandler.ServeHTTP` immediately after deriving the name — a flat `400` for GET/HEAD/PUT, which also closes the existence oracle.
- Enforce it in `LocalIndexStore.GetIndexReader`/`StoreIndex` as defense in depth so non-HTTP callers are protected too (`GetIndex` is covered transitively).

## Tests

New `TestIndexServerPathTraversal` starts a writable server with a nested store dir and asserts the `..%5C..%5Cevil.caibx` payload yields `400` for PUT/GET/HEAD and that no file is created above the store root. Because the rejection is OS-independent, the test passes on the existing Linux/Windows/macOS CI.

`go build ./...`, `go vet ./...`, `gofmt -l`, `go test .` and `go test ./cmd/desync -run TestIndexServer` all pass; the pre-existing read/write index-server tests are unaffected.