### PR TITLE
Add Code Style section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,11 @@ Key environment variables: `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_REGION`, `CASYN
 - **`t.Fatal()` restriction** — do not call `t.Fatal()`/`t.FailNow()` from non-main goroutines (see PR #291)
 - **Avoid recompression** — if a chunk already has compressed form, don't recompress (see PR #289)
 
+## Code Style
+
+- **Tests use testify** — write new (or modified) Go tests with `github.com/stretchr/testify`: `require` for fatal checks, `assert` for non-fatal. Don't hand-roll `if … { t.Fatalf(…) }` conditionals. Existing plain-`testing` tests don't need a mass rewrite — apply this to new tests and tests you're already changing. Note: `require.*` calls `FailNow()`, so per the non-main-goroutine `t.Fatal()` restriction in Key Patterns, only use `require.*` from the test goroutine — in spawned goroutines use `assert.*` or pass errors back over a channel.
+- **Build into the main package's directory** — always `go build -o cmd/desync/ ./cmd/desync`, never a bare `go build ./cmd/desync`. The bare form drops an untracked `desync` binary in the repo root (it is not git-ignored). Build artifacts belong next to their `main` package, never the project root.
+
 ## Module
 
 Module path: `github.com/folbricht/desync`, Go 1.24.0.


### PR DESCRIPTION
Adds a `## Code Style` section to `CLAUDE.md` documenting two conventions surfaced while working in this repo.

## Conventions

- **Tests use testify** — new or modified Go tests use `github.com/stretchr/testify` (`require` for fatal checks, `assert` for non-fatal) instead of hand-rolled `if … { t.Fatalf(…) }` conditionals. Existing plain-`testing` tests are not mass-rewritten. Cross-references the existing non-main-goroutine `t.Fatal()` restriction (Key Patterns / PR #291): since `require.*` calls `FailNow()`, it must only be used from the test goroutine — spawned goroutines use `assert.*` or pass errors back over a channel.
- **Build into the main package's directory** — always `go build -o cmd/desync/ ./cmd/desync`, never a bare `go build ./cmd/desync`. The bare form drops an untracked `desync` binary in the repo root (it is not git-ignored). This matches the command already shown in the Build and Test Commands section.

Docs-only change; no code impact.