### PR TITLE
Fix LocalStore.GetChunk dropping read errors

### DIFF
--- a/local.go
+++ b/local.go
@@ -48,8 +48,11 @@ func NewLocalStore(dir string, opt StoreOptions) (LocalStore, error) {
 func (s LocalStore) GetChunk(id ChunkID) (*Chunk, error) {
 	_, p := s.nameFromID(id)
 	b, err := os.ReadFile(p)
-	if os.IsNotExist(err) {
-		return nil, ChunkMissing{id}
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ChunkMissing{id}
+		}
+		return nil, err
 	}
 	return NewChunkFromStorage(id, b, s.converters, s.Opt.SkipVerify)
 }

--- a/local_test.go
+++ b/local_test.go
@@ -147,3 +147,24 @@ func TestLocalStoreErrorHandling(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// A read failure that isn't "file does not exist" must be reported to the
+// caller, not turned into a misleading ChunkInvalid or, with SkipVerify, a
+// chunk holding partial data.
+func TestLocalStoreGetChunkReadError(t *testing.T) {
+	store := t.TempDir()
+
+	s, err := NewLocalStore(store, StoreOptions{SkipVerify: true})
+	require.NoError(t, err)
+
+	// Put a directory where the chunk file is expected, making os.ReadFile
+	// fail with an error other than IsNotExist on all platforms
+	id := NewChunk([]byte("some data")).ID()
+	_, p := s.nameFromID(id)
+	require.NoError(t, os.MkdirAll(p, 0755))
+
+	_, err = s.GetChunk(id)
+	require.Error(t, err)
+	require.NotErrorAs(t, err, &ChunkMissing{})
+	require.NotErrorAs(t, err, &ChunkInvalid{})
+}


### PR DESCRIPTION
`LocalStore.GetChunk()` only checked the error from `os.ReadFile` with `os.IsNotExist()`. Any other read failure — permission problems, I/O errors, truncated reads — was silently ignored and the nil or partial buffer handed to `NewChunkFromStorage()`:

- With verification enabled, the caller saw a misleading `ChunkInvalid` instead of the real error (and a `RepairableCache` would then treat it as missing and re-fetch, hiding e.g. a permission problem indefinitely).
- With `SkipVerify` set (`--skip-verify`, or the `pull` command), the store returned a chunk holding partial data with **no error at all**.

Return the underlying error instead. The new test uses a directory in place of the chunk file to trigger a non-`IsNotExist` read error on all platforms; it fails against the previous code (returned a bogus chunk with nil error under `SkipVerify`).