### PR TITLE
Fix data race on pChunker.next in the parallel chunker

### DIFF
--- a/make.go
+++ b/make.go
@@ -117,7 +117,7 @@ func IndexFromFile(ctx context.Context,
 
 	// Link the workers, each one gets a pointer to the next, the last one gets nil
 	for i := 1; i < n; i++ {
-		worker[i-1].next = worker[i]
+		worker[i-1].next.Store(worker[i])
 	}
 
 	// Start the workers
@@ -176,10 +176,15 @@ type pChunker struct {
 	// the absolute position of every boundary that is returned
 	offset uint64
 
-	once  sync.Once
-	done  chan struct{}
-	err   error
-	next  *pChunker
+	once sync.Once
+	done chan struct{}
+	err  error
+
+	// next worker in the chain. Written by this worker when skipping dead
+	// neighbors and read by the previous worker, which may happen concurrently
+	// since the main routine can stop workers mid-iteration.
+	next atomic.Pointer[pChunker]
+
 	eof   bool
 	sync  IndexChunk
 	stats *ChunkingStats
@@ -223,8 +228,9 @@ func (c *pChunker) start(ctx context.Context) {
 
 		// Check if the next worker already has this chunk, at which point we stop
 		// here and let the next continue
-		if c.next != nil {
-			inSync, zeroes := c.next.syncWith(chunk)
+		next := c.next.Load()
+		if next != nil {
+			inSync, zeroes := next.syncWith(chunk)
 			if inSync {
 				return
 			}
@@ -245,8 +251,8 @@ func (c *pChunker) start(ctx context.Context) {
 
 		// If the next worker has stopped and has no more chunks in its bucket,
 		// we want to skip that and try to sync with the one after
-		if c.next != nil && !c.next.active() && len(c.next.results) == 0 {
-			c.next = c.next.next
+		if next != nil && !next.active() && len(next.results) == 0 {
+			c.next.Store(next.next.Load())
 		}
 	}
 }


### PR DESCRIPTION
Fixes the data race that failed [this CI run](https://github.com/folbricht/desync/actions/runs/28925682678/job/85812625382) on #369. The race is in the parallel chunker and pre-dates that PR; it reproduces on master with:

```
go test -race -run TestExtractCommand -count=10 ./cmd/desync
```

## Race

Each chunk worker holds a pointer to the next worker in the chain and skips over stopped neighbors with `c.next = c.next.next` (make.go:249). A worker's `next` field is therefore written by the worker itself and read by its predecessor (the `c.next.next` expression reaches into the neighbor's struct).

The predecessor only reads the field after observing the neighbor's `done` channel closed, and when the neighbor closes `done` itself on return, that close provides the necessary happens-before edge. But `IndexFromFile`'s main routine also closes all workers' `done` channels as soon as the first worker reaches EOF or errors — the normal completion path — and a worker only checks `done` at the top of its loop. The predecessor can then observe a still-running neighbor as inactive and read its `next` pointer while the neighbor concurrently updates it.

The practical impact is low (the value read is a valid pointer either way and the workers are about to exit), but it's a real race under the Go memory model and makes `-race` CI runs flaky.

## Fix

Make the field an `atomic.Pointer[pChunker]`, loaded once per iteration. The reproducer above failed reliably before this change and passes 20 consecutive runs after; the full `go test -race ./...` suite passes as well.