### PR TITLE
Fix panics when extracting or reading an index of a zero-length file

### DIFF
--- a/assemble.go
+++ b/assemble.go
@@ -137,6 +137,12 @@ func AssembleFile(ctx context.Context, name string, idx Index, s Store, seeds []
 		}
 	}
 
+	// An index of a zero-length file has no chunks. The file has been created
+	// (and truncated) above, so there is nothing left to do.
+	if len(idx.Chunks) == 0 {
+		return stats, nil
+	}
+
 	// Determine the blocksize of the target file which is required for reflinking
 	blocksize := blocksizeOfFile(name)
 

--- a/assemble_test.go
+++ b/assemble_test.go
@@ -364,6 +364,34 @@ func readCaibxFile(t *testing.T, indexLocation string) (idx Index) {
 	return idx
 }
 
+// An index of a zero-length file has no chunks. Extracting it should produce
+// an empty output file rather than panic.
+func TestExtractEmptyIndex(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "out")
+
+	// Write some data into the output file to confirm it gets truncated
+	require.NoError(t, os.WriteFile(out, []byte("old content"), 0644))
+
+	index := Index{
+		Index: FormatIndex{
+			FeatureFlags: CaFormatSHA512256,
+			ChunkSizeMin: ChunkSizeMinDefault,
+			ChunkSizeAvg: ChunkSizeAvgDefault,
+			ChunkSizeMax: ChunkSizeMaxDefault,
+		},
+	}
+	store, err := NewLocalStore(t.TempDir(), StoreOptions{})
+	require.NoError(t, err)
+
+	_, err = AssembleFile(context.Background(), out, index, store, nil,
+		AssembleOptions{10, InvalidSeedActionBailOut})
+	require.NoError(t, err)
+
+	b, err := os.ReadFile(out)
+	require.NoError(t, err)
+	require.Empty(t, b)
+}
+
 func TestExtractWithNonStaticSeeds(t *testing.T) {
 	n := 10
 	outDir := t.TempDir()

--- a/readseeker.go
+++ b/readseeker.go
@@ -25,13 +25,17 @@ type IndexPos struct {
 
 // NewIndexReadSeeker initializes a ReadSeeker for indexes.
 func NewIndexReadSeeker(i Index, s Store) *IndexPos {
-	return &IndexPos{
-		Store:      s,
-		Index:      i,
-		Length:     i.Length(),
-		curChunkID: i.Chunks[0].ID,
-		nullChunk:  NewNullChunk(i.Index.ChunkSizeMax),
+	ip := &IndexPos{
+		Store:     s,
+		Index:     i,
+		Length:    i.Length(),
+		nullChunk: NewNullChunk(i.Index.ChunkSizeMax),
 	}
+	// An index of a zero-length file has no chunks
+	if len(i.Chunks) > 0 {
+		ip.curChunkID = i.Chunks[0].ID
+	}
+	return ip
 }
 
 /* findOffset - Actually update our IndexPos for a new Index
@@ -50,6 +54,13 @@ func (ip *IndexPos) findOffset(newPos int64) (int64, error) {
 	// Degenerate case: Seeking to existing position
 	delta = newPos - ip.pos
 	if delta == 0 {
+		return ip.pos, nil
+	}
+
+	// Degenerate case: An empty index has no chunk to look up. Just track
+	// the position, Read() returns EOF for anything at or past the end.
+	if len(ip.Index.Chunks) == 0 {
+		ip.pos = newPos
 		return ip.pos, nil
 	}
 
@@ -143,7 +154,7 @@ func (ip *IndexPos) Seek(offset int64, whence int) (int64, error) {
 func (ip *IndexPos) Read(p []byte) (n int, err error) {
 	var totalCopiedBytes int
 	remainingBytes := p[:]
-	if ip.pos == ip.Length { // if initially called when already at the end, return EOF
+	if ip.pos >= ip.Length { // if initially called when already at or past the end, return EOF
 		return 0, io.EOF
 	}
 	for len(remainingBytes) > 0 {

--- a/readseeker_test.go
+++ b/readseeker_test.go
@@ -120,3 +120,32 @@ func TestIndexReadSeekerValid(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, tail, got)
 }
+
+// An index of a zero-length file has no chunks. Reading and seeking should
+// behave like an empty file rather than panic.
+func TestIndexReadSeekerEmptyIndex(t *testing.T) {
+	idx := Index{
+		Index: FormatIndex{ChunkSizeMax: ChunkSizeMaxDefault},
+	}
+	store := &TestStore{}
+
+	r := NewIndexReadSeeker(idx, store)
+
+	got, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+
+	// Seeking to the start (and end, they're the same) is allowed
+	pos, err := r.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), pos)
+
+	pos, err = r.Seek(0, io.SeekEnd)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), pos)
+
+	buf := make([]byte, 16)
+	n, err := r.Read(buf)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, io.EOF, err)
+}


### PR DESCRIPTION
An index created from an empty file contains no chunks (`desync make` produces one without complaint), but reading such an index back panicked:

- `desync extract` crashed with `slice bounds out of range [:1] with capacity 0` — `SeedSequencer.Next()` always emits a segment `{first: 0, last: 0}` even for an empty chunk list, and the assemble worker then slices `Chunks[0:1]`.
- `desync cat` and `desync mount-index` crashed with `index out of range [0]` in `NewIndexReadSeeker`, which reads `Chunks[0].ID` unconditionally.

Reproducer:

```
$ : > empty.bin
$ desync make -s ./store empty.caibx empty.bin
$ desync extract -s ./store empty.caibx out.bin
panic: runtime error: slice bounds out of range [:1] with capacity 0
$ desync cat -s ./store empty.caibx
panic: runtime error: index out of range [0] with length 0
```

Fixes:

- `AssembleFile()` returns right after creating and truncating the output file when the index has no chunks.
- `NewIndexReadSeeker()` tolerates an empty chunk list; `findOffset()` just tracks the position for an empty index; `Read()` returns EOF at or past the end.

Both paths verified with the reproducer above and covered by new tests.