### PR TITLE
Skip destination read-back for null segments during assembly

### DIFF
--- a/assemble.go
+++ b/assemble.go
@@ -188,6 +188,17 @@ func AssembleFile(ctx context.Context, name string, idx Index, s Store, seeds []
 						return err
 					}
 
+					// Null segments (identified by an empty filename, like in
+					// Plan.Validate) skip the read-back validation below: they write
+					// deterministic zeros with no external source that could change,
+					// and reading back and hashing large null sections is expensive.
+					if job.source.FileName() == "" {
+						stats.addBytesCopied(copied)
+						stats.addBytesCloned(cloned)
+						ss.add(job.segment)
+						continue
+					}
+
 					// Validate that the written chunks are exactly what we were expecting.
 					// Because the seed might point to a RW location, if the data changed
 					// while we were extracting an index, we might end up writing to the

--- a/assemble_test.go
+++ b/assemble_test.go
@@ -346,6 +346,50 @@ func TestSelfSeedInPlace(t *testing.T) {
 
 }
 
+// Null segments skip the destination read-back after writing since they have
+// no external source that could change during extraction. Assemble a null-heavy
+// file over an existing file full of non-zero data to confirm the null sections
+// are still written out correctly.
+func TestExtractNullsOverExistingFile(t *testing.T) {
+	data := make([]byte, 4*ChunkSizeMaxDefault)
+	rand.Read(data)
+	null := make([]byte, 4*ChunkSizeMaxDefault)
+	b := join(null, data, null)
+
+	tmp := t.TempDir()
+	in := filepath.Join(tmp, "in")
+	require.NoError(t, os.WriteFile(in, b, 0644))
+	inSum := md5.Sum(b)
+
+	index, _, err := IndexFromFile(
+		context.Background(),
+		in,
+		10,
+		ChunkSizeMinDefault, ChunkSizeAvgDefault, ChunkSizeMaxDefault,
+		NewProgressBar(""),
+	)
+	require.NoError(t, err)
+
+	s, err := NewLocalStore(t.TempDir(), StoreOptions{})
+	require.NoError(t, err)
+	require.NoError(t, ChopFile(context.Background(), in, index.Chunks, s, 10, NewProgressBar("")))
+
+	// Pre-populate the output file with non-zero data so the null sections
+	// actually have to be written, not just skipped over in a blank file
+	garbage := make([]byte, len(b))
+	rand.Read(garbage)
+	out := filepath.Join(tmp, "out")
+	require.NoError(t, os.WriteFile(out, garbage, 0644))
+
+	_, err = AssembleFile(context.Background(), out, index, s, nil,
+		AssembleOptions{10, InvalidSeedActionBailOut})
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(out)
+	require.NoError(t, err)
+	require.Equal(t, inSum, md5.Sum(got))
+}
+
 func join(slices ...[]byte) []byte {
 	var out []byte
 	for _, b := range slices {


### PR DESCRIPTION
## Problem

After writing a seed segment, the `AssembleFile` workers read every chunk of the segment back from the destination and hash it, to catch seeds whose content changed while the extraction was running. This read-back also runs for null segments, where the rationale doesn't apply: a `nullChunkSection` writes deterministic zeros (or clones from desync's own temporary block file), so there is no external file that can change underneath the extraction. `Plan.Validate` already treats null segments as always-valid for the same reason.

For sparse files such as VM images, this read-back is essentially the entire cost of assembly: the null writes themselves are nearly free (skipped entirely on blank files, or reflinked), while reading back and SHA512/256-hashing the zeroed ranges runs at only ~500 MB/s per core.

## Change

Skip the post-write read-back for null segments, identified by an empty `FileName()` — the same convention `isFileSeed()` uses in the sequencer. Read-back still runs for all file seed segments.

Assembling a 1 GiB image that is ~97% zeros (chunked at default sizes, local store, `N: 10`) went from **1.5 s to under 0.1 s**, with the output verified byte-identical.

Also adds a test that assembles a null-heavy index over an existing file full of random data, confirming null sections are still written out correctly without the read-back.