### PR TITLE
Fix inverted HEAD response and fd leak in index server

### DIFF
--- a/cmd/desync/indexserver_test.go
+++ b/cmd/desync/indexserver_test.go
@@ -114,6 +114,29 @@ func TestIndexServerPathTraversal(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
+// TestIndexServerHead confirms HEAD accurately reflects index existence: an
+// existing index returns 200 OK, a missing one returns 404 Not Found. This
+// guards against the response inversion that previously made HEAD-before-PUT
+// clients clobber existing indexes.
+func TestIndexServerHead(t *testing.T) {
+	addr, cancel := startIndexServer(t, "-s", "testdata")
+	defer cancel()
+
+	// Existing index -> 200 OK
+	req, _ := http.NewRequest("HEAD", fmt.Sprintf("http://%s/blob1.caibx", addr), nil)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Missing index -> 404 Not Found
+	req, _ = http.NewRequest("HEAD", fmt.Sprintf("http://%s/does-not-exist.caibx", addr), nil)
+	resp, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
 func startIndexServer(t *testing.T, args ...string) (string, context.CancelFunc) {
 	// Find a free local port to be used to run the index server on
 	l, err := net.Listen("tcp", "127.0.0.1:0")

--- a/httpindexhandler.go
+++ b/httpindexhandler.go
@@ -66,12 +66,18 @@ func (h HTTPIndexHandler) get(indexName string, w http.ResponseWriter) {
 }
 
 func (h HTTPIndexHandler) head(indexName string, w http.ResponseWriter) {
-	_, err := h.s.GetIndexReader(indexName)
+	rdr, err := h.s.GetIndexReader(indexName)
 	if err != nil {
-		w.WriteHeader(http.StatusOK)
+		if os.IsNotExist(err) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		fmt.Fprintf(os.Stderr, "failed to retrieve index %s: %s\n", indexName, err)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	w.WriteHeader(http.StatusNotFound)
+	defer rdr.Close()
+	w.WriteHeader(http.StatusOK)
 }
 
 func (h HTTPIndexHandler) put(indexName string, w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Problem

`HTTPIndexHandler.head` (`httpindexhandler.go`) had two defects:

1. **Inverted status logic.** It returned `200 OK` when `GetIndexReader` failed and `404 Not Found` when it succeeded. A client that does HEAD-before-PUT to avoid clobbering an index would see `404` for an index that exists and overwrite it.
2. **File-descriptor leak.** The `io.ReadCloser` returned by `GetIndexReader` was discarded into `_` and never closed. For `LocalIndexStore` this reader is the `*os.File` from `os.Open`, so every HEAD to an existing index leaked one fd until GC finalization. A sustained HEAD burst against a known index name could exhaust the process fd limit (EMFILE), breaking `Accept()` and legitimate GET/PUT traffic.

## Fix

- Correct the status mapping to mirror the sibling `get` handler in the same file: `os.IsNotExist(err)` → `404`, other error → stderr log + `400`, success → `200`. This keeps HEAD and GET consistent for the same name and correctly detects the missing-file case for `LocalIndexStore` (the index-server default backing).
- Close the returned reader deterministically with `defer rdr.Close()`, matching the `defer obj.Close()` pattern used by every `GetIndex` implementation, eliminating the fd leak.
- Add `TestIndexServerHead` covering the existing-index (→ 200) and missing-index (→ 404) paths, which the existing suite never exercised.

## Verification

- `go build ./cmd/desync` — OK
- `go test ./cmd/desync -run TestIndexServer -v` — all pass, including the new `TestIndexServerHead`
- `go test ./...` — full suite green, no regressions
- `gofmt -l` — clean