### PR TITLE
Fix data race on ChunkingStats in IndexFromFile

### DIFF
--- a/make.go
+++ b/make.go
@@ -27,6 +27,7 @@ func IndexFromFile(ctx context.Context,
 ) (Index, ChunkingStats, error) {
 
 	stats := ChunkingStats{}
+	var wg sync.WaitGroup
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -121,14 +122,15 @@ func IndexFromFile(ctx context.Context,
 
 	// Start the workers
 	for _, w := range worker {
-		go w.start(ctx)
-		defer w.stop() // shouldn't be necessary, but better be safe
+		wg.Go(func() { w.start(ctx) })
+		defer w.stop() // panic/return safety net (idempotent via once)
 	}
 
 	// Go through the workers, starting with the first one, taking all chunks
 	// from their bucket before moving on to the next. It's possible that a worker
 	// reaches the end of the stream before the following worker does (eof=true),
 	// don't advance to the next worker in that case.
+	var chunkErr error
 	for _, w := range worker {
 		for chunk := range w.results {
 			// Assemble the list of chunks in the index
@@ -138,7 +140,8 @@ func IndexFromFile(ctx context.Context,
 		}
 		// Done reading all chunks from this worker, check for any errors
 		if w.err != nil {
-			return index, stats, w.err
+			chunkErr = w.err
+			break
 		}
 		// Stop if this worker reached the end of the stream (it's not necessarily
 		// the last worker!)
@@ -146,7 +149,17 @@ func IndexFromFile(ctx context.Context,
 			break
 		}
 	}
-	return index, stats, nil
+
+	// Stop every worker and wait for all goroutines to fully exit before
+	// copying stats by value into the return. Otherwise the copy races the
+	// workers' atomic stats updates and the count would be incomplete.
+	cancel()
+	for _, w := range worker {
+		w.stop()
+	}
+	wg.Wait()
+
+	return index, stats, chunkErr
 }
 
 // Parallel chunk worker - Splits a stream and stores start, size and ID in

--- a/make_test.go
+++ b/make_test.go
@@ -84,3 +84,61 @@ func TestParallelChunking(t *testing.T) {
 		})
 	}
 }
+
+// TestIndexFromFileStats exercises the parallel chunker's early-EOF/straggler
+// path (null-heavy inputs, multiple workers) and asserts the returned
+// ChunkingStats. It guards the data race where IndexFromFile copied stats by
+// value while worker goroutines were still atomically updating them: with the
+// join in place the counters must be complete and deterministic for every
+// worker count. Run under -race to catch a regression of the join.
+func TestIndexFromFileStats(t *testing.T) {
+	null := make([]byte, 4*ChunkSizeMaxDefault)
+	rnd := make([]byte, 4*ChunkSizeMaxDefault)
+	rand.Read(rnd)
+
+	tests := map[string][][]byte{
+		"trailing null":   {rnd, rnd, null, null, null, null},
+		"middle null":     {rnd, null, null, null, null, rnd},
+		"spread out null": {rnd, null, null, null, rnd, null, null, null, rnd},
+	}
+
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			f, err := tempfile.New("", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(f.Name())
+			if _, err := f.Write(join(input...)); err != nil {
+				t.Fatal(err)
+			}
+			f.Close()
+
+			for n := 2; n <= 8; n++ {
+				t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+					index, stats, err := IndexFromFile(
+						context.Background(),
+						f.Name(),
+						n,
+						ChunkSizeMinDefault, ChunkSizeAvgDefault, ChunkSizeMaxDefault,
+						NewProgressBar(""),
+					)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if stats.ChunksAccepted != uint64(len(index.Chunks)) {
+						t.Fatalf("ChunksAccepted=%d, want %d (len(index.Chunks))",
+							stats.ChunksAccepted, len(index.Chunks))
+					}
+					if stats.ChunksProduced < stats.ChunksAccepted {
+						t.Fatalf("ChunksProduced=%d < ChunksAccepted=%d",
+							stats.ChunksProduced, stats.ChunksAccepted)
+					}
+					if stats.ChunksProduced == 0 {
+						t.Fatal("ChunksProduced=0, expected the workers to produce chunks")
+					}
+				})
+			}
+		})
+	}
+}

