### PR TITLE
Minor cleanups from a staticcheck pass

### DIFF
--- a/assemble_test.go
+++ b/assemble_test.go
@@ -382,6 +382,7 @@ func TestExtractWithNonStaticSeeds(t *testing.T) {
 	var seeds []Seed
 	srcIndex := readCaibxFile(t, "testdata/blob2_corrupted.caibx")
 	seed, err := NewIndexSeed(out, "testdata/blob2_corrupted", srcIndex)
+	require.NoError(t, err)
 	seeds = append(seeds, seed)
 
 	// Test that the MockValidate works as expected

--- a/cmd/desync/options_test.go
+++ b/cmd/desync/options_test.go
@@ -85,6 +85,7 @@ func TestErrorRetryOptions(t *testing.T) {
 			require.NoError(t, err)
 
 			configOptions, err := cfg.GetStoreOptionsFor("/store/20230901")
+			require.NoError(t, err)
 			opt := cmdOpt.MergedWith(configOptions)
 			require.Equal(t, test.errorRetryStoreHit, opt.ErrorRetry)
 			require.Equal(t, test.baseIntervalStoreHit, opt.ErrorRetryBaseInterval)
@@ -178,6 +179,7 @@ func TestStringOptions(t *testing.T) {
 			require.NoError(t, err)
 
 			configOptions, err := cfg.GetStoreOptionsFor("/store/20230901")
+			require.NoError(t, err)
 			opt := cmdOpt.MergedWith(configOptions)
 			require.Equal(t, test.clientCertStoreHit, opt.ClientCert)
 			require.Equal(t, test.clientKeyStoreHit, opt.ClientKey)

--- a/cmd/desync/store.go
+++ b/cmd/desync/store.go
@@ -99,7 +99,7 @@ func WritableStore(location string, cmdOpt cmdStoreOptions) (desync.WriteStore, 
 func storeFromLocation(location string, cmdOpt cmdStoreOptions) (desync.Store, error) {
 	loc, err := url.Parse(location)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to parse store location %s : %s", location, err)
+		return nil, fmt.Errorf("unable to parse store location %s : %s", location, err)
 	}
 
 	// Get any store options from the config if present and overwrite with settings from
@@ -206,7 +206,7 @@ func writableIndexStore(location string, cmdOpt cmdStoreOptions) (desync.IndexWr
 func indexStoreFromLocation(location string, cmdOpt cmdStoreOptions) (desync.IndexStore, string, error) {
 	loc, err := url.Parse(location)
 	if err != nil {
-		return nil, "", fmt.Errorf("Unable to parse store location %s : %s", location, err)
+		return nil, "", fmt.Errorf("unable to parse store location %s : %s", location, err)
 	}
 
 	indexName := path.Base(loc.Path)

--- a/dedupqueue.go
+++ b/dedupqueue.go
@@ -13,7 +13,6 @@ var _ Store = &DedupQueue{}
 // upstream store. Implements the Store interface.
 type DedupQueue struct {
 	store         Store
-	mu            sync.Mutex
 	getChunkQueue *queue
 	hasChunkQueue *queue
 }

--- a/fileseed.go
+++ b/fileseed.go
@@ -135,10 +135,9 @@ func (s *FileSeed) maxMatchFrom(chunks []IndexChunk, p int, limit int) []IndexCh
 }
 
 type fileSeedSegment struct {
-	file           string
-	chunks         []IndexChunk
-	canReflink     bool
-	needValidation bool
+	file       string
+	chunks     []IndexChunk
+	canReflink bool
 }
 
 func newFileSeedSegment(file string, chunks []IndexChunk, canReflink bool) *fileSeedSegment {

--- a/sftp.go
+++ b/sftp.go
@@ -185,7 +185,10 @@ func (s *SFTPStore) RemoveChunk(id ChunkID) error {
 	defer func() { s.pool <- c }()
 	name := c.nameFromID(id)
 	if _, err := c.client.Stat(name); err != nil {
-		return ChunkMissing{id}
+		if os.IsNotExist(err) {
+			return ChunkMissing{id}
+		}
+		return err
 	}
 	return c.client.Remove(name)
 }

--- a/storerouter.go
+++ b/storerouter.go
@@ -16,9 +16,7 @@ type StoreRouter struct {
 // NewStoreRouter returns an initialized router
 func NewStoreRouter(stores ...Store) StoreRouter {
 	var l []Store
-	for _, s := range stores {
-		l = append(l, s)
-	}
+	l = append(l, stores...)
 	return StoreRouter{l}
 }
 


### PR DESCRIPTION
A collection of small fixes surfaced by staticcheck and review; `staticcheck ./...` is clean after this.

- **Dropped test errors checked**: `assemble_test.go` ignored the error from `NewIndexSeed()`, and `cmd/desync/options_test.go` ignored the error from the first `GetStoreOptionsFor()` call in two tests (SA4006). These could have masked failures.
- **`SFTPStore.RemoveChunk` error mapping**: any `Stat` failure — including connection or permission errors — was reported as `ChunkMissing`. Only map actual not-found errors; return everything else as-is. This matters for `verify -repair` against an SFTP store, where a dropped connection previously looked like a missing chunk.
- **Dead fields removed**: `DedupQueue.mu` (the real locking lives in the inner `queue` type) and `fileSeedSegment.needValidation` (U1000).
- **Style**: replace an append loop with `append(l, stores...)` (S1011), lowercase two error strings (ST1005).