### PR TITLE
Require --client-ca when --mutual-tls is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,8 +403,8 @@ Not all options apply to all commands.
 | `--store-file <file>` | Read store arguments from a JSON file; supports SIGHUP reload. Applies to `chunk-server` and `mount-index`. |
 | `--key <file>` | Key file in PEM format for HTTPS `chunk-server` and `index-server`. Requires `--cert`. |
 | `--cert <file>` | Certificate file in PEM format for HTTPS `chunk-server` and `index-server`. Requires `--key`. |
-| `--mutual-tls` | Require a valid client certificate. Applies to `chunk-server` and `index-server`. |
-| `--client-ca <file>` | Acceptable client certificate or CA for mutual TLS. |
+| `--mutual-tls` | Require a valid client certificate, verified against `--client-ca` (which is mandatory when this is set). Applies to `chunk-server` and `index-server`. |
+| `--client-ca <file>` | Acceptable client certificate or CA for mutual TLS. Required when `--mutual-tls` is set; otherwise client certs would be verified against the system trust store. |
 | `--authorization <value>` | Expected value of the Authorization header in client requests. |
 | `--log <file>` | Request log file, or `-` for STDOUT. Applies to `chunk-server` and `index-server`. |
 

--- a/cmd/desync/indexserver.go
+++ b/cmd/desync/indexserver.go
@@ -120,6 +120,12 @@ func runIndexServer(ctx context.Context, opt indexServerOptions, args []string) 
 func serve(ctx context.Context, opt cmdServerOptions, addresses ...string) error {
 	tlsConfig := &tls.Config{}
 	if opt.mutualTLS {
+		// Defense-in-depth: validate() already rejects this combination, but
+		// without an explicit client CA, crypto/tls falls back to the system
+		// trust store and would accept any publicly-trusted client cert.
+		if opt.clientCA == "" {
+			return errors.New("--mutual-tls requires --client-ca")
+		}
 		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
 	}
 	if opt.clientCA != "" {

--- a/cmd/desync/options.go
+++ b/cmd/desync/options.go
@@ -95,6 +95,9 @@ func (o cmdServerOptions) validate() error {
 			return errors.New("--client-ca requires --cert and --key (TLS must be enabled)")
 		}
 	}
+	if o.mutualTLS && o.clientCA == "" {
+		return errors.New("--mutual-tls requires --client-ca (otherwise any certificate trusted by the system CA pool would be accepted)")
+	}
 	if o.clientCA != "" && !o.mutualTLS {
 		return errors.New("--client-ca requires --mutual-tls (otherwise client certificates are not verified)")
 	}

--- a/cmd/desync/options_test.go
+++ b/cmd/desync/options_test.go
@@ -107,11 +107,11 @@ func TestServerOptionsValidate(t *testing.T) {
 	}{
 		{"no TLS, no mTLS", cmdServerOptions{}, ""},
 		{"TLS only", cmdServerOptions{cert: "c", key: "k"}, ""},
-		{"TLS with mutualTLS", cmdServerOptions{cert: "c", key: "k", mutualTLS: true}, ""},
 		{"TLS with mutualTLS and clientCA", cmdServerOptions{cert: "c", key: "k", mutualTLS: true, clientCA: "ca"}, ""},
 		{"key without cert", cmdServerOptions{key: "k"}, "--key and --cert"},
 		{"cert without key", cmdServerOptions{cert: "c"}, "--key and --cert"},
-		{"mutualTLS without TLS", cmdServerOptions{mutualTLS: true}, "--mutual-tls requires"},
+		{"mutualTLS without TLS", cmdServerOptions{mutualTLS: true}, "--mutual-tls requires --cert and --key"},
+		{"mutualTLS without clientCA", cmdServerOptions{cert: "c", key: "k", mutualTLS: true}, "--mutual-tls requires --client-ca"},
 		{"clientCA without TLS", cmdServerOptions{clientCA: "ca"}, "--client-ca requires --cert"},
 		{"clientCA without mutualTLS", cmdServerOptions{cert: "c", key: "k", clientCA: "ca"}, "--client-ca requires --mutual-tls"},
 	} {


### PR DESCRIPTION
## Problem

`cmdServerOptions.validate()` (`cmd/desync/options.go`) enforced that `--client-ca` requires `--mutual-tls`, but never the inverse. `--mutual-tls` without `--client-ca` passed validation silently.

In `serve()` (`cmd/desync/indexserver.go`), `--mutual-tls` sets `ClientAuth = tls.RequireAndVerifyClientCert`, but `tls.Config.ClientCAs` is only populated when `--client-ca` is given. With `ClientCAs == nil`, Go's `crypto/tls` falls back to the **system root CA pool** for client-certificate verification (`x509.Certificate.Verify` uses `systemRootsPool()` when `Roots` is nil).

Result: an operator running `chunk-server`/`index-server` with `--mutual-tls` but no `--client-ca` believes access is pinned to their internally-issued client certs, but the server actually accepts **any certificate chaining to a publicly-trusted CA** with the `clientAuth` EKU — silently bypassing the intended client authentication and granting read or read/write access to the chunk/index store.

There is no legitimate use for verifying client auth against public CAs (anyone can obtain such a cert), so requiring an explicit `--client-ca` breaks no valid workflow.

## Changes

- `cmd/desync/options.go`: `validate()` now returns an error when `--mutual-tls` is set without `--client-ca`, so mTLS always pins to an explicitly-configured trust anchor. The pre-existing "`--mutual-tls` requires `--cert` and `--key`" error still takes precedence when TLS is entirely off.
- `cmd/desync/indexserver.go`: defense-in-depth guard in `serve()` rejecting the same combination, in case `serve()` is ever reached without validation.
- `cmd/desync/options_test.go`: `TestServerOptionsValidate` updated — the previously-accepted `mutualTLS` without `clientCA` case now asserts the error; valid path (`mutualTLS` + `clientCA`) retained.
- `README.md`: clarified that `--client-ca` is mandatory when `--mutual-tls` is set.

## Testing

- `go build -o cmd/desync/ ./cmd/desync`
- `go test ./cmd/desync` passes, including `TestServerOptionsValidate`, `TestChunkServerMutualTLS`, and `TestChunkServerInsecureTLS`.