### PR TITLE
Fix GCS not-found detection to unwrap ErrObjectNotExist (#358)

### DIFF
--- a/gcs.go
+++ b/gcs.go
@@ -105,7 +105,7 @@ func (s GCStore) GetChunk(id ChunkID) (*Chunk, error) {
 
 	rc, err := s.client.Object(name).NewReader(ctx)
 
-	if err == storage.ErrObjectNotExist {
+	if errors.Is(err, storage.ErrObjectNotExist) {
 		log.Warning("Unable to create reader for object in GCS bucket; the object may not exist, or the bucket may not exist, or you may not have permission to access it")
 		return nil, ChunkMissing{ID: id}
 	} else if err != nil {
@@ -116,7 +116,7 @@ func (s GCStore) GetChunk(id ChunkID) (*Chunk, error) {
 
 	b, err := io.ReadAll(rc)
 
-	if err == storage.ErrObjectNotExist {
+	if errors.Is(err, storage.ErrObjectNotExist) {
 		log.Warning("Unable to read from object in GCS bucket; the object may not exist, or the bucket may not exist, or you may not have permission to access it")
 		return nil, ChunkMissing{ID: id}
 	} else if err != nil {
@@ -184,7 +184,7 @@ func (s GCStore) HasChunk(id ChunkID) (bool, error) {
 
 	_, err := s.client.Object(name).Attrs(ctx)
 
-	if err == storage.ErrObjectNotExist {
+	if errors.Is(err, storage.ErrObjectNotExist) {
 		log.WithField("exists", false).Debug("Chunk does not exist in GCS bucket")
 		return false, nil
 	} else if err != nil {


### PR DESCRIPTION
## Problem

`desync make` fails when it encounters a chunk that doesn't yet exist in a Google Cloud Storage bucket, aborting with:

```
Error: storage: object doesn't exist: googleapi: Error 404: No such object
```

The missing object is expected — it's a new chunk awaiting upload — and should be treated as a cache miss, not a fatal error.

## Root cause

`gcs.go` detected "object not found" using direct equality (`err == storage.ErrObjectNotExist`) in three places (`GetChunk` after `NewReader` and after `io.ReadAll`, and `HasChunk` after `Attrs`).

The dependency bump in a452c77 (`cloud.google.com/go/storage` v1.30.1 → v1.60.0) changed the library to *wrap* the sentinel rather than return it bare. `formatObjectErr` now does:

```go
return fmt.Errorf("%w: %w", ErrObjectNotExist, err)
```

so the returned error is no longer `== storage.ErrObjectNotExist`. Both `Attrs` and `NewReader` route through `formatObjectErr`, producing exactly the `"storage: object doesn't exist: googleapi: Error 404: No such object"` message above.

In `ChunkStorage.StoreChunk`, the dedup check `if hasChunk, err := s.ws.HasChunk(...); err != nil || hasChunk` then propagates this misclassified error and aborts the whole `make`. The same flaw also turns legitimate read misses in `GetChunk` into hard errors instead of `ChunkMissing`, breaking cache/failover self-repair. (S3 is unaffected; it uses status-code-based detection.)

## Fix

Use `errors.Is`, which unwraps the chain, in all three locations. No import change is needed — `github.com/pkg/errors` (already imported) passes `Is` straight through to the stdlib.

Fixes #358