### PR TITLE
Replace deprecated stdlib/x APIs

### DIFF
--- a/fileseed.go
+++ b/fileseed.go
@@ -197,10 +197,10 @@ func (s *fileSeedSegment) Validate(file *os.File) error {
 // Performs a plain copy of everything in the seed to the target, not cloning
 // of blocks.
 func (s *fileSeedSegment) copy(dst, src *os.File, srcOffset, length, dstOffset uint64) (uint64, uint64, error) {
-	if _, err := dst.Seek(int64(dstOffset), os.SEEK_SET); err != nil {
+	if _, err := dst.Seek(int64(dstOffset), io.SeekStart); err != nil {
 		return 0, 0, err
 	}
-	if _, err := src.Seek(int64(srcOffset), os.SEEK_SET); err != nil {
+	if _, err := src.Seek(int64(srcOffset), io.SeekStart); err != nil {
 		return 0, 0, err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -19,9 +19,9 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.11.1
-	golang.org/x/crypto v0.47.0
 	golang.org/x/sync v0.19.0
 	golang.org/x/sys v0.42.0
+	golang.org/x/term v0.39.0
 	google.golang.org/api v0.267.0
 	gopkg.in/cheggaaa/pb.v1 v1.0.28
 )
@@ -77,9 +77,9 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
+	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
-	golang.org/x/term v0.39.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/genproto v0.0.0-20260128011058-8636f8732409 // indirect

--- a/make_test.go
+++ b/make_test.go
@@ -3,9 +3,9 @@ package desync
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"crypto/sha512"
 	"fmt"
-	"math/rand"
 	"os"
 	"testing"
 

--- a/nullseed.go
+++ b/nullseed.go
@@ -121,7 +121,7 @@ func (s *nullChunkSection) WriteInto(dst *os.File, offset, length, blocksize uin
 }
 
 func (s *nullChunkSection) copy(dst *os.File, offset, length uint64) (uint64, uint64, error) {
-	if _, err := dst.Seek(int64(offset), os.SEEK_SET); err != nil {
+	if _, err := dst.Seek(int64(offset), io.SeekStart); err != nil {
 		return 0, 0, err
 	}
 	// Copy using a fixed buffer. Using io.Copy() with a LimitReader will make it

--- a/progressbar.go
+++ b/progressbar.go
@@ -5,14 +5,14 @@ import (
 	"os"
 	"time"
 
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 	pb "gopkg.in/cheggaaa/pb.v1"
 )
 
 // NewProgressBar initializes a wrapper for a https://github.com/cheggaaa/pb
 // progressbar that implements desync.ProgressBar
 func NewProgressBar(prefix string) ProgressBar {
-	if !terminal.IsTerminal(int(os.Stderr.Fd())) &&
+	if !term.IsTerminal(int(os.Stderr.Fd())) &&
 		os.Getenv("DESYNC_PROGRESSBAR_ENABLED") == "" &&
 		os.Getenv("DESYNC_ENABLE_PARSABLE_PROGRESS") == "" {
 		return NullProgressBar{}

--- a/tarfs.go
+++ b/tarfs.go
@@ -5,7 +5,44 @@ import (
 	"io"
 	"os"
 	"path"
+	"strings"
 )
+
+// paxSchilyXattr is the PAX-record key prefix GNU tar / star (and casync) use
+// for extended attributes. It matches the prefix archive/tar uses internally
+// for the deprecated Header.Xattrs field, so storing xattrs via PAXRecords
+// directly keeps the tar wire format byte-for-byte unchanged.
+const paxSchilyXattr = "SCHILY.xattr."
+
+// xattrsToPAXRecords converts a set of extended attributes into the PAX
+// records archive/tar writes them as. Returns nil when there are none so the
+// header stays in the same (non-PAX) format as before.
+func xattrsToPAXRecords(x Xattrs) map[string]string {
+	if len(x) == 0 {
+		return nil
+	}
+	r := make(map[string]string, len(x))
+	for k, v := range x {
+		r[paxSchilyXattr+k] = v
+	}
+	return r
+}
+
+// paxRecordsToXattrs extracts extended attributes from PAX records, mirroring
+// how archive/tar populates the deprecated Header.Xattrs field on read. The
+// map is allocated lazily so the result is nil when no xattrs are present.
+func paxRecordsToXattrs(r map[string]string) map[string]string {
+	var x map[string]string
+	for k, v := range r {
+		if name, ok := strings.CutPrefix(k, paxSchilyXattr); ok {
+			if x == nil {
+				x = make(map[string]string)
+			}
+			x[name] = v
+		}
+	}
+	return x
+}
 
 // TarWriter uses a GNU tar archive for tar/untar operations of a catar archive.
 type TarWriter struct {
@@ -23,29 +60,29 @@ func NewTarWriter(w io.Writer) TarWriter {
 
 func (fs TarWriter) CreateDir(n NodeDirectory) error {
 	hdr := &gnutar.Header{
-		Typeflag: gnutar.TypeDir,
-		Name:     n.Name,
-		Uid:      n.UID,
-		Gid:      n.GID,
-		Mode:     int64(n.Mode),
-		ModTime:  n.MTime,
-		Xattrs:   n.Xattrs,
-		Format:   fs.format,
+		Typeflag:   gnutar.TypeDir,
+		Name:       n.Name,
+		Uid:        n.UID,
+		Gid:        n.GID,
+		Mode:       int64(n.Mode),
+		ModTime:    n.MTime,
+		PAXRecords: xattrsToPAXRecords(n.Xattrs),
+		Format:     fs.format,
 	}
 	return fs.w.WriteHeader(hdr)
 }
 
 func (fs TarWriter) CreateFile(n NodeFile) error {
 	hdr := &gnutar.Header{
-		Typeflag: gnutar.TypeReg,
-		Name:     n.Name,
-		Uid:      n.UID,
-		Gid:      n.GID,
-		Mode:     int64(n.Mode),
-		ModTime:  n.MTime,
-		Size:     int64(n.Size),
-		Xattrs:   n.Xattrs,
-		Format:   fs.format,
+		Typeflag:   gnutar.TypeReg,
+		Name:       n.Name,
+		Uid:        n.UID,
+		Gid:        n.GID,
+		Mode:       int64(n.Mode),
+		ModTime:    n.MTime,
+		Size:       int64(n.Size),
+		PAXRecords: xattrsToPAXRecords(n.Xattrs),
+		Format:     fs.format,
 	}
 	if err := fs.w.WriteHeader(hdr); err != nil {
 		return err
@@ -56,15 +93,15 @@ func (fs TarWriter) CreateFile(n NodeFile) error {
 
 func (fs TarWriter) CreateSymlink(n NodeSymlink) error {
 	hdr := &gnutar.Header{
-		Typeflag: gnutar.TypeSymlink,
-		Linkname: n.Target,
-		Name:     n.Name,
-		Uid:      n.UID,
-		Gid:      n.GID,
-		Mode:     int64(n.Mode),
-		ModTime:  n.MTime,
-		Xattrs:   n.Xattrs,
-		Format:   fs.format,
+		Typeflag:   gnutar.TypeSymlink,
+		Linkname:   n.Target,
+		Name:       n.Name,
+		Uid:        n.UID,
+		Gid:        n.GID,
+		Mode:       int64(n.Mode),
+		ModTime:    n.MTime,
+		PAXRecords: xattrsToPAXRecords(n.Xattrs),
+		Format:     fs.format,
 	}
 	return fs.w.WriteHeader(hdr)
 }
@@ -79,15 +116,15 @@ func (fs TarWriter) CreateDevice(n NodeDevice) error {
 		typ = gnutar.TypeChar
 	}
 	hdr := &gnutar.Header{
-		Typeflag: typ,
-		Name:     n.Name,
-		Uid:      n.UID,
-		Gid:      n.GID,
-		Mode:     int64(n.Mode),
-		ModTime:  n.MTime,
-		Xattrs:   n.Xattrs,
-		Devmajor: int64(n.Major),
-		Devminor: int64(n.Minor),
+		Typeflag:   typ,
+		Name:       n.Name,
+		Uid:        n.UID,
+		Gid:        n.GID,
+		Mode:       int64(n.Mode),
+		ModTime:    n.MTime,
+		PAXRecords: xattrsToPAXRecords(n.Xattrs),
+		Devmajor:   int64(n.Major),
+		Devminor:   int64(n.Minor),
 	}
 	return fs.w.WriteHeader(hdr)
 }
@@ -151,7 +188,7 @@ func (fs *TarReader) Next() (f *File, err error) {
 		LinkTarget: h.Linkname,
 		Uid:        h.Uid,
 		Gid:        h.Gid,
-		Xattrs:     h.Xattrs,
+		Xattrs:     paxRecordsToXattrs(h.PAXRecords),
 		DevMajor:   uint64(h.Devmajor),
 		DevMinor:   uint64(h.Devminor),
 		Data:       io.NopCloser(fs.r),

--- a/tarfs_test.go
+++ b/tarfs_test.go
@@ -6,8 +6,9 @@ import (
 	"context"
 	"io"
 	"os"
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGnuTarWrite(t *testing.T) {
@@ -43,12 +44,8 @@ func TestGnuTarWrite(t *testing.T) {
 func TestTarXattrHelpers(t *testing.T) {
 	// Empty/nil input must yield a nil map so the header stays in its
 	// original (non-PAX) format.
-	if r := xattrsToPAXRecords(nil); r != nil {
-		t.Fatalf("expected nil for nil xattrs, got %v", r)
-	}
-	if r := xattrsToPAXRecords(Xattrs{}); r != nil {
-		t.Fatalf("expected nil for empty xattrs, got %v", r)
-	}
+	require.Nil(t, xattrsToPAXRecords(nil), "expected nil for nil xattrs")
+	require.Nil(t, xattrsToPAXRecords(Xattrs{}), "expected nil for empty xattrs")
 
 	// Keys must get the SCHILY.xattr. prefix archive/tar uses internally.
 	in := Xattrs{"user.comment": "hello", "security.selinux": "ctx"}
@@ -57,22 +54,15 @@ func TestTarXattrHelpers(t *testing.T) {
 		"SCHILY.xattr.user.comment":     "hello",
 		"SCHILY.xattr.security.selinux": "ctx",
 	}
-	if !reflect.DeepEqual(rec, want) {
-		t.Fatalf("xattrsToPAXRecords = %v, want %v", rec, want)
-	}
+	require.Equal(t, want, rec)
 
 	// Reverse must strip the prefix and ignore unrelated PAX records.
 	rec["mtime"] = "12345"
 	rec["path"] = "some/file"
-	if got := paxRecordsToXattrs(rec); !reflect.DeepEqual(got, map[string]string(in)) {
-		t.Fatalf("paxRecordsToXattrs = %v, want %v", got, in)
-	}
-	if x := paxRecordsToXattrs(map[string]string{"mtime": "1"}); x != nil {
-		t.Fatalf("expected nil when no SCHILY records present, got %v", x)
-	}
-	if x := paxRecordsToXattrs(nil); x != nil {
-		t.Fatalf("expected nil for nil records, got %v", x)
-	}
+	require.Equal(t, map[string]string(in), paxRecordsToXattrs(rec))
+	require.Nil(t, paxRecordsToXattrs(map[string]string{"mtime": "1"}),
+		"expected nil when no SCHILY records present")
+	require.Nil(t, paxRecordsToXattrs(nil), "expected nil for nil records")
 }
 
 func TestTarXattrsRoundTrip(t *testing.T) {
@@ -84,51 +74,33 @@ func TestTarXattrsRoundTrip(t *testing.T) {
 	// actually exercised.
 	var buf bytes.Buffer
 	w := NewTarWriter(&buf)
-	if err := w.CreateDevice(NodeDevice{
+	require.NoError(t, w.CreateDevice(NodeDevice{
 		Name: "dev0", Mode: 0644, Major: 1, Minor: 3, Xattrs: xattrs,
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if err := w.CreateDevice(NodeDevice{
+	}))
+	require.NoError(t, w.CreateDevice(NodeDevice{
 		Name: "dev1", Mode: 0644, Major: 1, Minor: 4,
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
-	}
+	}))
+	require.NoError(t, w.Close())
 
 	// On the wire the xattrs must be SCHILY.xattr.<name> PAX records,
 	// exactly as the deprecated Header.Xattrs field produced them.
 	sr := gnutar.NewReader(bytes.NewReader(buf.Bytes()))
 	h, err := sr.Next()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	for k, v := range xattrs {
-		if got := h.PAXRecords["SCHILY.xattr."+k]; got != v {
-			t.Fatalf("PAX record SCHILY.xattr.%s = %q, want %q", k, got, v)
-		}
+		require.Equal(t, v, h.PAXRecords["SCHILY.xattr."+k],
+			"PAX record SCHILY.xattr.%s", k)
 	}
 
 	// Reading back through TarReader must reconstruct the xattr map, and a
 	// node without xattrs must yield a nil map (unchanged behavior).
 	rd := NewTarReader(bytes.NewReader(buf.Bytes()), TarReaderOptions{})
 	f0, err := rd.Next()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(f0.Xattrs, map[string]string(xattrs)) {
-		t.Fatalf("round-tripped xattrs = %v, want %v", f0.Xattrs, xattrs)
-	}
+	require.NoError(t, err)
+	require.Equal(t, map[string]string(xattrs), f0.Xattrs)
 	f1, err := rd.Next()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if f1.Xattrs != nil {
-		t.Fatalf("expected nil xattrs for node without any, got %v", f1.Xattrs)
-	}
-	if _, err := rd.Next(); err != io.EOF {
-		t.Fatalf("expected io.EOF, got %v", err)
-	}
+	require.NoError(t, err)
+	require.Nil(t, f1.Xattrs, "expected nil xattrs for node without any")
+	_, err = rd.Next()
+	require.ErrorIs(t, err, io.EOF)
 }

--- a/tarfs_test.go
+++ b/tarfs_test.go
@@ -1,9 +1,12 @@
 package desync
 
 import (
+	gnutar "archive/tar"
 	"bytes"
 	"context"
+	"io"
 	"os"
+	"reflect"
 	"testing"
 )
 
@@ -34,5 +37,98 @@ func TestGnuTarWrite(t *testing.T) {
 	// Compare to expected
 	if !bytes.Equal(b.Bytes(), exp) {
 		t.Fatal("tar file does not match expected")
+	}
+}
+
+func TestTarXattrHelpers(t *testing.T) {
+	// Empty/nil input must yield a nil map so the header stays in its
+	// original (non-PAX) format.
+	if r := xattrsToPAXRecords(nil); r != nil {
+		t.Fatalf("expected nil for nil xattrs, got %v", r)
+	}
+	if r := xattrsToPAXRecords(Xattrs{}); r != nil {
+		t.Fatalf("expected nil for empty xattrs, got %v", r)
+	}
+
+	// Keys must get the SCHILY.xattr. prefix archive/tar uses internally.
+	in := Xattrs{"user.comment": "hello", "security.selinux": "ctx"}
+	rec := xattrsToPAXRecords(in)
+	want := map[string]string{
+		"SCHILY.xattr.user.comment":     "hello",
+		"SCHILY.xattr.security.selinux": "ctx",
+	}
+	if !reflect.DeepEqual(rec, want) {
+		t.Fatalf("xattrsToPAXRecords = %v, want %v", rec, want)
+	}
+
+	// Reverse must strip the prefix and ignore unrelated PAX records.
+	rec["mtime"] = "12345"
+	rec["path"] = "some/file"
+	if got := paxRecordsToXattrs(rec); !reflect.DeepEqual(got, map[string]string(in)) {
+		t.Fatalf("paxRecordsToXattrs = %v, want %v", got, in)
+	}
+	if x := paxRecordsToXattrs(map[string]string{"mtime": "1"}); x != nil {
+		t.Fatalf("expected nil when no SCHILY records present, got %v", x)
+	}
+	if x := paxRecordsToXattrs(nil); x != nil {
+		t.Fatalf("expected nil for nil records, got %v", x)
+	}
+}
+
+func TestTarXattrsRoundTrip(t *testing.T) {
+	xattrs := Xattrs{"user.comment": "hello", "user.tag": "v1"}
+
+	// CreateDir/File/Symlink hardcode FormatGNU, which archive/tar rejects
+	// in combination with xattrs. CreateDevice leaves the format
+	// unspecified, so the writer negotiates PAX and the xattr path is
+	// actually exercised.
+	var buf bytes.Buffer
+	w := NewTarWriter(&buf)
+	if err := w.CreateDevice(NodeDevice{
+		Name: "dev0", Mode: 0644, Major: 1, Minor: 3, Xattrs: xattrs,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.CreateDevice(NodeDevice{
+		Name: "dev1", Mode: 0644, Major: 1, Minor: 4,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// On the wire the xattrs must be SCHILY.xattr.<name> PAX records,
+	// exactly as the deprecated Header.Xattrs field produced them.
+	sr := gnutar.NewReader(bytes.NewReader(buf.Bytes()))
+	h, err := sr.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for k, v := range xattrs {
+		if got := h.PAXRecords["SCHILY.xattr."+k]; got != v {
+			t.Fatalf("PAX record SCHILY.xattr.%s = %q, want %q", k, got, v)
+		}
+	}
+
+	// Reading back through TarReader must reconstruct the xattr map, and a
+	// node without xattrs must yield a nil map (unchanged behavior).
+	rd := NewTarReader(bytes.NewReader(buf.Bytes()), TarReaderOptions{})
+	f0, err := rd.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(f0.Xattrs, map[string]string(xattrs)) {
+		t.Fatalf("round-tripped xattrs = %v, want %v", f0.Xattrs, xattrs)
+	}
+	f1, err := rd.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f1.Xattrs != nil {
+		t.Fatalf("expected nil xattrs for node without any, got %v", f1.Xattrs)
+	}
+	if _, err := rd.Next(); err != io.EOF {
+		t.Fatalf("expected io.EOF, got %v", err)
 	}
 }


### PR DESCRIPTION
Replaces four deprecated APIs flagged by the Go 1.25 toolchain with their supported equivalents. No behavior change — the wire-sensitive `tar.Header.Xattrs` swap is byte-for-byte identical and guarded by the existing golden-file test.

## Changes

| Deprecated | Replacement | Files |
|---|---|---|
| `os.SEEK_SET` | `io.SeekStart` (same value, `0`) | `fileseed.go`, `nullseed.go` |
| `math/rand`'s `rand.Read` | `crypto/rand.Read` | `make_test.go` (test data only) |
| `tar.Header.Xattrs` | `PAXRecords` | `tarfs.go` |
| `golang.org/x/crypto/ssh/terminal` | `golang.org/x/term` | `progressbar.go` |

### `tar.Header.Xattrs` → `PAXRecords`

Verified against the installed Go stdlib that this is exactly equivalent:

- `archive/tar/common.go`: *"The following are semantically equivalent: `h.Xattrs[key]=value` / `h.PAXRecords["SCHILY.xattr."+key]=value`"* — and `Xattrs` is internally copied into the PAX-record map with exactly that `SCHILY.xattr.` prefix, so format negotiation and output bytes are identical.
- `archive/tar/reader.go`: `Header.Xattrs` is populated by stripping `SCHILY.xattr.` from `PAXRecords`, lazily allocated (nil when none).

Added `xattrsToPAXRecords` / `paxRecordsToXattrs` helpers mirroring those exact semantics (including the lazy/nil map, so `File.Xattrs == nil` behavior for entries without xattrs is preserved).

### `math/rand` → `crypto/rand`

`make_test.go` used `math/rand`'s `rand.Read` only for generating test input. Swapped to `crypto/rand`, matching the convention already used in `failover_test.go`, `selfseed_test.go`, and `assemble_test.go`.

### `ssh/terminal` → `x/term`

Identical `IsTerminal(int) bool` signature. `go mod tidy` promotes `golang.org/x/term` to a direct dependency and demotes `golang.org/x/crypto` to indirect; `go.sum` is unchanged (both were already in the module graph).

## Tests

- **`TestTarXattrHelpers`** — direct unit tests of the conversion helpers: `SCHILY.xattr.` prefix correctness, nil/empty handling, and that unrelated PAX records are ignored on the way back.
- **`TestTarXattrsRoundTrip`** — writes xattrs via `TarWriter`, parses with the stdlib `archive/tar` reader to assert the wire records are exactly `SCHILY.xattr.<name>`, then round-trips them back through `TarReader`; also asserts a node without xattrs yields a nil map. Uses `CreateDevice` because `CreateDir`/`File`/`Symlink` hardcode `FormatGNU`, which `archive/tar` rejects together with xattrs — a pre-existing constraint, unchanged here.
- Pre-existing **`TestGnuTarWrite`** (golden byte-compare against `testdata/complex.gnu-tar`) still passes, confirming the tar output did not change.

Verification: `go vet ./...` clean (no deprecation diagnostics), `go build ./cmd/desync`, full `go test .` / `go test ./cmd/desync`, and `-race` on the tar/seed code paths all pass.