### PR TITLE
Don't retry S3 requests for missing chunks

### DIFF
--- a/s3.go
+++ b/s3.go
@@ -105,21 +105,23 @@ retry:
 
 	b, err := io.ReadAll(obj)
 	if err != nil {
+		// Don't retry if the chunk or the bucket doesn't exist, those aren't
+		// transient errors. A missing chunk in particular is a normal
+		// occurrence when this store is behind a router or cache.
+		if e, ok := err.(minio.ErrorResponse); ok {
+			switch e.Code {
+			case "NoSuchBucket":
+				return nil, fmt.Errorf("bucket '%s' does not exist", s.bucket)
+			case "NoSuchKey":
+				return nil, ChunkMissing{ID: id}
+			}
+		}
 		if attempt <= s.opt.ErrorRetry {
 			time.Sleep(time.Duration(attempt) * s.opt.ErrorRetryBaseInterval)
 			goto retry
 		}
-		if e, ok := err.(minio.ErrorResponse); ok {
-			switch e.Code {
-			case "NoSuchBucket":
-				err = fmt.Errorf("bucket '%s' does not exist", s.bucket)
-			case "NoSuchKey":
-				err = ChunkMissing{ID: id}
-			default: // Without ListBucket perms in AWS, we get Permission Denied for a missing chunk, not 404
-				err = errors.Wrap(err, fmt.Sprintf("chunk %s could not be retrieved from s3 store", id))
-			}
-		}
-		return nil, err
+		// Without ListBucket perms in AWS, we get Permission Denied for a missing chunk, not 404
+		return nil, errors.Wrap(err, fmt.Sprintf("chunk %s could not be retrieved from s3 store", id))
 	}
 	return NewChunkFromStorage(id, b, s.converters, s.opt.SkipVerify)
 }

--- a/s3_test.go
+++ b/s3_test.go
@@ -8,12 +8,15 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	minio "github.com/minio/minio-go/v6"
 	"github.com/minio/minio-go/v6/pkg/credentials"
@@ -282,4 +285,32 @@ func TestS3StoreGetChunk(t *testing.T) {
 
 		require.NoError(t, group.Wait())
 	})
+}
+
+// A missing chunk is not a transient error and is a normal occurrence when
+// the store sits behind a router or cache. GetChunk must return ChunkMissing
+// right away instead of going through the ErrorRetry sleep/retry loop.
+func TestS3StoreGetMissingChunk(t *testing.T) {
+	chunkId, err := ChunkIDFromString("dda036db05bc2b99b6b9303d28496000c34b246457ae4bbf00fe625b5cabd7cd")
+	require.NoError(t, err)
+	provider := MockCredProvider{}
+
+	var requests int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+	u, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+
+	endpoint := url.URL{Scheme: "s3+http", Host: u.Host, Path: "/doomsdaydevices/blob1.store/"}
+	store, err := NewS3Store(&endpoint, credentials.New(&provider), "vertucon-central",
+		StoreOptions{ErrorRetry: 3, ErrorRetryBaseInterval: time.Millisecond}, minio.BucketLookupAuto)
+	require.NoError(t, err)
+
+	_, err = store.GetChunk(chunkId)
+	var missing ChunkMissing
+	require.ErrorAs(t, err, &missing)
+	require.EqualValues(t, 1, atomic.LoadInt32(&requests), "missing chunk should not be retried")
 }


### PR DESCRIPTION
A `NoSuchKey` error from S3 went through the full `ErrorRetry` sleep/retry loop before being mapped to `ChunkMissing`. A missing chunk isn't a transient error though, and hitting one is a normal occurrence when the store sits behind a `StoreRouter` or `Cache` — every miss on the first store paid the entire retry delay (e.g. 3 retries with backoff) for nothing.

This moves the `NoSuchKey`/`NoSuchBucket` detection ahead of the retry decision so both return immediately. Other errors — including `AccessDenied`, which AWS returns for missing chunks when `ListBucket` permission isn't granted — retry exactly as before.

One side effect: non-`ErrorResponse` errors that exhaust retries are now wrapped with the chunk ID like the `ErrorResponse` default case already was, instead of being returned bare. `errors.As`/`errors.Is` still unwrap them (the existing `fail` test relies on this and passes).

The new test asserts a missing chunk returns `ChunkMissing` after exactly one request with `ErrorRetry: 3` configured; it fails against the previous code (4 requests).