--- a/make_test.go
+++ b/make_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/folbricht/tempfile"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParallelChunking(t *testing.T) {
@@ -105,13 +106,10 @@ func TestIndexFromFileStats(t *testing.T) {
 	for name, input := range tests {
 		t.Run(name, func(t *testing.T) {
 			f, err := tempfile.New("", "")
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			defer os.Remove(f.Name())
-			if _, err := f.Write(join(input...)); err != nil {
-				t.Fatal(err)
-			}
+			_, err = f.Write(join(input...))
+			require.NoError(t, err)
 			f.Close()
 
 			for n := 2; n <= 8; n++ {
@@ -123,20 +121,13 @@ func TestIndexFromFileStats(t *testing.T) {
 						ChunkSizeMinDefault, ChunkSizeAvgDefault, ChunkSizeMaxDefault,
 						NewProgressBar(""),
 					)
-					if err != nil {
-						t.Fatal(err)
-					}
-					if stats.ChunksAccepted != uint64(len(index.Chunks)) {
-						t.Fatalf("ChunksAccepted=%d, want %d (len(index.Chunks))",
-							stats.ChunksAccepted, len(index.Chunks))
-					}
-					if stats.ChunksProduced < stats.ChunksAccepted {
-						t.Fatalf("ChunksProduced=%d < ChunksAccepted=%d",
-							stats.ChunksProduced, stats.ChunksAccepted)
-					}
-					if stats.ChunksProduced == 0 {
-						t.Fatal("ChunksProduced=0, expected the workers to produce chunks")
-					}
+					require.NoError(t, err)
+					require.Equal(t, uint64(len(index.Chunks)), stats.ChunksAccepted,
+						"ChunksAccepted should equal len(index.Chunks)")
+					require.GreaterOrEqual(t, stats.ChunksProduced, stats.ChunksAccepted,
+						"ChunksProduced should be >= ChunksAccepted")
+					require.NotZero(t, stats.ChunksProduced,
+						"workers should have produced chunks")
 				})
 			}
 		})


### PR DESCRIPTION
## Problem

`go test -race` on `TestParallelChunking` reliably reports a data race in `IndexFromFile` (`make.go`). It is a pre-existing latent bug in production code — the recently merged deprecation PR #340 only shifted goroutine timing enough to make it observable.

- `stats := ChunkingStats{}` is a local in the main goroutine; its address is shared with every worker via `pChunker.stats = &stats`.
- Worker goroutines call `c.stats.incProduced()` → `atomic.AddUint64(&s.ChunksProduced, 1)`.
- `stop()` is **signal-only** (`once.Do(func(){ close(done) })`); there is no join/`WaitGroup` anywhere. The consumer loop `break`s early when a worker reports `eof`, leaving later workers' goroutines still running.
- The main goroutine then returns `stats` **by value** — a non-atomic full-struct read concurrent with the still-running workers' atomic increments. That is the race the detector flags.

Beyond the race, the by-value snapshot was also **non-deterministic**: abandoned workers keep incrementing after the function returns, so `ChunksProduced` was whatever happened to be counted at that instant.

## Fix

`make.go` only:

- Track the worker goroutines with a `sync.WaitGroup`, spawned via the Go 1.25 `(*sync.WaitGroup).Go` helper (does `Add(1)`/`Done()` automatically).
- On the post-spawn exit path, route both the mid-loop error case and the normal case through a single tail that `cancel()`s the context, `stop()`s every worker, and `wg.Wait()`s for all goroutines to fully exit **before** `stats` is copied into the return.
  - The wait must be inline before `return` — a deferred cleanup runs *after* the return value is already copied, so it cannot fix this.
  - Because the wait runs before the deferred per-worker `f.Close()` calls, it also closes a latent read-from-closed-file hazard for abandoned stragglers.
  - `defer cancel()` / `defer w.stop()` are kept as an idempotent panic safety net.
- Pre-spawn early returns are unchanged (no goroutines exist yet). No signature change; `cmd/desync/make.go` (the only consumer that reads the returned stats) and all `_`-discarding callers are unaffected.

Scope: only the stats race (the one `-race` flags). The `c.err`/`c.eof` cross-goroutine reads are already safe via the `close(c.results)` happens-before edge; the `c.next` list-collapse mutation is a separate theoretical concern intentionally left out to keep this minimal.

## Test

Added `TestIndexFromFileStats`: drives the early-EOF/straggler path with null-heavy inputs across worker counts 2–8 and asserts the now race-free, deterministic invariants — `ChunksAccepted == len(index.Chunks)`, `ChunksProduced >= ChunksAccepted`, `ChunksProduced > 0`. `TestParallelChunking` is kept as-is as the chunk-equivalence guard.

## Verification

- `go test -race -count=5 -run 'TestParallelChunking|TestIndexFromFileStats' .` — no `WARNING: DATA RACE` (162s; previously reproduced within a few iterations).
- `go test -run TestIndexFromFileStats -count=20 .` — deterministic, green.
- Full `go test -race .` and `go test ./cmd/desync` — green.
- `go vet ./...` clean, `go build ./cmd/desync` clean.