### PR TITLE
Report the real status code when HTTP retries are exhausted

### DIFF
--- a/remotehttp.go
+++ b/remotehttp.go
@@ -160,7 +160,9 @@ retry:
 	if (err != nil) || (statusCode >= 500 && statusCode < 600) {
 		if attempt >= r.opt.ErrorRetry {
 			log.WithField("attempt", attempt).Debug("failed, giving up")
-			return 0, nil, err
+			// Return the last response as-is. In the server-error case err is
+			// nil and the callers report the actual status code and body.
+			return statusCode, responseBody, err
 		} else {
 			log.WithField("attempt", attempt).WithField("delay", attempt).Debug("waiting, then retrying")
 			time.Sleep(time.Duration(attempt) * r.opt.ErrorRetryBaseInterval)

--- a/remotehttp_test.go
+++ b/remotehttp_test.go
@@ -314,3 +314,35 @@ func TestPutChunk(t *testing.T) {
 		})
 	}
 }
+
+// When retries are exhausted on a server error, the returned error must
+// reflect the actual status code and response body, not a synthetic status
+// code 0 or an empty message.
+func TestRetryExhaustedError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		io.WriteString(w, "service down for maintenance")
+	}))
+	defer ts.Close()
+	u, _ := url.Parse(ts.URL)
+
+	s, err := NewRemoteHTTPStore(u, StoreOptions{ErrorRetry: 2, ErrorRetryBaseInterval: time.Microsecond, Uncompressed: true})
+	require.NoError(t, err)
+
+	// GetChunk reports the real status code
+	_, err = s.GetChunk(ChunkID{0, 0, 0, 1})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "503")
+
+	// HasChunk reports the real status code
+	_, err = s.HasChunk(ChunkID{0, 0, 0, 1})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "503")
+
+	// StoreChunk reports the response body
+	chunk, err := NewChunkWithID(ChunkID{0, 0, 0, 1}, []byte("data"), true)
+	require.NoError(t, err)
+	err = s.StoreChunk(chunk)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "service down for maintenance")
+}


### PR DESCRIPTION
When a request kept failing with a 5xx response until `ErrorRetry` was exhausted, `IssueRetryableHttpRequest()` returned `(0, nil, err)` — but `err` is nil in the 5xx case since the request itself succeeded at the HTTP level. Callers then saw status code 0 with no error detail:

- `GetObject()` reported `unexpected status code 0` instead of the real 503/502.
- `StoreObject()` returned `errors.New(string(nil))` — an error with an empty message.

Return the last response's status code and body instead, so callers report what actually happened. The transport-error path is unchanged (status code 0 and a non-nil error, as before).

The new test asserts that GetChunk/HasChunk errors mention the real status code and that StoreChunk errors carry the response body; it fails against the previous code.