### PR TITLE
Fix inverted --trust-insecure flag silently disabling TLS verification

### DIFF
--- a/cmd/desync/options.go
+++ b/cmd/desync/options.go
@@ -41,7 +41,7 @@ func (o cmdStoreOptions) MergedWith(opt desync.StoreOptions) desync.StoreOptions
 		opt.SkipVerify = true
 	}
 	if o.FlagSet.Lookup("trust-insecure").Changed {
-		opt.TrustInsecure = true
+		opt.TrustInsecure = o.trustInsecure
 	}
 	if o.FlagSet.Lookup("error-retry").Changed {
 		opt.ErrorRetry = o.errorRetry

--- a/cmd/desync/options_test.go
+++ b/cmd/desync/options_test.go
@@ -196,3 +196,71 @@ func TestStringOptions(t *testing.T) {
 		})
 	}
 }
+
+func TestTrustInsecureOption(t *testing.T) {
+	for _, test := range []struct {
+		name                   string
+		args                   []string
+		cfgFileContent         []byte
+		trustInsecureStoreHit  bool
+		trustInsecureStoreMiss bool
+	}{
+		{"Config enables trust-insecure, no CLI flag",
+			[]string{""},
+			[]byte(`{"store-options": {"/store/*/":{"trust-insecure": true}}}`),
+			true, false,
+		},
+		{"Config enables trust-insecure, CLI explicitly disables it",
+			[]string{"--trust-insecure=false"},
+			[]byte(`{"store-options": {"/store/*/":{"trust-insecure": true}}}`),
+			false, false,
+		},
+		{"Config without trust-insecure, CLI enables it",
+			[]string{"--trust-insecure"},
+			[]byte(`{"store-options": {"/store/*/":{"uncompressed": true}}}`),
+			true, true,
+		},
+		{"Config without trust-insecure, no CLI flag",
+			[]string{""},
+			[]byte(`{"store-options": {"/store/*/":{"uncompressed": true}}}`),
+			false, false,
+		},
+		{"Config disables trust-insecure, CLI enables it",
+			[]string{"--trust-insecure"},
+			[]byte(`{"store-options": {"/store/*/":{"trust-insecure": false}}}`),
+			true, true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f, err := os.CreateTemp("", "desync-options")
+			require.NoError(t, err)
+			defer os.Remove(f.Name())
+			_, err = f.Write(test.cfgFileContent)
+			require.NoError(t, err)
+
+			// Set the global config file name
+			cfgFile = f.Name()
+
+			initConfig()
+
+			var cmdOpt cmdStoreOptions
+
+			cmd := newTestOptionsCommand(&cmdOpt)
+			cmd.SetArgs(test.args)
+
+			// Execute the mock command, to load the options provided in the launch arguments
+			_, err = cmd.ExecuteC()
+			require.NoError(t, err)
+
+			configOptions, err := cfg.GetStoreOptionsFor("/store/20230901")
+			require.NoError(t, err)
+			opt := cmdOpt.MergedWith(configOptions)
+			require.Equal(t, test.trustInsecureStoreHit, opt.TrustInsecure)
+
+			configOptions, err = cfg.GetStoreOptionsFor("/missingStore")
+			require.NoError(t, err)
+			opt = cmdOpt.MergedWith(configOptions)
+			require.Equal(t, test.trustInsecureStoreMiss, opt.TrustInsecure)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`cmdStoreOptions.MergedWith()` in `cmd/desync/options.go` gated `TrustInsecure` on `pflag`'s `.Changed` field — which is `true` whenever the flag *appears* on the command line, regardless of its value — but then hard-coded the assignment to `true`:

```go
if o.FlagSet.Lookup("trust-insecure").Changed {
	opt.TrustInsecure = true
}
```

So passing `--trust-insecure=false` (or `-t=false`), e.g. to explicitly override a config file that set `"trust-insecure": true` for a particular store, set `TrustInsecure=true`. This propagates to `remotehttp.go:49` `tls.Config{InsecureSkipVerify: opt.TrustInsecure}`, silently disabling server-certificate validation for HTTPS chunk and index stores.

While chunks are content-addressed (SHA512/256 verified), index files (`.caibx`/`.caidx`) are **not** integrity-checked, so a network MITM able to substitute the index response controls what the user reconstructs.

This was an oversight rather than intent: every other `.Changed`-gated option in the same function (`client-cert`, `client-key`, `ca-cert`, `error-retry`, `error-retry-base-interval`) copies the flag's actual value.

## Fix

Use the flag's actual value, matching the surrounding pattern:

```go
if o.FlagSet.Lookup("trust-insecure").Changed {
	opt.TrustInsecure = o.trustInsecure
}
```

Presence-based gating is preserved (an absent flag still lets a config-file `"trust-insecure": true` through), but an explicit `--trust-insecure=false` now correctly forces verification on and overrides the config.

`skipVerify` (line 40) is intentionally left unchanged: it is bound only to `--skip-verify-read` (chunk-server) and is not registered via `addStoreOptions`, so its value-based check is correct and in scope elsewhere.

## Tests

Added `TestTrustInsecureOption`, a table-driven test covering config/CLI precedence, including the regression case where a config enables `trust-insecure` and the CLI explicitly disables it. Full suite (`go test ./...`) passes.