### PR TITLE
Fix sparse-file cache serving zeros after a transient chunk load failure

### DIFF
--- a/sparse-file.go
+++ b/sparse-file.go
@@ -149,7 +149,7 @@ func (h *SparseFileHandle) Close() error {
 
 type sparseIndexChunk struct {
 	IndexChunk
-	once sync.Once
+	mu sync.Mutex
 }
 
 // Loader for sparse files
@@ -229,36 +229,48 @@ func (l *sparseFileLoader) loadRange(start, length int64) error {
 }
 
 func (l *sparseFileLoader) loadChunk(i int) error {
-	var loadErr error
-	l.chunks[i].once.Do(func() {
-		c, err := l.s.GetChunk(l.chunks[i].ID)
-		if err != nil {
-			loadErr = err
-			return
-		}
-		b, err := c.Data()
-		if err != nil {
-			loadErr = err
-			return
-		}
+	c := l.chunks[i]
 
-		f, err := os.OpenFile(l.name, os.O_RDWR, 0666)
-		if err != nil {
-			loadErr = err
-			return
-		}
-		defer f.Close()
+	// Serialize loads of the same chunk so concurrent reads don't fetch it
+	// twice or race on the write to the sparse file. Different chunks still
+	// load in parallel.
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-		if _, err := f.WriteAt(b, int64(l.chunks[i].Start)); err != nil {
-			loadErr = err
-			return
-		}
+	// Already loaded by an earlier successful call? The done bitmap is the
+	// authoritative record of what has actually been written to the sparse
+	// file. A failed load never sets it, so this stays false and the load
+	// is retried until it succeeds.
+	l.mu.RLock()
+	loaded := l.done.Get(i)
+	l.mu.RUnlock()
+	if loaded {
+		return nil
+	}
 
-		l.mu.Lock()
-		l.done.Set(i, true)
-		l.mu.Unlock()
-	})
-	return loadErr
+	chunk, err := l.s.GetChunk(c.ID)
+	if err != nil {
+		return err
+	}
+	b, err := chunk.Data()
+	if err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(l.name, os.O_RDWR, 0666)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.WriteAt(b, int64(c.Start)); err != nil {
+		return err
+	}
+
+	l.mu.Lock()
+	l.done.Set(i, true)
+	l.mu.Unlock()
+	return nil
 }
 
 // writeState saves the current internal state about which chunks have

--- a/sparse-file_test.go
+++ b/sparse-file_test.go
@@ -3,12 +3,34 @@ package desync
 import (
 	"bytes"
 	"crypto/sha256"
+	"errors"
 	"math/rand"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+// flakyStore wraps a Store and injects a fixed number of transient failures
+// for a specific chunk before delegating to the underlying store.
+type flakyStore struct {
+	Store
+	mu        sync.Mutex
+	failID    ChunkID
+	failsLeft int
+}
+
+func (s *flakyStore) GetChunk(id ChunkID) (*Chunk, error) {
+	s.mu.Lock()
+	if id == s.failID && s.failsLeft > 0 {
+		s.failsLeft--
+		s.mu.Unlock()
+		return nil, errors.New("injected transient failure")
+	}
+	s.mu.Unlock()
+	return s.Store.GetChunk(id)
+}
 
 func TestLoaderChunkRange(t *testing.T) {
 	idx := Index{
@@ -103,4 +125,66 @@ func TestSparseFileRead(t *testing.T) {
 	blobHash := sha256.Sum256(b)
 	sparseHash := sha256.Sum256(whole)
 	require.Equal(t, blobHash, sparseHash)
+}
+
+// TestSparseFileRetryAfterFailedLoad ensures that a transient fetch failure
+// for a chunk does not permanently poison its region of the sparse file. The
+// failed load must surface an error, and a subsequent read must retry and
+// return the real chunk data rather than the zeroed (never-written) region.
+func TestSparseFileRetryAfterFailedLoad(t *testing.T) {
+	sparseFile, err := os.CreateTemp("", "")
+	require.NoError(t, err)
+	defer os.Remove(sparseFile.Name())
+
+	s, err := NewLocalStore("testdata/blob1.store", StoreOptions{})
+	require.NoError(t, err)
+	defer s.Close()
+
+	indexFile, err := os.Open("testdata/blob1.caibx")
+	require.NoError(t, err)
+	defer indexFile.Close()
+	index, err := IndexFromReader(indexFile)
+	require.NoError(t, err)
+
+	b, err := os.ReadFile("testdata/blob1")
+	require.NoError(t, err)
+
+	// Pick the first chunk that actually needs fetching from the store. Null
+	// chunks are served from the truncated sparse file and never hit GetChunk.
+	nullChunk := NewNullChunk(index.Index.ChunkSizeMax)
+	var target IndexChunk
+	found := false
+	for _, c := range index.Chunks {
+		if c.ID != nullChunk.ID {
+			target = c
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "expected at least one non-null chunk")
+
+	// Store that fails the first GetChunk for the target chunk, then works.
+	flaky := &flakyStore{Store: s, failID: target.ID, failsLeft: 1}
+
+	sparse, err := NewSparseFile(sparseFile.Name(), index, flaky, SparseFileOptions{})
+	require.NoError(t, err)
+	h, err := sparse.Open()
+	require.NoError(t, err)
+	defer h.Close()
+
+	buf := make([]byte, target.Size)
+
+	// First read of the target chunk's range must surface the transient error.
+	_, err = h.ReadAt(buf, int64(target.Start))
+	require.Error(t, err)
+
+	// The retry must actually load the chunk and return real data, not the
+	// zeroed sparse-file region.
+	_, err = h.ReadAt(buf, int64(target.Start))
+	require.NoError(t, err)
+
+	expected := make([]byte, target.Size)
+	_, err = bytes.NewReader(b).ReadAt(expected, int64(target.Start))
+	require.NoError(t, err)
+	require.Equal(t, expected, buf)
 }


### PR DESCRIPTION
## Problem

`sparseFileLoader.loadChunk` (`sparse-file.go`) wrapped the chunk fetch in a per-chunk `sync.Once` whose closure recorded failures in a stack-local error.

`sync.Once` latches on *invocation*, not on *success*:

- **First call, transient failure:** the closure runs, the error is set and returned correctly, but `l.done` is never set and the `Once` is now permanently consumed.
- **Every subsequent call for that chunk:** `once.Do` is a no-op, the closure never runs, the fresh stack-local error stays `nil`, and `loadChunk` returns `nil` without ever writing the chunk.

`loadRange` then reports success and `SparseFileHandle.ReadAt` reads the never-written region of the file (which `NewSparseFile` truncated to full length) — **zeros** — returning them to the FUSE caller as valid data, with no error and no hash check at this layer.

Impact: a single transient fetch error (brief connectivity loss, or one store in a router/failover group returning an error once) permanently poisons that chunk's byte range, silently serving zeros for the remaining life of the mount. `preloadChunksFromState` had the same defect.

## Fix

- Replace the per-chunk `sync.Once` with a per-chunk `sync.Mutex`.
- Use the existing `l.done` bitmap as the authoritative record of what has actually been written to the sparse file.
- `loadChunk` now: takes the per-chunk lock (serializing same-chunk loads; different chunks still load in parallel), returns early only when the chunk is genuinely loaded, sets `done` **only on success**, and returns the error directly on any failure.

Failed loads stay in a failed state (error returned on every read) and remain retryable until the chunk is actually fetched; success is never reported for data that was not written. Lock order is consistently per-chunk `mu` → loader `mu` (no deadlock; `loadRange` releases the loader lock before calling `loadChunk`).

## Test

Added `TestSparseFileRetryAfterFailedLoad`: injects a single transient `GetChunk` failure for a target chunk, asserts the first read surfaces the error, and asserts the retry returns the real chunk data byte-for-byte (rather than zeros). Under the old code the retry returned a zeroed region and the test fails.

Verified: `go test -race` (sparse-file tests + full library suite), `go build ./cmd/desync`, `go vet .` all pass.