### PR TITLE
Escape space in mtree filename output to prevent keyword injection

### DIFF
--- a/mtreefs.go
+++ b/mtreefs.go
@@ -92,11 +92,17 @@ func (fs MtreeFS) CreateDevice(n NodeDevice) error {
 // printable ASCII characters must be encoded as a backslash followed by three octal digits.
 // When reading mtree files, any appearance of a backslash followed by three octal digits should
 // be converted into the corresponding character.
+//
+// The space character is also escaped even though it is printable ASCII. mtree(5) lines are
+// space-delimited keyword=value pairs following the filename, so an unescaped space in an
+// untrusted entry name would let it inject keywords (e.g. "ignore", "optional", "nochange")
+// that suppress integrity checks. This matches the escaped set used by libarchive and BSD
+// mtree (non-printable, '\', ' ', '\t', '#'); tab and other control bytes are covered by c < 32.
 func mtreeFilename(s string) string {
 	var b strings.Builder
 	for _, c := range []byte(s) {
 		switch {
-		case c == '\\' || c == '#' || c < 32 || c > 126:
+		case c == '\\' || c == '#' || c == ' ' || c < 32 || c > 126:
 			b.WriteString(fmt.Sprintf("\\%03o", c))
 		default:
 			b.WriteByte(c)

--- a/mtreefs_test.go
+++ b/mtreefs_test.go
@@ -1,0 +1,65 @@
+package desync
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMtreeFilename(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"abc", "abc"},
+		{"name with space", `name\040with\040space`},
+		{`a\b`, `a\134b`},
+		{"a#b", `a\043b`},
+		{"a\tb", `a\011b`},
+		{"a\nb", `a\012b`},
+		{"a\x7fb", `a\177b`},
+		{"é", `\303\251`}, // UTF-8 bytes, each > 126
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, mtreeFilename(c.in), "mtreeFilename(%q)", c.in)
+	}
+}
+
+// TestMtreeFSNoKeywordInjection verifies that an entry name containing a space
+// cannot inject mtree(5) keywords. mtree lines are space-delimited
+// keyword=value pairs after the filename, so an unescaped space in
+// "usr ignore" would make mtree(8) read "ignore" as a value-less keyword that
+// suppresses verification of the whole subtree.
+func TestMtreeFSNoKeywordInjection(t *testing.T) {
+	var buf bytes.Buffer
+	fs, err := NewMtreeFS(&buf)
+	require.NoError(t, err)
+
+	require.NoError(t, fs.CreateDir(NodeDirectory{
+		Name:  "usr ignore",
+		Mode:  os.ModeDir | 0755,
+		MTime: time.Unix(0, 0),
+	}))
+
+	// Grab the line describing the directory (skip the "#mtree v1.0" header).
+	var line string
+	for _, l := range strings.Split(buf.String(), "\n") {
+		if strings.HasPrefix(l, "#") || l == "" {
+			continue
+		}
+		line = l
+		break
+	}
+	require.NotEmpty(t, line)
+
+	fields := strings.Split(line, " ")
+	assert.Equal(t, `usr\040ignore`, fields[0], "filename must be a single escaped field")
+	for _, f := range fields[1:] {
+		assert.NotEqual(t, "ignore", f, "injected keyword must not appear as its own field")
+	}
+}


### PR DESCRIPTION
## Problem

`mtreeFilename()` escaped backslash, `#`, control bytes (`c < 32`), and bytes `> 126`, but **not space (0x20)**. mtree(5) lines are space-delimited `keyword=value` pairs following the filename (joined via `strings.Join(attr, " ")`), so an untrusted catar entry name containing a space was emitted verbatim:

```
usr ignore type=dir mode=0755 ...
```

mtree(8) then parses `usr` as the filename and `ignore` as a value-less keyword that **suppresses verification of the entire subtree**. `optional` and `nochange` suppress detection similarly. The attack is reachable: `safeComponent()` explicitly treats names with spaces as valid, and `CreateSymlink` passes the attacker-controlled `target` through the same function — a second injection vector.

## Fix

Add space to the octal-escape set in `mtreeFilename()`, matching the escaped set used by libarchive and BSD mtree (non-printable, `\`, ` `, `\t`, `#`; tab and other control bytes were already covered by `c < 32`). Space becomes `\040`, which mtree(8) readers decode back correctly, so legitimate spaced filenames still round-trip. The doc comment is updated to document the space rule and the rationale.

## Tests

- `TestMtreeFilename` — table covering space → `\040`, `\`, `#`, tab, newline, DEL, and multi-byte UTF-8, plus an untouched plain name.
- `TestMtreeFSNoKeywordInjection` — drives `MtreeFS.CreateDir` with `Name: "usr ignore"` and asserts the filename is a single escaped field and no bare `ignore` keyword field appears.

Full suite (`go test ./...`) passes; binary builds.