### PR TITLE
CI: least-privilege token, dedupe runs, release timeout, Node 24 actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,15 +12,16 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: '~> v2'

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -19,7 +19,7 @@ permissions:
 # branch. Group them so only one full matrix runs, and cancel runs that
 # are superseded by a newer commit on the same branch/PR.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -2,11 +2,13 @@
 name: Validate
 
 on:
+  # Post-merge validation only. Feature branches are validated by their
+  # pull_request run, so a branch push with an open PR no longer triggers
+  # a duplicate (previously cancelled) push run.
   push:
-    # Always run when there are new commits
     branches:
-      - '**'
-  # Always run when there are pull requests
+      - master
+  # All pull requests.
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -11,6 +11,17 @@ on:
     branches:
       - '**'
 
+# Least-privilege token; the validate workflow only needs to read the repo.
+permissions:
+  contents: read
+
+# A push and its pull_request both trigger this workflow on the same
+# branch. Group them so only one full matrix runs, and cancel runs that
+# are superseded by a newer commit on the same branch/PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Validate on ${{ matrix.os }}
@@ -22,13 +33,13 @@ jobs:
 
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - run: go test ./...
-      - run: go build ./cmd/desync
+      - run: go build -o cmd/desync/ ./cmd/desync
 
       - name: Race detector
         if: runner.os == 'Linux'


### PR DESCRIPTION
Applies the remaining CI improvements (items 5–8 from the earlier review). Workflow-only changes. **Validate CI green on all 3 OSes; item 6 verified live.**

### 5. Least-privilege token (`validate.yaml`)
Added `permissions: contents: read` (the workflow only reads the repo; it previously ran with the repo-default token scope). `release.yaml` already scopes its token to `contents: write`.

### 6. Stop running the matrix twice (`validate.yaml`)
A push to a branch with an open PR fired both `push` and `pull_request`, running the full 3-OS matrix twice.

Approach: scope the `push` trigger to `branches: [master]` and keep `pull_request: ['**']`, plus a `concurrency` group (`github.head_ref || github.ref_name`, `cancel-in-progress: true`) for cancelling superseded in-progress runs within an event stream.

This eliminates the duplicate at the source rather than relying on `cancel-in-progress` to tear down an already-started duplicate (which still spun up 3 jobs and left a cancelled run in the Actions tab). **Verified live:**
- feature-branch push with open PR → exactly **1** run (`pull_request`), no `push` run, no cancelled jobs
- merge to `master` → **1** run (`push`)

Tradeoff: a feature branch with no open PR gets no CI until a PR is opened (previously every branch push ran CI). Standard pattern; PR-driven CI is the intended coverage.

### 7. Release job timeout + build convention
- `release.yaml`: added `timeout-minutes: 30` to the release job (`validate` already had one; `release` had none).
- `validate.yaml`: `go build ./cmd/desync` → `go build -o cmd/desync/ ./cmd/desync` to match the documented build convention (output is git-ignored; harmless in CI).

### 8. Move off the deprecated Node 20 action runtime
All pinned actions ran on Node 20, which GitHub force-migrates to Node 24 on **2026-06-02** and removes on **2026-09-16**. Bumped to latest majors, all Node 24:
- `actions/checkout` v4 → **v6**
- `actions/setup-go` v5 → **v6** (`go-version-file` input unchanged)
- `goreleaser/goreleaser-action` v6 → **v7** (inputs unchanged; already targeting goreleaser v2)

### Coverage caveat
`release.yaml` only runs on tag pushes, so its changes (timeout + the checkout/setup-go/goreleaser bumps there) are **not exercised by this PR's CI** — they're first validated on the next tagged release. All `validate.yaml` changes are covered by this PR's run.
