### PR TITLE
Prevent SSH option/shell injection via store URLs

### DIFF
--- a/remotessh.go
+++ b/remotessh.go
@@ -88,8 +88,15 @@ func StartProtocol(u *url.URL) (*Protocol, error) {
 	if u.User != nil {
 		host = u.User.Username() + "@" + u.Host
 	}
+	// Reject destinations that ssh would parse as command-line options.
+	if err := validateSSHHost(host); err != nil {
+		return nil, err
+	}
 
-	c := exec.Command(sshCmd, host, fmt.Sprintf("%s pull - - - '%s'", remoteCmd, path))
+	// "--" terminates ssh's option parsing so the destination can't be read as a
+	// flag, and the path is shell-quoted so it can't break out of the remote
+	// command string.
+	c := exec.Command(sshCmd, "--", host, fmt.Sprintf("%s pull - - - %s", remoteCmd, shellQuote(path)))
 	c.Stderr = os.Stderr
 	r, err := c.StdoutPipe()
 	if err != nil {

--- a/sftp.go
+++ b/sftp.go
@@ -52,8 +52,13 @@ func newSFTPStoreBase(location *url.URL, opt StoreOptions) (*SFTPStoreBase, erro
 	if location.User != nil {
 		host = location.User.Username() + "@" + location.Host
 	}
+	// Reject destinations that ssh would parse as command-line options.
+	if err := validateSSHHost(host); err != nil {
+		return nil, err
+	}
 	ctx, cancel := context.WithCancel(context.Background())
-	c := exec.CommandContext(ctx, sshCmd, host, "-s", "sftp")
+	// "--" terminates option parsing so the destination can't be read as a flag.
+	c := exec.CommandContext(ctx, sshCmd, "-s", "--", host, "sftp")
 	c.Stderr = os.Stderr
 	r, err := c.StdoutPipe()
 	if err != nil {

--- a/sshcmd.go
+++ b/sshcmd.go
@@ -1,0 +1,29 @@
+package desync
+
+import (
+	"fmt"
+	"strings"
+)
+
+// validateSSHHost rejects an ssh destination that begins with a dash. Such a
+// value (built from the store URL's user and host) would otherwise be parsed by
+// ssh as a command-line option rather than a destination, allowing option
+// injection such as -oProxyCommand=... and arbitrary local command execution
+// (the same class of bug as Git CVE-2017-1000117 and Mercurial CVE-2017-1000116).
+// Callers must reject the destination before passing it to ssh; the "--"
+// argument added to the ssh invocation is a defense-in-depth measure that only
+// some ssh implementations honor.
+func validateSSHHost(host string) error {
+	if strings.HasPrefix(host, "-") {
+		return fmt.Errorf("invalid ssh destination %q: must not begin with '-'", host)
+	}
+	return nil
+}
+
+// shellQuote wraps s in single quotes for safe inclusion in a POSIX shell
+// command line, escaping any embedded single quotes. This prevents shell
+// injection when interpolating untrusted values (such as a store URL path) into
+// the remote command string passed to ssh.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/sshcmd_test.go
+++ b/sshcmd_test.go
@@ -1,0 +1,53 @@
+package desync
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateSSHHost(t *testing.T) {
+	valid := []string{
+		"example.com",
+		"user@example.com",
+		"user@example.com:2222",
+		"192.0.2.1",
+		"a-b.example.com", // dash allowed mid-string
+	}
+	for _, h := range valid {
+		assert.NoError(t, validateSSHHost(h), "%q should be accepted", h)
+	}
+
+	invalid := []string{
+		"-",
+		"-x",
+		"-oProxyCommand=touch${IFS}pwned",
+		"-oProxyCommand=id@example.com",
+	}
+	for _, h := range invalid {
+		assert.Error(t, validateSSHHost(h), "%q should be rejected", h)
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	// Each input must survive a round-trip through a POSIX shell unchanged,
+	// proving the quoting can't be broken out of.
+	inputs := []string{
+		"",
+		"/path/to/store/",
+		"plain",
+		"o'brien",
+		`a'; touch pwned; '`,
+		`'`,
+		`''`,
+		`back\slash`,
+		`$VAR ${IFS} "dq" |&;<>`,
+	}
+	for _, in := range inputs {
+		out, err := exec.Command("sh", "-c", "printf %s "+shellQuote(in)).Output()
+		require.NoError(t, err, "input %q", in)
+		assert.Equal(t, in, string(out), "input %q did not round-trip", in)
+	}
+}


### PR DESCRIPTION
## Problem

`SFTPStore` (`sftp.go`) and `RemoteSSH` (`remotessh.go`) build their ssh destination from the store URL (`user@host`) and pass it as the **first positional argument** to `ssh`. The destination is never validated or guarded with `--`.

- **Option injection** — a store URL whose host begins with `-` (e.g. `sftp://-oProxyCommand=touch${IFS}pwned/`) is parsed by `ssh` as a command-line option rather than a destination, leading to arbitrary local command execution as the desync process user. Same class as Git CVE-2017-1000117 and Mercurial CVE-2017-1000116. Store URLs come from CLI flags **and** from `--store-file` JSON config that `chunk-server`/`mount-index` re-read on `SIGHUP`, so a less-privileged writer of that file can trigger it.
- **Remote shell injection** — `remotessh.go` interpolated the URL path into the remote command string with only single-quote wrapping (`fmt.Sprintf("%s pull - - - '%s'", remoteCmd, path)`), so a `'` in the path breaks out and injects into the `sh -c` the remote runs.

Verified on OpenSSH 9.9p1: `ssh -oProxyCommand=id host` parses as an option, while `ssh -- -oProxyCommand=id host` treats it as a destination.

## Fix

Applied at the library boundary (`newSFTPStoreBase`, `StartProtocol`) so both the CLI and direct library users are protected; `sftpindex.go` shares `newSFTPStoreBase` and is covered automatically.

- `validateSSHHost` rejects any destination beginning with `-`. This is the portable guarantee — it also protects when `CASYNC_SSH_PATH` points at an ssh implementation that doesn't honor `--`.
- Pass `--` before the destination as defense in depth (`ssh -s -- <host> sftp`, `ssh -- <host> <cmd>`). Confirmed the reordered sftp invocation still invokes the subsystem.
- `shellQuote` POSIX-escapes the path before embedding it in the remote command string.

`CASYNC_REMOTE_PATH` is left interpolated unquoted on purpose: it is operator-controlled and quoting it would break legitimate `casync <args>` usage.

## Tests

New `sshcmd_test.go`:
- `TestValidateSSHHost` — rejects `-`, `-x`, `-oProxyCommand=...`; accepts `host`, `user@host`, `host:port`, mid-string dashes.
- `TestShellQuote` — round-trips adversarial inputs (`o'brien`, `a'; touch pwned; '`, `$VAR ${IFS} "dq" |&;<>`, etc.) through a real `sh -c` and asserts byte-for-byte equality.

`go test ./...` and `go build -o cmd/desync/ ./cmd/desync` pass.