### PR TITLE
Add optional chunk encryption to stores

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ Stores are composed for routing, caching, and failover:
 
 **Chunking:** `Chunker` (`chunker.go`) uses a rolling hash (SipHash, 48-byte window) for content-defined chunking with configurable min/avg/max sizes (default 16KB/64KB/256KB).
 
-**Converter pipeline** (`coverter.go`): Layered data transformations applied in order for writes, reverse for reads. Currently only compression (zstd via `Compressor`), but designed for adding encryption.
+**Converter pipeline** (`converter.go`): Layered data transformations applied in order for writes, reverse for reads: compression (zstd via `Compressor`) and optional encryption (`encrypt.go`, XChaCha20-Poly1305 or AES-256-GCM). Converter stacks determine the chunk file extension via `storageExtension()`.
 
 **Assembly:** `AssembleFile()` (`assemble.go`) reconstructs files from an index and chunk stores, supporting self-seeding and file seeds for efficient cloning with reflink support (Btrfs/XFS).
 

--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ Not all options apply to all commands.
 | `DESYNC_PROGRESSBAR_ENABLED` | Enables the progress bar if set to any non-empty value. By default, the progress bar is only shown when STDERR is a terminal. |
 | `DESYNC_ENABLE_PARSABLE_PROGRESS` | Prints operation name, completion percentage, and estimated remaining time to STDERR. Similar to the default progress bar but without the visual bar. |
 | `DESYNC_HTTP_AUTH` | Sets the expected `Authorization` header value from clients when using `chunk-server` or `index-server`. Needs the full string including type and encoding, e.g. `"Basic dXNlcjpwYXNzd29yZAo="`. Command-line values take precedence. |
-| `DESYNC_ENCRYPTION_KEY` | Hex-encoded 256-bit chunk encryption key. Used for stores that have `encryption` enabled but no `encryption-key` configured, and by `chunk-server` when `--encryption-key` is not given. |
+| `DESYNC_ENCRYPTION_KEY` | Hex-encoded 256-bit chunk encryption key. Used for stores that have `encryption` enabled but no `encryption-key` configured, and by `chunk-server` when encryption is enabled with `--encryption` but no `--encryption-key` is given. The variable alone never enables encryption. |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ desync is a Go library and CLI tool that re-implements [casync](https://github.c
 - **Built-in servers** — HTTP(S) chunk server and index server with proxy support
 - **FUSE mounting** — mount blob indexes as files
 - **Tar interoperability** — create/extract catar from standard tar streams
+- **Chunk encryption** — optional store encryption with XChaCha20-Poly1305 or AES-256-GCM
 - **Cross-platform** — Linux, macOS, Windows (subset), BSD
 
 ## Table of Contents
@@ -35,6 +36,7 @@ desync is a Go library and CLI tool that re-implements [casync](https://github.c
   - [Failover Groups](#failover-groups)
   - [S3 Store URLs](#s3-store-urls)
   - [Compressed vs Uncompressed](#compressed-vs-uncompressed)
+  - [Chunk Encryption](#chunk-encryption)
   - [Remote Indexes](#remote-indexes)
 - [CLI Reference](#cli-reference)
   - [Commands](#commands)
@@ -276,6 +278,37 @@ Compressed and uncompressed chunks can live in the same store and don't interfer
 
 </details>
 
+<details>
+<summary><h3>Chunk Encryption</h3></summary>
+
+Chunks can be encrypted with a symmetric algorithm on a per-store basis. To use encryption, it has to be enabled in the [configuration](#configuration) file by setting `encryption` to `true` and providing a 256-bit encryption key. The key is expected hex-encoded and should be randomly generated, for example with:
+
+```text
+openssl rand -hex 32
+```
+
+A single instance of desync can use multiple stores at the same time, each with a different (or the same) encryption algorithm and key. Encrypted chunks are stored with file extensions containing the algorithm and a key identifier (the leading 4 bytes of the SHA256 hash of the key). If the key for a store is changed, all existing chunks in it will become "invisible" since the extension no longer matches. To change the key, chunks have to be re-encrypted with the new key, ideally into a new store. Create a new store, then either re-chunk the data, or use `desync cache -c <new-store> -s <old-store> <index>` to decrypt the chunks from the old store and re-encrypt them with the new key in the new store.
+
+Encryption nonces are generated randomly per chunk which can weaken encryption in some modes when used on very large chunk stores, see notes below.
+
+| ID | Algorithm | Key | Nonce/IV | Notes |
+|:---:|:---:|:---:|:---:|:---:|
+| `xchacha20-poly1305` | XChaCha20-Poly1305 (AEAD) | 256bit | 192bit | Default |
+| `aes-256-gcm` | AES 256bit Galois Counter Mode (AEAD) | 256bit | 96bit | Don't use for large chunk stores (>2<sup>32</sup> chunks) |
+
+Chunk extensions in stores are chosen based on compression or encryption settings as follows:
+
+| Compressed | Encrypted | Extension | Example |
+|:---:|:---:|:---:|:---:|
+| no | no | n/a | `fbef/fbef1a00ced..9280ce78` |
+| yes | no | `.cacnk` | `fbef/fbef1a00ced..9280ce78.cacnk` |
+| no | yes | `.<algorithm>-<keyID>` | `fbef/fbef1a00ced..9280ce78.aes-256-gcm-635af003` |
+| yes | yes | `.cacnk.<algorithm>-<keyID>` | `fbef/fbef1a00ced..9280ce78.cacnk.aes-256-gcm-635af003` |
+
+Note that encryption only protects the chunk data itself. Chunk file names, which are the content hashes of the plain data, remain visible to anyone with access to the store. An observer that already knows the plain content of a chunk can therefore confirm its presence in the store.
+
+</details>
+
 ### Remote Indexes
 
 Indexes can be stored and retrieved from remote locations via SFTP, S3, and HTTP. Storing indexes remotely is optional and deliberately separate from chunk storage. While it's possible to store indexes in the same location as chunks in the case of SFTP and S3, this should only be done in secured environments. The built-in HTTP chunk store (`chunk-server` command) can not be used as index server. Use the `index-server` command instead to start an index server that serves indexes and can optionally store them as well (with `-w`).
@@ -429,6 +462,7 @@ Not all options apply to all commands.
 | `DESYNC_PROGRESSBAR_ENABLED` | Enables the progress bar if set to any non-empty value. By default, the progress bar is only shown when STDERR is a terminal. |
 | `DESYNC_ENABLE_PARSABLE_PROGRESS` | Prints operation name, completion percentage, and estimated remaining time to STDERR. Similar to the default progress bar but without the visual bar. |
 | `DESYNC_HTTP_AUTH` | Sets the expected `Authorization` header value from clients when using `chunk-server` or `index-server`. Needs the full string including type and encoding, e.g. `"Basic dXNlcjpwYXNzd29yZAo="`. Command-line values take precedence. |
+| `DESYNC_ENCRYPTION_KEY` | Hex-encoded 256-bit chunk encryption key. Used for stores that have `encryption` enabled but no `encryption-key` configured, and by `chunk-server` when `--encryption-key` is not given. |
 
 </details>
 
@@ -474,6 +508,9 @@ This can be combined with store failover by providing the same syntax as used in
   | `uncompressed` | Read and write uncompressed chunks. Both formats can coexist in the same store. | false |
   | `http-auth` | Value of the `Authorization` header in HTTP requests, e.g. `"Bearer <token>"` or `"Basic dXNlcjpwYXNzd29yZAo="`. | — |
   | `http-cookie` | Value of the `Cookie` header in HTTP requests, e.g. `"name=value; name2=value2"`. | — |
+  | `encryption` | Set to `true` to encrypt chunks in the store. See [Chunk Encryption](#chunk-encryption). | false |
+  | `encryption-key` | Hex-encoded 256-bit encryption key, e.g. generated with `openssl rand -hex 32`. Can also be provided via the `DESYNC_ENCRYPTION_KEY` environment variable. | — |
+  | `encryption-algorithm` | Encryption algorithm, `xchacha20-poly1305` or `aes-256-gcm`. | `xchacha20-poly1305` |
 
 </details>
 
@@ -519,6 +556,11 @@ This can be combined with store failover by providing the same syntax as used in
     },
     "/path/to/local/cache": {
       "uncompressed": true
+    },
+    "/path/to/encrypted/store": {
+      "encryption": true,
+      "encryption-algorithm": "xchacha20-poly1305",
+      "encryption-key": "d69371915dbc4b1f0ec55e2a80f0e089accf4b32e0f8dc0e29fed7f0f30d1b26"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -307,6 +307,8 @@ Chunk extensions in stores are chosen based on compression or encryption setting
 
 Note that encryption only protects the chunk data itself. Chunk file names, which are the content hashes of the plain data, remain visible to anyone with access to the store. An observer that already knows the plain content of a chunk can therefore confirm its presence in the store.
 
+Encryption applies to chunk stores only. Index files are always stored in plain form, and index stores reject encryption options rather than silently ignoring them. If a config entry enabling encryption matches a location that is also used to store indexes, index operations will fail with an error — keep indexes in a separate location, or use a more specific config entry without encryption for them. Keep in mind that a plain index reveals metadata about the encrypted content: the IDs, sizes and offsets of all its chunks.
+
 Encryption provides confidentiality, while integrity comes from desync's regular chunk validation: every chunk is identified by the hash of its plain content, which is verified when chunks are read (unless `skip-verify` is set). The AEAD ciphertext is authenticated under the key, but it is not bound to the chunk's name — someone with write access to the store could swap two encrypted chunk files and decryption alone would not detect it. Such a swap is caught by the content validation of the final consumer, e.g. during `extract`, which is enabled by default. Only disable verification (`skip-verify`, `--skip-verify-read`) for intermediate proxies or caches where a downstream reader still validates the chunks.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -307,6 +307,8 @@ Chunk extensions in stores are chosen based on compression or encryption setting
 
 Note that encryption only protects the chunk data itself. Chunk file names, which are the content hashes of the plain data, remain visible to anyone with access to the store. An observer that already knows the plain content of a chunk can therefore confirm its presence in the store.
 
+Encryption provides confidentiality, while integrity comes from desync's regular chunk validation: every chunk is identified by the hash of its plain content, which is verified when chunks are read (unless `skip-verify` is set). The AEAD ciphertext is authenticated under the key, but it is not bound to the chunk's name — someone with write access to the store could swap two encrypted chunk files and decryption alone would not detect it. Such a swap is caught by the content validation of the final consumer, e.g. during `extract`, which is enabled by default. Only disable verification (`skip-verify`, `--skip-verify-read`) for intermediate proxies or caches where a downstream reader still validates the chunks.
+
 </details>
 
 ### Remote Indexes
@@ -504,7 +506,7 @@ This can be combined with store failover by providing the same syntax as used in
   | `client-key` | Key file for mutual SSL. | — |
   | `ca-cert` | Certificate file containing trusted certs or CAs. | — |
   | `trust-insecure` | Trust any certificate presented by the server. | false |
-  | `skip-verify` | Disable data integrity verification on read. Only recommended when chaining stores with `chunk-server` using compressed stores. | false |
+  | `skip-verify` | Disable data integrity verification on read. Only recommended when chaining stores with `chunk-server` where the final consumer still verifies. Chunk validation is also what detects renamed or swapped chunks in encrypted stores, see [Chunk Encryption](#chunk-encryption). | false |
   | `uncompressed` | Read and write uncompressed chunks. Both formats can coexist in the same store. | false |
   | `http-auth` | Value of the `Authorization` header in HTTP requests, e.g. `"Bearer <token>"` or `"Basic dXNlcjpwYXNzd29yZAo="`. | — |
   | `http-cookie` | Value of the `Cookie` header in HTTP requests, e.g. `"name=value; name2=value2"`. | — |

--- a/chunk.go
+++ b/chunk.go
@@ -33,20 +33,10 @@ func (c *Chunk) clone() *Chunk {
 	return &cp
 }
 
-// NewChunkWithID creates a new chunk from either compressed or uncompressed data
-// (or both if available). It also expects an ID and validates that it matches
-// the uncompressed data unless skipVerify is true. If called with just compressed
-// data, it'll decompress it for the ID validation.
+// NewChunkWithID creates a new chunk from plain data. It also expects an ID
+// and validates that it matches the data unless skipVerify is true.
 func NewChunkWithID(id ChunkID, b []byte, skipVerify bool) (*Chunk, error) {
-	c := &Chunk{id: id, data: b}
-	if skipVerify {
-		c.idCalculated = true // Pretend this was calculated. No need to re-calc later
-		return c, nil
-	}
-	if err := c.verify(); err != nil {
-		return nil, err
-	}
-	return c, nil
+	return NewChunkFromStorage(id, b, nil, skipVerify)
 }
 
 // NewChunkFromStorage builds a new chunk from data that is not in plain format.
@@ -122,11 +112,10 @@ func (c *Chunk) ID() ChunkID {
 func (c *Chunk) Storage(modifiers Converters) ([]byte, error) {
 	if len(c.storage) > 0 {
 		// If the stacks share leading layers, unwind the chunk's own extra
-		// layers and apply the requested ones on top. When nothing is shared
-		// and the storage data isn't plain, unwinding is the same work as
-		// Data() below, which also caches the plain data on the chunk for
-		// other consumers, so prefer that path.
-		if n := modifiers.commonPrefix(c.converters); n > 0 || len(c.converters) == 0 {
+		// layers and apply the requested ones on top. When nothing is shared,
+		// unwinding is the same work as Data() below, which also caches the
+		// plain data on the chunk for other consumers, so prefer that path.
+		if n := modifiers.commonPrefix(c.converters); n > 0 {
 			b := c.storage
 			if n < len(c.converters) {
 				var err error

--- a/chunk.go
+++ b/chunk.go
@@ -97,12 +97,21 @@ func (c *Chunk) ID() ChunkID {
 	return c.id
 }
 
-// Storage returns the chunk data in compressed form. If the chunk was created
-// with compressed data and same modifiers, this data will be returned as is. The
-// caller must not modify the data in the returned slice.
+// Storage returns the chunk data in storage format according to the given
+// modifiers. If the chunk was created with storage data and the same modifiers,
+// this data will be returned as is. If the modifiers only differ by extra or
+// missing trailing layers, just that difference is applied, avoiding expensive
+// conversions of the shared layers, such as recompression when only an
+// encryption layer is added or removed. The caller must not modify the data
+// in the returned slice.
 func (c *Chunk) Storage(modifiers Converters) ([]byte, error) {
-	if len(c.storage) > 0 && modifiers.equal(c.converters) {
-		return c.storage, nil
+	if len(c.storage) > 0 {
+		if suffix, ok := modifiers.trimPrefix(c.converters); ok {
+			return suffix.toStorage(c.storage)
+		}
+		if suffix, ok := c.converters.trimPrefix(modifiers); ok {
+			return suffix.fromStorage(c.storage)
+		}
 	}
 	b, err := c.Data()
 	if err != nil {

--- a/chunk.go
+++ b/chunk.go
@@ -43,9 +43,8 @@ func NewChunkWithID(id ChunkID, b []byte, skipVerify bool) (*Chunk, error) {
 		c.idCalculated = true // Pretend this was calculated. No need to re-calc later
 		return c, nil
 	}
-	sum := c.ID()
-	if sum != id {
-		return nil, ChunkInvalid{ID: id, Sum: sum}
+	if err := c.verify(); err != nil {
+		return nil, err
 	}
 	return c, nil
 }
@@ -59,11 +58,27 @@ func NewChunkFromStorage(id ChunkID, b []byte, modifiers Converters, skipVerify 
 		c.idCalculated = true // Pretend this was calculated. No need to re-calc later
 		return c, nil
 	}
-	sum := c.ID()
-	if sum != id {
-		return nil, ChunkInvalid{ID: id, Sum: sum}
+	if err := c.verify(); err != nil {
+		return nil, err
 	}
 	return c, nil
+}
+
+// verify confirms the chunk's plain data matches its expected ID. Errors
+// converting the storage data to plain form, such as decryption failures,
+// are reported as ChunkInvalid as well, with the cause preserved, since
+// they equally mean the chunk in the store is unusable.
+func (c *Chunk) verify() error {
+	b, err := c.Data()
+	if err != nil {
+		return ChunkInvalid{ID: c.id, Err: err}
+	}
+	sum := Digest.Sum(b)
+	if sum != c.id {
+		return ChunkInvalid{ID: c.id, Sum: sum}
+	}
+	c.idCalculated = true
+	return nil
 }
 
 // Data returns the chunk data in uncompressed form. If the chunk was created
@@ -99,18 +114,28 @@ func (c *Chunk) ID() ChunkID {
 
 // Storage returns the chunk data in storage format according to the given
 // modifiers. If the chunk was created with storage data and the same modifiers,
-// this data will be returned as is. If the modifiers only differ by extra or
-// missing trailing layers, just that difference is applied, avoiding expensive
-// conversions of the shared layers, such as recompression when only an
-// encryption layer is added or removed. The caller must not modify the data
-// in the returned slice.
+// this data will be returned as is. If the modifiers share leading layers with
+// the chunk's own, only the difference is applied, avoiding expensive
+// conversions of the shared layers, such as recompression when just an
+// encryption layer is added, removed, or uses a different key. The caller
+// must not modify the data in the returned slice.
 func (c *Chunk) Storage(modifiers Converters) ([]byte, error) {
 	if len(c.storage) > 0 {
-		if suffix, ok := modifiers.trimPrefix(c.converters); ok {
-			return suffix.toStorage(c.storage)
-		}
-		if suffix, ok := c.converters.trimPrefix(modifiers); ok {
-			return suffix.fromStorage(c.storage)
+		// If the stacks share leading layers, unwind the chunk's own extra
+		// layers and apply the requested ones on top. When nothing is shared
+		// and the storage data isn't plain, unwinding is the same work as
+		// Data() below, which also caches the plain data on the chunk for
+		// other consumers, so prefer that path.
+		if n := modifiers.commonPrefix(c.converters); n > 0 || len(c.converters) == 0 {
+			b := c.storage
+			if n < len(c.converters) {
+				var err error
+				b, err = c.converters[n:].fromStorage(b)
+				if err != nil {
+					return nil, err
+				}
+			}
+			return modifiers[n:].toStorage(b)
 		}
 	}
 	b, err := c.Data()

--- a/cmd/desync/chunkserver.go
+++ b/cmd/desync/chunkserver.go
@@ -97,11 +97,24 @@ func runChunkServer(ctx context.Context, opt chunkServerOptions, args []string) 
 	if opt.auth == "" {
 		opt.auth = os.Getenv("DESYNC_HTTP_AUTH")
 	}
-	// Encryption needs to be requested explicitly with a flag. The env variable
-	// alone must not switch the wire format, it may be set for the sake of an
-	// encrypted store elsewhere in the config.
-	encryption := opt.encryption || opt.encryptionKey != "" || opt.encryptionAlg != ""
-	opt.encryptionKey = encryptionKeyFallback(encryption, opt.encryptionKey)
+
+	// Build the converters for the format this server exchanges with its
+	// clients, before any upstream store is opened, so that invalid encryption
+	// options fail fast. Encryption needs to be requested explicitly with one
+	// of its flags. The env variable alone must not switch the wire format, it
+	// may be set for the sake of an encrypted store elsewhere in the config.
+	wireOpt := desync.StoreOptions{
+		Uncompressed:        opt.uncompressed,
+		Encryption:          opt.encryption,
+		EncryptionAlgorithm: opt.encryptionAlg,
+		EncryptionKey:       opt.encryptionKey,
+	}
+	wireOpt.Encryption = wireOpt.EncryptionConfigured()
+	wireOpt.EncryptionKey = encryptionKeyFallback(wireOpt.Encryption, wireOpt.EncryptionKey)
+	converters, err := wireOpt.StorageConverters()
+	if err != nil {
+		return err
+	}
 
 	addresses := opt.listenAddresses
 	if len(addresses) == 0 {
@@ -145,20 +158,6 @@ func runChunkServer(ctx context.Context, opt chunkServerOptions, args []string) 
 		}()
 	}
 	defer s.Close()
-
-	// Build the converters. In this case, the "storage" side is what is served
-	// up by the server towards the client. The StoreOptions struct already has
-	// logic to build the converters from options so use that instead of repeating
-	// it here.
-	converters, err := desync.StoreOptions{
-		Uncompressed:        opt.uncompressed,
-		Encryption:          encryption,
-		EncryptionAlgorithm: opt.encryptionAlg,
-		EncryptionKey:       opt.encryptionKey,
-	}.StorageConverters()
-	if err != nil {
-		return err
-	}
 
 	handler := desync.NewHTTPHandler(s, opt.writable, opt.skipVerifyWrite, converters, opt.auth)
 

--- a/cmd/desync/chunkserver.go
+++ b/cmd/desync/chunkserver.go
@@ -24,6 +24,7 @@ type chunkServerOptions struct {
 	skipVerifyWrite bool
 	uncompressed    bool
 	logFile         string
+	encryption      bool
 	encryptionAlg   string
 	encryptionKey   string
 }
@@ -43,9 +44,11 @@ of chunks written to this server, avoiding the decompression step needed to
 calculate checksums, to improve performance. If -u is used, only uncompressed
 chunks are served (and accepted). If the upstream store serves compressed chunks,
 everything will have to be decompressed server-side so it's better to also read
-from uncompressed upstream stores. With --encryption-key, chunks are served (and
-accepted) encrypted, regardless of how they are stored in the upstream store. The
-key can also be provided in the DESYNC_ENCRYPTION_KEY environment variable.
+from uncompressed upstream stores. With --encryption, chunks are served (and
+accepted) encrypted, regardless of how they are stored in the upstream store.
+The key is read from the DESYNC_ENCRYPTION_KEY environment variable unless
+--encryption-key is used. The environment variable on its own does not enable
+encryption, one of the encryption flags is required.
 
 While --concurrency does not limit the number of clients that can be served
 concurrently, it does influence connection pools to remote upstream stores and
@@ -76,8 +79,9 @@ needing to restart the server. This can be done under load as well.
 	flags.BoolVar(&opt.skipVerifyWrite, "skip-verify-write", true, "don't verify chunk data written to this server (faster)")
 	flags.BoolVarP(&opt.uncompressed, "uncompressed", "u", false, "serve uncompressed chunks")
 	flags.StringVar(&opt.logFile, "log", "", "request log file or - for STDOUT")
-	flags.StringVar(&opt.encryptionKey, "encryption-key", "", "serve chunks encrypted with this hex-encoded 256-bit key")
-	flags.StringVar(&opt.encryptionAlg, "encryption-algorithm", "xchacha20-poly1305", "encryption algorithm")
+	flags.BoolVar(&opt.encryption, "encryption", false, "serve chunks encrypted, expects the key in $DESYNC_ENCRYPTION_KEY unless --encryption-key is given")
+	flags.StringVar(&opt.encryptionKey, "encryption-key", "", "serve chunks encrypted with this hex-encoded 256-bit key, implies --encryption")
+	flags.StringVar(&opt.encryptionAlg, "encryption-algorithm", "", "encryption algorithm, xchacha20-poly1305 (default) or aes-256-gcm, implies --encryption")
 	addStoreOptions(&opt.cmdStoreOptions, flags)
 	addServerOptions(&opt.cmdServerOptions, flags)
 	return cmd
@@ -93,7 +97,11 @@ func runChunkServer(ctx context.Context, opt chunkServerOptions, args []string) 
 	if opt.auth == "" {
 		opt.auth = os.Getenv("DESYNC_HTTP_AUTH")
 	}
-	if opt.encryptionKey == "" {
+	// Encryption needs to be requested explicitly with a flag. The env variable
+	// alone must not switch the wire format, it may be set for the sake of an
+	// encrypted store elsewhere in the config.
+	encryption := opt.encryption || opt.encryptionKey != "" || opt.encryptionAlg != ""
+	if encryption && opt.encryptionKey == "" {
 		opt.encryptionKey = os.Getenv("DESYNC_ENCRYPTION_KEY")
 	}
 
@@ -146,7 +154,7 @@ func runChunkServer(ctx context.Context, opt chunkServerOptions, args []string) 
 	// it here.
 	converters, err := desync.StoreOptions{
 		Uncompressed:        opt.uncompressed,
-		Encryption:          opt.encryptionKey != "",
+		Encryption:          encryption,
 		EncryptionAlgorithm: opt.encryptionAlg,
 		EncryptionKey:       opt.encryptionKey,
 	}.StorageConverters()

--- a/cmd/desync/chunkserver.go
+++ b/cmd/desync/chunkserver.go
@@ -101,9 +101,7 @@ func runChunkServer(ctx context.Context, opt chunkServerOptions, args []string) 
 	// alone must not switch the wire format, it may be set for the sake of an
 	// encrypted store elsewhere in the config.
 	encryption := opt.encryption || opt.encryptionKey != "" || opt.encryptionAlg != ""
-	if encryption && opt.encryptionKey == "" {
-		opt.encryptionKey = os.Getenv("DESYNC_ENCRYPTION_KEY")
-	}
+	opt.encryptionKey = encryptionKeyFallback(encryption, opt.encryptionKey)
 
 	addresses := opt.listenAddresses
 	if len(addresses) == 0 {

--- a/cmd/desync/chunkserver.go
+++ b/cmd/desync/chunkserver.go
@@ -24,6 +24,8 @@ type chunkServerOptions struct {
 	skipVerifyWrite bool
 	uncompressed    bool
 	logFile         string
+	encryptionAlg   string
+	encryptionKey   string
 }
 
 func newChunkServerCommand(ctx context.Context) *cobra.Command {
@@ -41,7 +43,9 @@ of chunks written to this server, avoiding the decompression step needed to
 calculate checksums, to improve performance. If -u is used, only uncompressed
 chunks are served (and accepted). If the upstream store serves compressed chunks,
 everything will have to be decompressed server-side so it's better to also read
-from uncompressed upstream stores.
+from uncompressed upstream stores. With --encryption-key, chunks are served (and
+accepted) encrypted, regardless of how they are stored in the upstream store. The
+key can also be provided in the DESYNC_ENCRYPTION_KEY environment variable.
 
 While --concurrency does not limit the number of clients that can be served
 concurrently, it does influence connection pools to remote upstream stores and
@@ -72,6 +76,8 @@ needing to restart the server. This can be done under load as well.
 	flags.BoolVar(&opt.skipVerifyWrite, "skip-verify-write", true, "don't verify chunk data written to this server (faster)")
 	flags.BoolVarP(&opt.uncompressed, "uncompressed", "u", false, "serve uncompressed chunks")
 	flags.StringVar(&opt.logFile, "log", "", "request log file or - for STDOUT")
+	flags.StringVar(&opt.encryptionKey, "encryption-key", "", "serve chunks encrypted with this hex-encoded 256-bit key")
+	flags.StringVar(&opt.encryptionAlg, "encryption-algorithm", "xchacha20-poly1305", "encryption algorithm")
 	addStoreOptions(&opt.cmdStoreOptions, flags)
 	addServerOptions(&opt.cmdServerOptions, flags)
 	return cmd
@@ -86,6 +92,9 @@ func runChunkServer(ctx context.Context, opt chunkServerOptions, args []string) 
 	}
 	if opt.auth == "" {
 		opt.auth = os.Getenv("DESYNC_HTTP_AUTH")
+	}
+	if opt.encryptionKey == "" {
+		opt.encryptionKey = os.Getenv("DESYNC_ENCRYPTION_KEY")
 	}
 
 	addresses := opt.listenAddresses
@@ -131,9 +140,18 @@ func runChunkServer(ctx context.Context, opt chunkServerOptions, args []string) 
 	}
 	defer s.Close()
 
-	var converters desync.Converters
-	if !opt.uncompressed {
-		converters = desync.Converters{desync.Compressor{}}
+	// Build the converters. In this case, the "storage" side is what is served
+	// up by the server towards the client. The StoreOptions struct already has
+	// logic to build the converters from options so use that instead of repeating
+	// it here.
+	converters, err := desync.StoreOptions{
+		Uncompressed:        opt.uncompressed,
+		Encryption:          opt.encryptionKey != "",
+		EncryptionAlgorithm: opt.encryptionAlg,
+		EncryptionKey:       opt.encryptionKey,
+	}.StorageConverters()
+	if err != nil {
+		return err
 	}
 
 	handler := desync.NewHTTPHandler(s, opt.writable, opt.skipVerifyWrite, converters, opt.auth)

--- a/cmd/desync/chunkserver_test.go
+++ b/cmd/desync/chunkserver_test.go
@@ -162,12 +162,24 @@ func TestChunkServerMutualTLS(t *testing.T) {
 }
 
 func startChunkServer(t *testing.T, args ...string) (string, context.CancelFunc) {
-	// Find a free local port to be used to run the index server on
+	addr := freeLocalAddr(t)
+	return addr, startChunkServerOnAddr(t, addr, args...)
+}
+
+// freeLocalAddr finds a free local address with a port that can be used to
+// run a server on.
+func freeLocalAddr(t *testing.T) string {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	addr := l.Addr().String()
 	l.Close()
+	return addr
+}
 
+// startChunkServerOnAddr starts a chunk server on the given address. The
+// server goroutine reads package globals like the config during startup,
+// so tests that modify those need to do that before calling this.
+func startChunkServerOnAddr(t *testing.T, addr string, args ...string) context.CancelFunc {
 	// Flush any handlers that were registered in the default mux before
 	http.DefaultServeMux = &http.ServeMux{}
 
@@ -183,7 +195,7 @@ func startChunkServer(t *testing.T, args ...string) (string, context.CancelFunc)
 
 	// Wait a little for the server to start
 	time.Sleep(time.Second)
-	return addr, cancel
+	return cancel
 }
 
 // randomEncryptionKey returns a new hex-encoded 256-bit chunk encryption key.
@@ -197,16 +209,13 @@ func randomEncryptionKey(t *testing.T) string {
 func TestChunkServerEncryption(t *testing.T) {
 	outdir := t.TempDir()
 	testEncryptionKey := randomEncryptionKey(t)
-
-	// Start a (writable) server, it'll expect compressed+encrypted chunks over
-	// the wire while storing them only compressed in the local store
-	addr, cancel := startChunkServer(t, "-s", outdir, "-w", "--skip-verify-read=false", "--skip-verify-write=false", "--encryption-key", testEncryptionKey)
-	defer cancel()
+	addr := freeLocalAddr(t)
 	store := fmt.Sprintf("http://%s/", addr)
 
 	// Build a client config. The client needs to be setup to talk to the HTTP chunk server
 	// compressed+encrypted. Create a temp JSON config for that HTTP store and load it.
-	// Restore the config globals afterwards so no other test picks up these options.
+	// This has to happen before the server starts since its goroutine reads the same
+	// config globals. Restore them afterwards so no other test picks up these options.
 	oldCfgFile, oldCfg := cfgFile, cfg
 	t.Cleanup(func() { cfgFile, cfg = oldCfgFile, oldCfg })
 	cfgFile = filepath.Join(outdir, "config.json")
@@ -214,6 +223,11 @@ func TestChunkServerEncryption(t *testing.T) {
 	cfgFileContent := fmt.Sprintf(`{"store-options": {"%s":{"encryption": true, "encryption-key": "%s"}}}`, store, testEncryptionKey)
 	require.NoError(t, os.WriteFile(cfgFile, []byte(cfgFileContent), 0644))
 	initConfig()
+
+	// Start a (writable) server, it'll expect compressed+encrypted chunks over
+	// the wire while storing them only compressed in the local store
+	cancel := startChunkServerOnAddr(t, addr, "-s", outdir, "-w", "--skip-verify-read=false", "--skip-verify-write=false", "--encryption-key", testEncryptionKey)
+	defer cancel()
 
 	// Run a "chop" command to send some chunks (encrypted) over HTTP, then have the server
 	// store them un-encrypted in its local store.

--- a/cmd/desync/chunkserver_test.go
+++ b/cmd/desync/chunkserver_test.go
@@ -198,7 +198,11 @@ func TestChunkServerEncryption(t *testing.T) {
 
 	// Build a client config. The client needs to be setup to talk to the HTTP chunk server
 	// compressed+encrypted. Create a temp JSON config for that HTTP store and load it.
+	// Restore the config globals afterwards so no other test picks up these options.
+	oldCfgFile, oldCfg := cfgFile, cfg
+	t.Cleanup(func() { cfgFile, cfg = oldCfgFile, oldCfg })
 	cfgFile = filepath.Join(outdir, "config.json")
+	cfg = Config{}
 	cfgFileContent := fmt.Sprintf(`{"store-options": {"%s":{"encryption": true, "encryption-key": "%s"}}}`, store, testEncryptionKey)
 	require.NoError(t, os.WriteFile(cfgFile, []byte(cfgFileContent), 0644))
 	initConfig()

--- a/cmd/desync/chunkserver_test.go
+++ b/cmd/desync/chunkserver_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -181,4 +182,47 @@ func startChunkServer(t *testing.T, args ...string) (string, context.CancelFunc)
 	// Wait a little for the server to start
 	time.Sleep(time.Second)
 	return addr, cancel
+}
+
+// Hex-encoded 256-bit key used in encryption tests.
+const testEncryptionKey = "6368616e676520746869732070617373776f726420746f206120736563726574"
+
+func TestChunkServerEncryption(t *testing.T) {
+	outdir := t.TempDir()
+
+	// Start a (writable) server, it'll expect compressed+encrypted chunks over
+	// the wire while storing them only compressed in the local store
+	addr, cancel := startChunkServer(t, "-s", outdir, "-w", "--skip-verify-read=false", "--skip-verify-write=false", "--encryption-key", testEncryptionKey)
+	defer cancel()
+	store := fmt.Sprintf("http://%s/", addr)
+
+	// Build a client config. The client needs to be setup to talk to the HTTP chunk server
+	// compressed+encrypted. Create a temp JSON config for that HTTP store and load it.
+	cfgFile = filepath.Join(outdir, "config.json")
+	cfgFileContent := fmt.Sprintf(`{"store-options": {"%s":{"encryption": true, "encryption-key": "%s"}}}`, store, testEncryptionKey)
+	require.NoError(t, os.WriteFile(cfgFile, []byte(cfgFileContent), 0644))
+	initConfig()
+
+	// Run a "chop" command to send some chunks (encrypted) over HTTP, then have the server
+	// store them un-encrypted in its local store.
+	chopCmd := newChopCommand(context.Background())
+	chopCmd.SetArgs([]string{"-s", store, "testdata/blob1.caibx", "testdata/blob1"})
+	chopCmd.SetOutput(io.Discard)
+	_, err := chopCmd.ExecuteC()
+	require.NoError(t, err)
+
+	// Now read it all back over HTTP (again encrypted) and re-assemble the test file
+	extractFile := filepath.Join(outdir, "blob1")
+	extractCmd := newExtractCommand(context.Background())
+	extractCmd.SetArgs([]string{"-s", store, "testdata/blob1.caibx", extractFile})
+	extractCmd.SetOutput(io.Discard)
+	_, err = extractCmd.ExecuteC()
+	require.NoError(t, err)
+
+	// Not actually necessary, but for good measure let's compare the blobs
+	blobIn, err := os.ReadFile("testdata/blob1")
+	require.NoError(t, err)
+	blobOut, err := os.ReadFile(extractFile)
+	require.NoError(t, err)
+	require.Equal(t, blobIn, blobOut)
 }

--- a/cmd/desync/chunkserver_test.go
+++ b/cmd/desync/chunkserver_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net"
@@ -184,11 +186,17 @@ func startChunkServer(t *testing.T, args ...string) (string, context.CancelFunc)
 	return addr, cancel
 }
 
-// Hex-encoded 256-bit key used in encryption tests.
-const testEncryptionKey = "6368616e676520746869732070617373776f726420746f206120736563726574"
+// randomEncryptionKey returns a new hex-encoded 256-bit chunk encryption key.
+func randomEncryptionKey(t *testing.T) string {
+	key := make([]byte, 32)
+	_, err := rand.Read(key)
+	require.NoError(t, err)
+	return hex.EncodeToString(key)
+}
 
 func TestChunkServerEncryption(t *testing.T) {
 	outdir := t.TempDir()
+	testEncryptionKey := randomEncryptionKey(t)
 
 	// Start a (writable) server, it'll expect compressed+encrypted chunks over
 	// the wire while storing them only compressed in the local store
@@ -235,7 +243,7 @@ func TestChunkServerEnvKeyDoesNotEnableEncryption(t *testing.T) {
 	// Having the key in the environment alone must not switch the server to
 	// encrypted serving, it may be set for the sake of an encrypted store
 	// elsewhere in the config
-	t.Setenv("DESYNC_ENCRYPTION_KEY", testEncryptionKey)
+	t.Setenv("DESYNC_ENCRYPTION_KEY", randomEncryptionKey(t))
 
 	// Reset any config a previous test may have loaded
 	oldCfg := cfg

--- a/cmd/desync/chunkserver_test.go
+++ b/cmd/desync/chunkserver_test.go
@@ -226,3 +226,52 @@ func TestChunkServerEncryption(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, blobIn, blobOut)
 }
+
+func TestChunkServerEnvKeyDoesNotEnableEncryption(t *testing.T) {
+	// Having the key in the environment alone must not switch the server to
+	// encrypted serving, it may be set for the sake of an encrypted store
+	// elsewhere in the config
+	t.Setenv("DESYNC_ENCRYPTION_KEY", testEncryptionKey)
+
+	// Reset any config a previous test may have loaded
+	oldCfg := cfg
+	cfg = Config{}
+	t.Cleanup(func() { cfg = oldCfg })
+
+	outdir := t.TempDir()
+	addr, cancel := startChunkServer(t, "-s", outdir, "-w")
+	defer cancel()
+	store := fmt.Sprintf("http://%s/", addr)
+
+	// A plain (compressed, unencrypted) client must be able to write chunks
+	chopCmd := newChopCommand(context.Background())
+	chopCmd.SetArgs([]string{"-s", store, "testdata/blob1.caibx", "testdata/blob1"})
+	chopCmd.SetOutput(io.Discard)
+	_, err := chopCmd.ExecuteC()
+	require.NoError(t, err)
+
+	// And the chunks have to be stored with the plain compressed extension
+	matches, err := filepath.Glob(filepath.Join(outdir, "*", "*"))
+	require.NoError(t, err)
+	require.NotEmpty(t, matches)
+	for _, m := range matches {
+		require.True(t, strings.HasSuffix(m, ".cacnk"), "chunk %s is not a plain compressed chunk", m)
+	}
+}
+
+func TestChunkServerEncryptionMissingKey(t *testing.T) {
+	// Encryption enabled without a key from flag or environment has to be
+	// rejected at startup rather than silently serving plaintext
+	t.Setenv("DESYNC_ENCRYPTION_KEY", "")
+
+	for _, args := range [][]string{
+		{"--encryption"},
+		{"--encryption-algorithm", "aes-256-gcm"},
+	} {
+		cmd := newChunkServerCommand(context.Background())
+		cmd.SetArgs(append(args, "-s", t.TempDir(), "-l", "127.0.0.1:0"))
+		cmd.SetOutput(io.Discard)
+		_, err := cmd.ExecuteC()
+		require.ErrorContains(t, err, "no encryption key configured")
+	}
+}

--- a/cmd/desync/config.go
+++ b/cmd/desync/config.go
@@ -88,6 +88,11 @@ func (c Config) GetStoreOptionsFor(location string) (options desync.StoreOptions
 			options = v
 		}
 	}
+	// Allow the encryption key to be kept out of the config file and be
+	// provided via the environment instead.
+	if options.Encryption && options.EncryptionKey == "" {
+		options.EncryptionKey = os.Getenv("DESYNC_ENCRYPTION_KEY")
+	}
 	return options, nil
 }
 

--- a/cmd/desync/config.go
+++ b/cmd/desync/config.go
@@ -88,12 +88,20 @@ func (c Config) GetStoreOptionsFor(location string) (options desync.StoreOptions
 			options = v
 		}
 	}
-	// Allow the encryption key to be kept out of the config file and be
-	// provided via the environment instead.
-	if options.Encryption && options.EncryptionKey == "" {
-		options.EncryptionKey = os.Getenv("DESYNC_ENCRYPTION_KEY")
-	}
+	options.EncryptionKey = encryptionKeyFallback(options.Encryption, options.EncryptionKey)
 	return options, nil
+}
+
+// encryptionKeyFallback allows the encryption key to be kept out of config
+// files and flags and be provided via the environment instead. It returns the
+// configured key, or the value of DESYNC_ENCRYPTION_KEY if no key is configured
+// while encryption is enabled. The environment variable alone never enables
+// encryption.
+func encryptionKeyFallback(enabled bool, key string) string {
+	if enabled && key == "" {
+		return os.Getenv("DESYNC_ENCRYPTION_KEY")
+	}
+	return key
 }
 
 func newConfigCommand(ctx context.Context) *cobra.Command {

--- a/cmd/desync/indexserver_test.go
+++ b/cmd/desync/indexserver_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -139,10 +138,7 @@ func TestIndexServerHead(t *testing.T) {
 
 func startIndexServer(t *testing.T, args ...string) (string, context.CancelFunc) {
 	// Find a free local port to be used to run the index server on
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	addr := l.Addr().String()
-	l.Close()
+	addr := freeLocalAddr(t)
 
 	// Flush any handlers that were registered in the default mux before
 	http.DefaultServeMux = &http.ServeMux{}

--- a/cmd/desync/inspectchunks.go
+++ b/cmd/desync/inspectchunks.go
@@ -94,8 +94,9 @@ func runInspectChunks(ctx context.Context, opt inspectChunksOptions, args []stri
 
 	for _, chunk := range c.Chunks {
 		var size int64 = 0
-		// Get the compressed size only if the store actually has compressed chunks
-		if opt.store != "" && !s.Opt.Uncompressed {
+		// Get the size in the store only if it differs from the plain size,
+		// i.e. the chunks are compressed, encrypted, or both
+		if opt.store != "" && (!s.Opt.Uncompressed || s.Opt.Encryption) {
 			size, _ = s.GetChunkSize(chunk.ID)
 		}
 

--- a/cmd/desync/inspectchunks.go
+++ b/cmd/desync/inspectchunks.go
@@ -92,11 +92,21 @@ func runInspectChunks(ctx context.Context, opt inspectChunksOptions, args []stri
 		}
 	}
 
+	// Get sizes in the store only if they differ from the plain size, i.e.
+	// a converter such as compression or encryption is configured. The
+	// store constructor already validated the options, so this can't fail.
+	var converted bool
+	if opt.store != "" {
+		converters, err := s.Opt.StorageConverters()
+		if err != nil {
+			return err
+		}
+		converted = len(converters) > 0
+	}
+
 	for _, chunk := range c.Chunks {
 		var size int64 = 0
-		// Get the size in the store only if it differs from the plain size,
-		// i.e. the chunks are compressed, encrypted, or both
-		if opt.store != "" && (!s.Opt.Uncompressed || s.Opt.Encryption) {
+		if converted {
 			size, _ = s.GetChunkSize(chunk.ID)
 		}
 

--- a/cmd/desync/store.go
+++ b/cmd/desync/store.go
@@ -232,6 +232,14 @@ func indexStoreFromLocation(location string, cmdOpt cmdStoreOptions) (desync.Ind
 	}
 	opt := cmdOpt.MergedWith(configOptions)
 
+	// The index store constructors reject encryption options themselves, but
+	// local and console index stores don't take any options. Check here so a
+	// config entry matching an index location fails uniformly for all backends
+	// instead of silently storing plaintext indexes.
+	if err := opt.ValidateIndexOptions(); err != nil {
+		return nil, "", fmt.Errorf("store options for %q: %w", location, err)
+	}
+
 	var s desync.IndexStore
 	switch loc.Scheme {
 	case "ssh":

--- a/compress.go
+++ b/compress.go
@@ -22,26 +22,3 @@ func Compress(src []byte) ([]byte, error) {
 func Decompress(dst, src []byte) ([]byte, error) {
 	return decoder.DecodeAll(src, dst)
 }
-
-// Compression layer converter. Compresses/decompresses chunk data
-// to and from storage. Implements the converter interface.
-type Compressor struct{}
-
-var _ converter = Compressor{}
-
-func (d Compressor) toStorage(in []byte) ([]byte, error) {
-	return Compress(in)
-}
-
-func (d Compressor) fromStorage(in []byte) ([]byte, error) {
-	return Decompress(nil, in)
-}
-
-func (d Compressor) equal(c converter) bool {
-	_, ok := c.(Compressor)
-	return ok
-}
-
-func (d Compressor) storageExtension() string {
-	return ".cacnk"
-}

--- a/compress.go
+++ b/compress.go
@@ -22,3 +22,26 @@ func Compress(src []byte) ([]byte, error) {
 func Decompress(dst, src []byte) ([]byte, error) {
 	return decoder.DecodeAll(src, dst)
 }
+
+// Compression layer converter. Compresses/decompresses chunk data
+// to and from storage. Implements the converter interface.
+type Compressor struct{}
+
+var _ converter = Compressor{}
+
+func (d Compressor) toStorage(in []byte) ([]byte, error) {
+	return Compress(in)
+}
+
+func (d Compressor) fromStorage(in []byte) ([]byte, error) {
+	return Decompress(nil, in)
+}
+
+func (d Compressor) equal(c converter) bool {
+	_, ok := c.(Compressor)
+	return ok
+}
+
+func (d Compressor) storageExtension() string {
+	return ".cacnk"
+}

--- a/const.go
+++ b/const.go
@@ -137,9 +137,3 @@ var (
 		CaFormatTableTailMarker:   "CaFormatTableTailMarker",
 	}
 )
-
-// CompressedChunkExt is the file extension used for compressed chunks
-const CompressedChunkExt = ".cacnk"
-
-// UncompressedChunkExt is the file extension of uncompressed chunks
-const UncompressedChunkExt = ""

--- a/converter.go
+++ b/converter.go
@@ -43,15 +43,25 @@ func (s Converters) fromStorage(in []byte) ([]byte, error) {
 // Returns true if both converters have the same layers in the
 // same order. Used for optimizations.
 func (s Converters) equal(c Converters) bool {
-	if len(s) != len(c) {
-		return false
+	suffix, ok := s.trimPrefix(c)
+	return ok && len(suffix) == 0
+}
+
+// trimPrefix returns the layers of s that remain after removing the given
+// prefix, and whether prefix actually is a prefix of s. Used to determine
+// the difference between two conversion stacks, for example a compressed
+// store being served encrypted, where only the extra layers need to be
+// applied. An equal stack returns an empty remainder.
+func (s Converters) trimPrefix(prefix Converters) (Converters, bool) {
+	if len(prefix) > len(s) {
+		return nil, false
 	}
-	for i := range s {
-		if !s[i].equal(c[i]) {
-			return false
+	for i := range prefix {
+		if !s[i].equal(prefix[i]) {
+			return nil, false
 		}
 	}
-	return true
+	return s[len(prefix):], true
 }
 
 // Extension to be used in storage. Concatenation of converter

--- a/converter.go
+++ b/converter.go
@@ -83,3 +83,28 @@ type converter interface {
 	// True is one converter matches another exactly.
 	equal(converter) bool
 }
+
+// Compression layer converter. Compresses/decompresses chunk data
+// to and from storage. Implements the converter interface. Lives in
+// this file rather than compress.go so it is part of both compression
+// build variants.
+type Compressor struct{}
+
+var _ converter = Compressor{}
+
+func (d Compressor) toStorage(in []byte) ([]byte, error) {
+	return Compress(in)
+}
+
+func (d Compressor) fromStorage(in []byte) ([]byte, error) {
+	return Decompress(nil, in)
+}
+
+func (d Compressor) equal(c converter) bool {
+	_, ok := c.(Compressor)
+	return ok
+}
+
+func (d Compressor) storageExtension() string {
+	return ".cacnk"
+}

--- a/converter.go
+++ b/converter.go
@@ -40,28 +40,16 @@ func (s Converters) fromStorage(in []byte) ([]byte, error) {
 	return b, nil
 }
 
-// Returns true if both converters have the same layers in the
-// same order. Used for optimizations.
-func (s Converters) equal(c Converters) bool {
-	suffix, ok := s.trimPrefix(c)
-	return ok && len(suffix) == 0
-}
-
-// trimPrefix returns the layers of s that remain after removing the given
-// prefix, and whether prefix actually is a prefix of s. Used to determine
-// the difference between two conversion stacks, for example a compressed
-// store being served encrypted, where only the extra layers need to be
-// applied. An equal stack returns an empty remainder.
-func (s Converters) trimPrefix(prefix Converters) (Converters, bool) {
-	if len(prefix) > len(s) {
-		return nil, false
+// commonPrefix returns the number of leading layers shared between the
+// two conversion stacks. Used to determine the difference between them,
+// for example a compressed store being served encrypted, where only the
+// differing layers need to be applied.
+func (s Converters) commonPrefix(c Converters) int {
+	var n int
+	for n < len(s) && n < len(c) && s[n].equal(c[n]) {
+		n++
 	}
-	for i := range prefix {
-		if !s[i].equal(prefix[i]) {
-			return nil, false
-		}
-	}
-	return s[len(prefix):], true
+	return n
 }
 
 // Extension to be used in storage. Concatenation of converter

--- a/converter.go
+++ b/converter.go
@@ -1,5 +1,7 @@
 package desync
 
+import "strings"
+
 // Converters are modifiers for chunk data, such as compression or encryption.
 // They are used to prepare chunk data for storage, or to read it from storage.
 // The order of the conversion layers matters. When plain data is prepared for
@@ -38,17 +40,6 @@ func (s Converters) fromStorage(in []byte) ([]byte, error) {
 	return b, nil
 }
 
-// Returns true if conversion involves compression. Typically
-// used to determine the correct file-extension.
-func (s Converters) hasCompression() bool {
-	for _, layer := range s {
-		if _, ok := layer.(Compressor); ok {
-			return true
-		}
-	}
-	return false
-}
-
 // Returns true if both converters have the same layers in the
 // same order. Used for optimizations.
 func (s Converters) equal(c Converters) bool {
@@ -63,6 +54,16 @@ func (s Converters) equal(c Converters) bool {
 	return true
 }
 
+// Extension to be used in storage. Concatenation of converter
+// extensions in order (towards storage).
+func (s Converters) storageExtension() string {
+	var ext strings.Builder
+	for _, layer := range s {
+		ext.WriteString(layer.storageExtension())
+	}
+	return ext.String()
+}
+
 // converter is a storage data modifier layer.
 type converter interface {
 	// Convert data from its original form to storage format.
@@ -75,23 +76,10 @@ type converter interface {
 	// the output may be used for the next conversion layer.
 	fromStorage([]byte) ([]byte, error)
 
+	// Returns the file extension that should be used for a
+	// chunk when stored. Usually a concatenation of layers.
+	storageExtension() string
+
+	// True is one converter matches another exactly.
 	equal(converter) bool
-}
-
-// Compression layer
-type Compressor struct{}
-
-var _ converter = Compressor{}
-
-func (d Compressor) toStorage(in []byte) ([]byte, error) {
-	return Compress(in)
-}
-
-func (d Compressor) fromStorage(in []byte) ([]byte, error) {
-	return Decompress(nil, in)
-}
-
-func (d Compressor) equal(c converter) bool {
-	_, ok := c.(Compressor)
-	return ok
 }

--- a/converter_test.go
+++ b/converter_test.go
@@ -39,4 +39,33 @@ func TestChunkStorageSharedLayers(t *testing.T) {
 	storage, err = c.Storage(Converters{Compressor{}, enc})
 	require.NoError(t, err)
 	require.Equal(t, encrypted, storage)
+
+	// Key rotation: convert between two encrypted formats that share the
+	// compression layer, as when re-encrypting a store with a new key.
+	// Only the encryption layer should be swapped.
+	otherEnc, err := NewXChaCha20Poly1305(testKey(t, otherEncryptionKey))
+	require.NoError(t, err)
+	reEncrypted, err := c.Storage(Converters{Compressor{}, otherEnc})
+	require.NoError(t, err)
+	decrypted, err = otherEnc.fromStorage(reEncrypted)
+	require.NoError(t, err)
+	require.Equal(t, compressed, decrypted)
+}
+
+// Converting a chunk to plain storage format goes through Data() which
+// caches the result on the chunk, so that later consumers, such as reading
+// a chunk back after storing it in an uncompressed cache, don't convert
+// the same data again.
+func TestChunkStoragePlainCached(t *testing.T) {
+	plain := []byte("some data")
+	compressed, err := Compress(plain)
+	require.NoError(t, err)
+
+	c, err := NewChunkFromStorage(ChunkID{}, compressed, Converters{Compressor{}}, true)
+	require.NoError(t, err)
+
+	storage, err := c.Storage(nil)
+	require.NoError(t, err)
+	require.Equal(t, plain, storage)
+	require.Equal(t, plain, c.data, "plain data not cached on the chunk")
 }

--- a/converter_test.go
+++ b/converter_test.go
@@ -1,0 +1,42 @@
+package desync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Chunks converted between storage formats that share converter layers must
+// only apply the difference, not rebuild the whole stack from plain data.
+// Verified by using storage data that isn't valid zstd: any attempt to
+// undo the shared compression layer would fail.
+func TestChunkStorageSharedLayers(t *testing.T) {
+	enc, err := NewXChaCha20Poly1305(testKey(t, testEncryptionKey))
+	require.NoError(t, err)
+
+	compressed := []byte("not valid zstd data")
+
+	// Chunk from a compressed store, requested compressed+encrypted, as when
+	// a chunk-server with --encryption reads from a compressed upstream store.
+	// Only the encryption layer should be applied.
+	c, err := NewChunkFromStorage(ChunkID{}, compressed, Converters{Compressor{}}, true)
+	require.NoError(t, err)
+	encrypted, err := c.Storage(Converters{Compressor{}, enc})
+	require.NoError(t, err)
+	decrypted, err := enc.fromStorage(encrypted)
+	require.NoError(t, err)
+	require.Equal(t, compressed, decrypted)
+
+	// The reverse: a compressed+encrypted chunk written to a compressed store.
+	// Only the encryption layer should be removed.
+	c, err = NewChunkFromStorage(ChunkID{}, encrypted, Converters{Compressor{}, enc}, true)
+	require.NoError(t, err)
+	storage, err := c.Storage(Converters{Compressor{}})
+	require.NoError(t, err)
+	require.Equal(t, compressed, storage)
+
+	// Same modifiers should return the storage data as-is.
+	storage, err = c.Storage(Converters{Compressor{}, enc})
+	require.NoError(t, err)
+	require.Equal(t, encrypted, storage)
+}

--- a/encrypt.go
+++ b/encrypt.go
@@ -17,13 +17,58 @@ import (
 // 256-bit keys.
 const EncryptionKeySize = 32
 
-// keyExtension builds the chunk file extension for an encryption
-// algorithm. It contains a key ID, the leading 4 bytes of the SHA256
-// hash of the key, to allow chunks encrypted with different keys to
-// live in the same store without conflict.
-func keyExtension(algorithm string, key []byte) string {
+// aeadConverter is an encryption layer for chunk storage. It
+// encrypts/decrypts to/from storage with an AEAD algorithm using
+// a 256-bit key. A random nonce is generated for every chunk and
+// prepended to the ciphertext.
+type aeadConverter struct {
+	algorithm string
+	key       []byte
+	aead      cipher.AEAD
+
+	// Chunk extension with identifier derived from the key.
+	extension string
+}
+
+var _ converter = aeadConverter{}
+
+// NewXChaCha20Poly1305 returns a converter that encrypts chunks with
+// XChaCha20-Poly1305 using the given 256-bit key.
+func NewXChaCha20Poly1305(key []byte) (aeadConverter, error) {
+	if err := validateKey(key); err != nil {
+		return aeadConverter{}, err
+	}
+	aead, err := chacha20poly1305.NewX(key)
+	if err != nil {
+		return aeadConverter{}, err
+	}
+	return newAEADConverter("xchacha20-poly1305", key, aead), nil
+}
+
+// NewAES256GCM returns a converter that encrypts chunks with
+// AES-256-GCM using the given 256-bit key.
+func NewAES256GCM(key []byte) (aeadConverter, error) {
+	if err := validateKey(key); err != nil {
+		return aeadConverter{}, err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return aeadConverter{}, err
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return aeadConverter{}, err
+	}
+	return newAEADConverter("aes-256-gcm", key, aead), nil
+}
+
+func newAEADConverter(algorithm string, key []byte, aead cipher.AEAD) aeadConverter {
+	// The extension contains a key ID, the leading 4 bytes of the SHA256
+	// hash of the key, to allow chunks encrypted with different keys to
+	// live in the same store without conflict.
 	keyHash := sha256.Sum256(key)
-	return fmt.Sprintf(".%s-%x", algorithm, keyHash[:4])
+	extension := fmt.Sprintf(".%s-%x", algorithm, keyHash[:4])
+	return aeadConverter{algorithm: algorithm, key: key, aead: aead, extension: extension}
 }
 
 // validateKey confirms the key is of the expected size for the
@@ -35,118 +80,34 @@ func validateKey(key []byte) error {
 	return nil
 }
 
-// sealWithRandomNonce encrypts data with a random nonce which is
-// prepended to the output.
-func sealWithRandomNonce(aead cipher.AEAD, in []byte) ([]byte, error) {
-	out := make([]byte, aead.NonceSize(), aead.NonceSize()+len(in)+aead.Overhead())
-	nonce := out[:aead.NonceSize()]
+// encrypt for storage. The nonce is prepended to the data.
+func (d aeadConverter) toStorage(in []byte) ([]byte, error) {
+	out := make([]byte, d.aead.NonceSize(), d.aead.NonceSize()+len(in)+d.aead.Overhead())
+	nonce := out[:d.aead.NonceSize()]
 	if _, err := rand.Read(nonce); err != nil {
 		return nil, err
 	}
-	return aead.Seal(out, nonce, in, nil), nil
+	return d.aead.Seal(out, nonce, in, nil), nil
 }
 
-// openWithNoncePrefix decrypts data that has the nonce prepended.
-func openWithNoncePrefix(aead cipher.AEAD, in []byte) ([]byte, error) {
-	if len(in) < aead.NonceSize() {
+// decrypt from storage. The nonce is taken from the start of the
+// chunk data.
+func (d aeadConverter) fromStorage(in []byte) ([]byte, error) {
+	if len(in) < d.aead.NonceSize() {
 		return nil, errors.New("no nonce prefix found in chunk, not encrypted or wrong algorithm")
 	}
-	nonce := in[:aead.NonceSize()]
-	return aead.Open(nil, nonce, in[aead.NonceSize():], nil)
+	nonce := in[:d.aead.NonceSize()]
+	return d.aead.Open(nil, nonce, in[d.aead.NonceSize():], nil)
 }
 
-// xchacha20poly1305 is an encryption layer for chunk storage. It
-// encrypts/decrypts to/from storage using XChaCha20-Poly1305 AEAD
-// with a 256-bit key.
-type xchacha20poly1305 struct {
-	key  []byte
-	aead cipher.AEAD
-
-	// Chunk extension with identifier derived from the key.
-	extension string
-}
-
-var _ converter = xchacha20poly1305{}
-
-// NewXChaCha20Poly1305 returns a converter that encrypts chunks with
-// XChaCha20-Poly1305 using the given 256-bit key.
-func NewXChaCha20Poly1305(key []byte) (xchacha20poly1305, error) {
-	if err := validateKey(key); err != nil {
-		return xchacha20poly1305{}, err
-	}
-	aead, err := chacha20poly1305.NewX(key)
-	return xchacha20poly1305{key: key, aead: aead, extension: keyExtension("xchacha20-poly1305", key)}, err
-}
-
-// encrypt for storage. The nonce is prepended to the data.
-func (d xchacha20poly1305) toStorage(in []byte) ([]byte, error) {
-	return sealWithRandomNonce(d.aead, in)
-}
-
-// decrypt from storage. The nonce is taken from the start of the
-// chunk data.
-func (d xchacha20poly1305) fromStorage(in []byte) ([]byte, error) {
-	return openWithNoncePrefix(d.aead, in)
-}
-
-func (d xchacha20poly1305) equal(c converter) bool {
-	other, ok := c.(xchacha20poly1305)
+func (d aeadConverter) equal(c converter) bool {
+	other, ok := c.(aeadConverter)
 	if !ok {
 		return false
 	}
-	return bytes.Equal(d.key, other.key)
+	return d.algorithm == other.algorithm && bytes.Equal(d.key, other.key)
 }
 
-func (d xchacha20poly1305) storageExtension() string {
-	return d.extension
-}
-
-// aes256gcm is an encryption layer for chunk storage. It
-// encrypts/decrypts to/from storage using AES-256-GCM with a
-// 256-bit key.
-type aes256gcm struct {
-	key  []byte
-	aead cipher.AEAD
-
-	// Chunk extension with identifier derived from the key.
-	extension string
-}
-
-var _ converter = aes256gcm{}
-
-// NewAES256GCM returns a converter that encrypts chunks with
-// AES-256-GCM using the given 256-bit key.
-func NewAES256GCM(key []byte) (aes256gcm, error) {
-	if err := validateKey(key); err != nil {
-		return aes256gcm{}, err
-	}
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return aes256gcm{}, err
-	}
-	aead, err := cipher.NewGCM(block)
-	return aes256gcm{key: key, aead: aead, extension: keyExtension("aes-256-gcm", key)}, err
-}
-
-// encrypt for storage. The nonce is prepended to the data.
-func (d aes256gcm) toStorage(in []byte) ([]byte, error) {
-	return sealWithRandomNonce(d.aead, in)
-}
-
-// decrypt from storage. The nonce is taken from the start of the
-// chunk data.
-func (d aes256gcm) fromStorage(in []byte) ([]byte, error) {
-	return openWithNoncePrefix(d.aead, in)
-}
-
-func (d aes256gcm) equal(c converter) bool {
-	other, ok := c.(aes256gcm)
-	if !ok {
-		return false
-	}
-	return bytes.Equal(d.key, other.key)
-}
-
-func (d aes256gcm) storageExtension() string {
+func (d aeadConverter) storageExtension() string {
 	return d.extension
 }

--- a/encrypt.go
+++ b/encrypt.go
@@ -1,0 +1,152 @@
+package desync
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+
+	"golang.org/x/crypto/chacha20poly1305"
+)
+
+// EncryptionKeySize is the size of the encryption key in bytes that is
+// expected by the encryption converters. All supported algorithms use
+// 256-bit keys.
+const EncryptionKeySize = 32
+
+// keyExtension builds the chunk file extension for an encryption
+// algorithm. It contains a key ID, the leading 4 bytes of the SHA256
+// hash of the key, to allow chunks encrypted with different keys to
+// live in the same store without conflict.
+func keyExtension(algorithm string, key []byte) string {
+	keyHash := sha256.Sum256(key)
+	return fmt.Sprintf(".%s-%x", algorithm, keyHash[:4])
+}
+
+// validateKey confirms the key is of the expected size for the
+// supported 256-bit algorithms.
+func validateKey(key []byte) error {
+	if len(key) != EncryptionKeySize {
+		return fmt.Errorf("encryption key must be %d bytes, got %d", EncryptionKeySize, len(key))
+	}
+	return nil
+}
+
+// sealWithRandomNonce encrypts data with a random nonce which is
+// prepended to the output.
+func sealWithRandomNonce(aead cipher.AEAD, in []byte) ([]byte, error) {
+	out := make([]byte, aead.NonceSize(), aead.NonceSize()+len(in)+aead.Overhead())
+	nonce := out[:aead.NonceSize()]
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, err
+	}
+	return aead.Seal(out, nonce, in, nil), nil
+}
+
+// openWithNoncePrefix decrypts data that has the nonce prepended.
+func openWithNoncePrefix(aead cipher.AEAD, in []byte) ([]byte, error) {
+	if len(in) < aead.NonceSize() {
+		return nil, errors.New("no nonce prefix found in chunk, not encrypted or wrong algorithm")
+	}
+	nonce := in[:aead.NonceSize()]
+	return aead.Open(nil, nonce, in[aead.NonceSize():], nil)
+}
+
+// xchacha20poly1305 is an encryption layer for chunk storage. It
+// encrypts/decrypts to/from storage using XChaCha20-Poly1305 AEAD
+// with a 256-bit key.
+type xchacha20poly1305 struct {
+	key  []byte
+	aead cipher.AEAD
+
+	// Chunk extension with identifier derived from the key.
+	extension string
+}
+
+var _ converter = xchacha20poly1305{}
+
+// NewXChaCha20Poly1305 returns a converter that encrypts chunks with
+// XChaCha20-Poly1305 using the given 256-bit key.
+func NewXChaCha20Poly1305(key []byte) (xchacha20poly1305, error) {
+	if err := validateKey(key); err != nil {
+		return xchacha20poly1305{}, err
+	}
+	aead, err := chacha20poly1305.NewX(key)
+	return xchacha20poly1305{key: key, aead: aead, extension: keyExtension("xchacha20-poly1305", key)}, err
+}
+
+// encrypt for storage. The nonce is prepended to the data.
+func (d xchacha20poly1305) toStorage(in []byte) ([]byte, error) {
+	return sealWithRandomNonce(d.aead, in)
+}
+
+// decrypt from storage. The nonce is taken from the start of the
+// chunk data.
+func (d xchacha20poly1305) fromStorage(in []byte) ([]byte, error) {
+	return openWithNoncePrefix(d.aead, in)
+}
+
+func (d xchacha20poly1305) equal(c converter) bool {
+	other, ok := c.(xchacha20poly1305)
+	if !ok {
+		return false
+	}
+	return bytes.Equal(d.key, other.key)
+}
+
+func (d xchacha20poly1305) storageExtension() string {
+	return d.extension
+}
+
+// aes256gcm is an encryption layer for chunk storage. It
+// encrypts/decrypts to/from storage using AES-256-GCM with a
+// 256-bit key.
+type aes256gcm struct {
+	key  []byte
+	aead cipher.AEAD
+
+	// Chunk extension with identifier derived from the key.
+	extension string
+}
+
+var _ converter = aes256gcm{}
+
+// NewAES256GCM returns a converter that encrypts chunks with
+// AES-256-GCM using the given 256-bit key.
+func NewAES256GCM(key []byte) (aes256gcm, error) {
+	if err := validateKey(key); err != nil {
+		return aes256gcm{}, err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return aes256gcm{}, err
+	}
+	aead, err := cipher.NewGCM(block)
+	return aes256gcm{key: key, aead: aead, extension: keyExtension("aes-256-gcm", key)}, err
+}
+
+// encrypt for storage. The nonce is prepended to the data.
+func (d aes256gcm) toStorage(in []byte) ([]byte, error) {
+	return sealWithRandomNonce(d.aead, in)
+}
+
+// decrypt from storage. The nonce is taken from the start of the
+// chunk data.
+func (d aes256gcm) fromStorage(in []byte) ([]byte, error) {
+	return openWithNoncePrefix(d.aead, in)
+}
+
+func (d aes256gcm) equal(c converter) bool {
+	other, ok := c.(aes256gcm)
+	if !ok {
+		return false
+	}
+	return bytes.Equal(d.key, other.key)
+}
+
+func (d aes256gcm) storageExtension() string {
+	return d.extension
+}

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -9,6 +9,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Hex-encoded 256-bit keys used in encryption tests.
+const (
+	testEncryptionKey  = "6368616e676520746869732070617373776f726420746f206120736563726574"
+	otherEncryptionKey = "746f74616c6c7920646966666572656e74206b65792075736564206865726521"
+)
+
 func testKey(t *testing.T, s string) []byte {
 	key, err := hex.DecodeString(s)
 	require.NoError(t, err)

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -1,0 +1,92 @@
+package desync
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testKey(t *testing.T, s string) []byte {
+	key, err := hex.DecodeString(s)
+	require.NoError(t, err)
+	return key
+}
+
+func TestEncryptDecrypt(t *testing.T) {
+	tests := map[string]struct {
+		alg func([]byte) (converter, error)
+	}{
+		"xchacha20-poly1305": {func(key []byte) (converter, error) { return NewXChaCha20Poly1305(key) }},
+		"aes-256-gcm":        {func(key []byte) (converter, error) { return NewAES256GCM(key) }},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			plainIn := []byte{1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
+
+			// Make two converters. One for encryption and one for decryption. Could use
+			// just one but this way we confirm the setup from a key is consistent
+			enc, err := test.alg(testKey(t, testEncryptionKey))
+			require.NoError(t, err)
+			dec, err := test.alg(testKey(t, testEncryptionKey))
+			require.NoError(t, err)
+
+			// Encrypt the data
+			ciphertext, err := enc.toStorage(plainIn)
+			require.NoError(t, err)
+
+			// Confirm the ciphertext is actually different than what went in
+			require.NotEqual(t, plainIn, ciphertext)
+
+			// Decrypt it
+			plainOut, err := dec.fromStorage(ciphertext)
+			require.NoError(t, err)
+
+			// This should match the original data of course
+			require.Equal(t, plainIn, plainOut)
+
+			// Make another instance with a different key
+			diffKey, err := test.alg(testKey(t, otherEncryptionKey))
+			require.NoError(t, err)
+
+			// Try to decrypt the data, should get an error from AEAD algorithms
+			_, err = diffKey.fromStorage(ciphertext)
+			require.Error(t, err)
+
+			// Keys need to be 256-bit, anything else should be rejected
+			_, err = test.alg([]byte("too short"))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestAES256GCMCompare(t *testing.T) {
+	// Make three converters. Two with the same, one with a diff key
+	enc1, err := NewAES256GCM(testKey(t, testEncryptionKey))
+	require.NoError(t, err)
+	enc2, err := NewAES256GCM(testKey(t, testEncryptionKey))
+	require.NoError(t, err)
+	diffKey, err := NewAES256GCM(testKey(t, otherEncryptionKey))
+	require.NoError(t, err)
+
+	// Check equality method
+	require.True(t, enc1.equal(enc2))
+	require.True(t, enc2.equal(enc1))
+	require.False(t, diffKey.equal(enc1))
+	require.False(t, enc1.equal(diffKey))
+}
+
+func TestAES256GCMExtension(t *testing.T) {
+	enc1, err := NewAES256GCM(testKey(t, testEncryptionKey))
+	require.NoError(t, err)
+
+	// Confirm that we have a key-handle in the file extension
+	require.Equal(t, ".aes-256-gcm-50d64035", enc1.extension)
+
+	// If algorithm and key are the same, the same key handle
+	// (extension) should be produced every time
+	enc2, err := NewAES256GCM(testKey(t, testEncryptionKey))
+	require.NoError(t, err)
+	require.Equal(t, enc1.extension, enc2.extension)
+}

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -2,8 +2,10 @@ package desync
 
 import (
 	"encoding/hex"
+	"net/url"
 	"testing"
 
+	"github.com/minio/minio-go/v6"
 	"github.com/stretchr/testify/require"
 )
 
@@ -95,6 +97,34 @@ func TestAES256GCMExtension(t *testing.T) {
 	enc2, err := NewAES256GCM(testKey(t, testEncryptionKey))
 	require.NoError(t, err)
 	require.Equal(t, enc1.extension, enc2.extension)
+}
+
+// Indexes are always stored in plain form, encryption options need to be
+// rejected by index stores rather than silently ignored, for example when
+// a config entry matches a location used for both chunks and indexes.
+func TestIndexStoresRejectEncryption(t *testing.T) {
+	opt := StoreOptions{Encryption: true, EncryptionKey: testEncryptionKey}
+
+	tests := map[string]struct {
+		location string
+		newStore func(*url.URL) (IndexStore, error)
+	}{
+		"sftp": {"sftp://host/store", func(u *url.URL) (IndexStore, error) { return NewSFTPIndexStore(u, opt) }},
+		"http": {"https://host/store", func(u *url.URL) (IndexStore, error) { return NewRemoteHTTPIndexStore(u, opt) }},
+		"s3": {"s3+https://host/bucket", func(u *url.URL) (IndexStore, error) {
+			return NewS3IndexStore(u, nil, "", opt, minio.BucketLookupAuto)
+		}},
+		"gs": {"gs://bucket/prefix", func(u *url.URL) (IndexStore, error) { return NewGCIndexStore(u, opt) }},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			u, err := url.Parse(test.location)
+			require.NoError(t, err)
+			_, err = test.newStore(u)
+			require.ErrorContains(t, err, "not supported by index stores")
+		})
+	}
 }
 
 func TestStorageConvertersValidation(t *testing.T) {

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -90,3 +90,28 @@ func TestAES256GCMExtension(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, enc1.extension, enc2.extension)
 }
+
+func TestStorageConvertersValidation(t *testing.T) {
+	tests := map[string]struct {
+		opt StoreOptions
+		err string
+	}{
+		"key without encryption flag":       {StoreOptions{EncryptionKey: testEncryptionKey}, "without setting encryption to true"},
+		"algorithm without encryption flag": {StoreOptions{EncryptionAlgorithm: "aes-256-gcm"}, "without setting encryption to true"},
+		"encryption without key":            {StoreOptions{Encryption: true}, "no encryption key configured"},
+		"invalid key encoding":              {StoreOptions{Encryption: true, EncryptionKey: "not-hex"}, "invalid encryption key"},
+		"unsupported algorithm":             {StoreOptions{Encryption: true, EncryptionKey: testEncryptionKey, EncryptionAlgorithm: "rot13"}, "unsupported encryption algorithm"},
+		"valid":                             {StoreOptions{Encryption: true, EncryptionKey: testEncryptionKey}, ""},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := test.opt.StorageConverters()
+			if test.err == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.err)
+			}
+		})
+	}
+}

--- a/encrypt_test.go
+++ b/encrypt_test.go
@@ -75,6 +75,12 @@ func TestAES256GCMCompare(t *testing.T) {
 	require.True(t, enc2.equal(enc1))
 	require.False(t, diffKey.equal(enc1))
 	require.False(t, enc1.equal(diffKey))
+
+	// A different algorithm with the same key must not be equal either
+	diffAlg, err := NewXChaCha20Poly1305(testKey(t, testEncryptionKey))
+	require.NoError(t, err)
+	require.False(t, enc1.equal(diffAlg))
+	require.False(t, diffAlg.equal(enc1))
 }
 
 func TestAES256GCMExtension(t *testing.T) {

--- a/errors.go
+++ b/errors.go
@@ -20,14 +20,26 @@ func (e NoSuchObject) Error() string {
 	return fmt.Sprintf("object %s missing from store", e.location)
 }
 
-// ChunkInvalid means the hash of the chunk content doesn't match its ID
+// ChunkInvalid means the chunk failed validation, either because the hash
+// of its content doesn't match its ID, or because the storage data couldn't
+// be converted to plain data in the first place, for example when
+// decryption or decompression fails. In the latter case Err holds the
+// conversion error.
 type ChunkInvalid struct {
 	ID  ChunkID
 	Sum ChunkID
+	Err error
 }
 
 func (e ChunkInvalid) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("invalid chunk %s: %s", e.ID.String(), e.Err)
+	}
 	return fmt.Sprintf("chunk id %s does not match its hash %s", e.ID.String(), e.Sum.String())
+}
+
+func (e ChunkInvalid) Unwrap() error {
+	return e.Err
 }
 
 // InvalidFormat is returned when an error occurred when parsing an archive file

--- a/gcs.go
+++ b/gcs.go
@@ -25,6 +25,9 @@ type GCStoreBase struct {
 	prefix     string
 	opt        StoreOptions
 	converters Converters
+
+	// Chunk file extension, derived from the converters at construction
+	extension string
 }
 
 // GCStore is a read-write store with Google Storage backing
@@ -58,7 +61,7 @@ func NewGCStoreBase(u *url.URL, opt StoreOptions) (GCStoreBase, error) {
 	if err != nil {
 		return GCStoreBase{}, err
 	}
-	s := GCStoreBase{Location: u.String(), opt: opt, converters: converters}
+	s := GCStoreBase{Location: u.String(), opt: opt, converters: converters, extension: converters.storageExtension()}
 	if u.Scheme != "gs" {
 		return s, fmt.Errorf("invalid scheme '%s', expected 'gs'", u.Scheme)
 	}
@@ -253,16 +256,15 @@ func (s GCStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 
 func (s GCStore) nameFromID(id ChunkID) string {
 	sID := id.String()
-	name := s.prefix + sID[0:4] + "/" + sID + s.converters.storageExtension()
+	name := s.prefix + sID[0:4] + "/" + sID + s.extension
 	return name
 }
 
 func (s GCStore) idFromName(name string) (ChunkID, error) {
-	extension := s.converters.storageExtension()
-	if !strings.HasSuffix(name, extension) {
+	if !strings.HasSuffix(name, s.extension) {
 		return ChunkID{}, fmt.Errorf("object %s is not a chunk", name)
 	}
-	n := strings.TrimSuffix(strings.TrimPrefix(name, s.prefix), extension)
+	n := strings.TrimSuffix(strings.TrimPrefix(name, s.prefix), s.extension)
 	fragments := strings.Split(n, "/")
 	if len(fragments) != 2 {
 		return ChunkID{}, fmt.Errorf("incorrect chunk name for object %s", name)

--- a/gcs.go
+++ b/gcs.go
@@ -239,7 +239,7 @@ func (s GCStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 			return err
 		}
 
-		id, err := s.idFromName(attrs.Name)
+		id, err := chunkIDFromObjectName(attrs.Name, s.prefix, s.extension)
 		if err != nil {
 			continue
 		}
@@ -258,16 +258,4 @@ func (s GCStore) nameFromID(id ChunkID) string {
 	sID := id.String()
 	name := s.prefix + sID[0:4] + "/" + sID + s.extension
 	return name
-}
-
-func (s GCStore) idFromName(name string) (ChunkID, error) {
-	fragments := strings.Split(strings.TrimPrefix(name, s.prefix), "/")
-	if len(fragments) != 2 || !strings.HasPrefix(fragments[1], fragments[0]) {
-		return ChunkID{}, fmt.Errorf("incorrect chunk name for object %s", name)
-	}
-	id, ok := chunkIDFromFilename(fragments[1], s.extension)
-	if !ok {
-		return ChunkID{}, fmt.Errorf("object %s is not a chunk", name)
-	}
-	return id, nil
 }

--- a/gcs.go
+++ b/gcs.go
@@ -261,18 +261,13 @@ func (s GCStore) nameFromID(id ChunkID) string {
 }
 
 func (s GCStore) idFromName(name string) (ChunkID, error) {
-	if !strings.HasSuffix(name, s.extension) {
+	fragments := strings.Split(strings.TrimPrefix(name, s.prefix), "/")
+	if len(fragments) != 2 || !strings.HasPrefix(fragments[1], fragments[0]) {
+		return ChunkID{}, fmt.Errorf("incorrect chunk name for object %s", name)
+	}
+	id, ok := chunkIDFromFilename(fragments[1], s.extension)
+	if !ok {
 		return ChunkID{}, fmt.Errorf("object %s is not a chunk", name)
 	}
-	n := strings.TrimSuffix(strings.TrimPrefix(name, s.prefix), s.extension)
-	fragments := strings.Split(n, "/")
-	if len(fragments) != 2 {
-		return ChunkID{}, fmt.Errorf("incorrect chunk name for object %s", name)
-	}
-	idx := fragments[0]
-	sid := fragments[1]
-	if !strings.HasPrefix(sid, idx) {
-		return ChunkID{}, fmt.Errorf("incorrect chunk name for object %s", name)
-	}
-	return ChunkIDFromString(sid)
+	return id, nil
 }

--- a/gcs.go
+++ b/gcs.go
@@ -53,9 +53,12 @@ func normalizeGCPrefix(path string) string {
 // NewGCStoreBase initializes a base object used for chunk or index stores
 // backed by Google Storage.
 func NewGCStoreBase(u *url.URL, opt StoreOptions) (GCStoreBase, error) {
-	var err error
 	ctx := context.TODO()
-	s := GCStoreBase{Location: u.String(), opt: opt, converters: opt.converters()}
+	converters, err := opt.StorageConverters()
+	if err != nil {
+		return GCStoreBase{}, err
+	}
+	s := GCStoreBase{Location: u.String(), opt: opt, converters: converters}
 	if u.Scheme != "gs" {
 		return s, fmt.Errorf("invalid scheme '%s', expected 'gs'", u.Scheme)
 	}
@@ -250,28 +253,16 @@ func (s GCStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 
 func (s GCStore) nameFromID(id ChunkID) string {
 	sID := id.String()
-	name := s.prefix + sID[0:4] + "/" + sID
-	if s.opt.Uncompressed {
-		name += UncompressedChunkExt
-	} else {
-		name += CompressedChunkExt
-	}
+	name := s.prefix + sID[0:4] + "/" + sID + s.converters.storageExtension()
 	return name
 }
 
 func (s GCStore) idFromName(name string) (ChunkID, error) {
-	var n string
-	if s.opt.Uncompressed {
-		if !strings.HasSuffix(name, UncompressedChunkExt) {
-			return ChunkID{}, fmt.Errorf("object %s is not a chunk", name)
-		}
-		n = strings.TrimSuffix(strings.TrimPrefix(name, s.prefix), UncompressedChunkExt)
-	} else {
-		if !strings.HasSuffix(name, CompressedChunkExt) {
-			return ChunkID{}, fmt.Errorf("object %s is not a chunk", name)
-		}
-		n = strings.TrimSuffix(strings.TrimPrefix(name, s.prefix), CompressedChunkExt)
+	extension := s.converters.storageExtension()
+	if !strings.HasSuffix(name, extension) {
+		return ChunkID{}, fmt.Errorf("object %s is not a chunk", name)
 	}
+	n := strings.TrimSuffix(strings.TrimPrefix(name, s.prefix), extension)
 	fragments := strings.Split(n, "/")
 	if len(fragments) != 2 {
 		return ChunkID{}, fmt.Errorf("incorrect chunk name for object %s", name)

--- a/gcsindex.go
+++ b/gcsindex.go
@@ -19,6 +19,9 @@ type GCIndexStore struct {
 // NewGCIndexStore creates an index store with Google Storage backing. The URL
 // should be provided like this: gc://bucket/prefix
 func NewGCIndexStore(location *url.URL, opt StoreOptions) (s GCIndexStore, e error) {
+	if err := opt.ValidateIndexOptions(); err != nil {
+		return s, err
+	}
 	b, err := NewGCStoreBase(location, opt)
 	if err != nil {
 		return s, err

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/crypto v0.52.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.45.0
 	golang.org/x/term v0.43.0
@@ -77,7 +78,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
-	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/text v0.37.0 // indirect

--- a/httphandler.go
+++ b/httphandler.go
@@ -21,11 +21,14 @@ type HTTPHandler struct {
 
 	// Storage-side of the converters in this case is towards the client
 	converters Converters
+
+	// Chunk file extension, derived from the converters at construction
+	extension string
 }
 
 // NewHTTPHandler initializes and returns a new HTTP handler for a chunks server.
 func NewHTTPHandler(s Store, writable, skipVerifyWrite bool, converters Converters, auth string) http.Handler {
-	return HTTPHandler{HTTPHandlerBase{"chunk", writable, auth}, s, skipVerifyWrite, converters}
+	return HTTPHandler{HTTPHandlerBase{"chunk", writable, auth}, s, skipVerifyWrite, converters, converters.storageExtension()}
 }
 
 func (h HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -113,7 +116,7 @@ func (h HTTPHandler) put(id ChunkID, w http.ResponseWriter, r *http.Request) {
 }
 
 func (h HTTPHandler) idFromPath(p string) (ChunkID, error) {
-	ext := h.converters.storageExtension()
+	ext := h.extension
 	if !strings.HasSuffix(p, ext) {
 		return ChunkID{}, errors.New("invalid chunk extension, verify compression and encryption settings")
 	}

--- a/httphandler.go
+++ b/httphandler.go
@@ -115,9 +115,16 @@ func (h HTTPHandler) put(id ChunkID, w http.ResponseWriter, r *http.Request) {
 func (h HTTPHandler) idFromPath(p string) (ChunkID, error) {
 	ext := h.converters.storageExtension()
 	if !strings.HasSuffix(p, ext) {
-		return ChunkID{}, errors.New("invalid chunk type, verify compression and encryption settings")
+		return ChunkID{}, errors.New("invalid chunk extension, verify compression and encryption settings")
 	}
 	sID := strings.TrimSuffix(path.Base(p), ext)
+	// Chunk IDs are hex-encoded and never contain a '.'. Any extension left
+	// after trimming means the client requested a chunk in a format this
+	// server doesn't serve. The suffix check above can't catch that when
+	// the server's own extension is empty (uncompressed, unencrypted).
+	if strings.Contains(sID, ".") {
+		return ChunkID{}, fmt.Errorf("requested chunk with an unexpected file extension, this server expects '<chunkid>%s', verify compression and encryption settings", ext)
+	}
 	if len(sID) < 4 {
 		return ChunkID{}, fmt.Errorf("expected format '/<prefix>/<chunkid>%s", ext)
 	}

--- a/httphandler.go
+++ b/httphandler.go
@@ -21,15 +21,11 @@ type HTTPHandler struct {
 
 	// Storage-side of the converters in this case is towards the client
 	converters Converters
-
-	// Use the file extension for compressed chunks
-	compressed bool
 }
 
 // NewHTTPHandler initializes and returns a new HTTP handler for a chunks server.
 func NewHTTPHandler(s Store, writable, skipVerifyWrite bool, converters Converters, auth string) http.Handler {
-	compressed := converters.hasCompression()
-	return HTTPHandler{HTTPHandlerBase{"chunk", writable, auth}, s, skipVerifyWrite, converters, compressed}
+	return HTTPHandler{HTTPHandlerBase{"chunk", writable, auth}, s, skipVerifyWrite, converters}
 }
 
 func (h HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -117,12 +113,9 @@ func (h HTTPHandler) put(id ChunkID, w http.ResponseWriter, r *http.Request) {
 }
 
 func (h HTTPHandler) idFromPath(p string) (ChunkID, error) {
-	ext := CompressedChunkExt
-	if !h.compressed {
-		if strings.HasSuffix(p, CompressedChunkExt) {
-			return ChunkID{}, errors.New("compressed chunk requested from http chunk store serving uncompressed chunks")
-		}
-		ext = UncompressedChunkExt
+	ext := h.converters.storageExtension()
+	if !strings.HasSuffix(p, ext) {
+		return ChunkID{}, errors.New("invalid chunk type, verify compression and encryption settings")
 	}
 	sID := strings.TrimSuffix(path.Base(p), ext)
 	if len(sID) < 4 {

--- a/httphandler_test.go
+++ b/httphandler_test.go
@@ -144,3 +144,19 @@ func TestHTTPHandlerEncryption(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, dataIn, dataOut)
 }
+
+func TestHTTPHandlerExtensionMismatch(t *testing.T) {
+	chunkID := NewChunk([]byte("some data")).ID()
+	id := chunkID.String()
+
+	// A server without compression or encryption has no chunk file extension.
+	// Asking it for a compressed chunk has to fail with an error that points
+	// at the mismatch, not with an ID parse error.
+	h := HTTPHandler{}
+	_, err := h.idFromPath("/" + id[0:4] + "/" + id + ".cacnk")
+	require.ErrorContains(t, err, "compression and encryption settings")
+
+	// The same path without the extension is accepted
+	_, err = h.idFromPath("/" + id[0:4] + "/" + id)
+	require.NoError(t, err)
+}

--- a/httphandler_test.go
+++ b/httphandler_test.go
@@ -1,7 +1,6 @@
 package desync
 
 import (
-	"encoding/hex"
 	"net/http/httptest"
 	"net/url"
 	"testing"
@@ -112,9 +111,7 @@ func TestHTTPHandlerEncryption(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start a read-write capable server with Encryption, no Compression
-	key, err := hex.DecodeString(testEncryptionKey)
-	require.NoError(t, err)
-	enc, err := NewXChaCha20Poly1305(key)
+	enc, err := NewXChaCha20Poly1305(testKey(t, testEncryptionKey))
 	require.NoError(t, err)
 	server := httptest.NewServer(NewHTTPHandler(upstream, true, false, []converter{enc}, ""))
 	defer server.Close()

--- a/httphandler_test.go
+++ b/httphandler_test.go
@@ -1,6 +1,7 @@
 package desync
 
 import (
+	"encoding/hex"
 	"net/http/httptest"
 	"net/url"
 	"testing"
@@ -102,4 +103,44 @@ func TestHTTPHandlerCompression(t *testing.T) {
 	// Try to get the uncompressed chunk
 	_, err = unStore.GetChunk(id)
 	require.NoError(t, err)
+}
+
+func TestHTTPHandlerEncryption(t *testing.T) {
+	// Prep a local store (no encryption)
+	store := t.TempDir()
+	upstream, err := NewLocalStore(store, StoreOptions{})
+	require.NoError(t, err)
+
+	// Start a read-write capable server with Encryption, no Compression
+	key, err := hex.DecodeString(testEncryptionKey)
+	require.NoError(t, err)
+	enc, err := NewXChaCha20Poly1305(key)
+	require.NoError(t, err)
+	server := httptest.NewServer(NewHTTPHandler(upstream, true, false, []converter{enc}, ""))
+	defer server.Close()
+
+	// Initialize HTTP chunks store (client)
+	httpStoreURL, _ := url.Parse(server.URL)
+	httpStore, err := NewRemoteHTTPStore(httpStoreURL, StoreOptions{
+		Uncompressed:  true,
+		Encryption:    true,
+		EncryptionKey: testEncryptionKey,
+	})
+	require.NoError(t, err)
+
+	// Make up some data and store it in the RW store
+	dataIn := []byte("some data")
+	chunkIn := NewChunk(dataIn)
+	id := chunkIn.ID()
+
+	// Write a chunk via HTTP
+	err = httpStore.StoreChunk(chunkIn)
+	require.NoError(t, err)
+
+	// Read it back via HTTP and compare to the original
+	chunkOut, err := httpStore.GetChunk(id)
+	require.NoError(t, err)
+	dataOut, err := chunkOut.Data()
+	require.NoError(t, err)
+	require.Equal(t, dataIn, dataOut)
 }

--- a/local.go
+++ b/local.go
@@ -41,7 +41,11 @@ func NewLocalStore(dir string, opt StoreOptions) (LocalStore, error) {
 	if !info.IsDir() {
 		return LocalStore{}, fmt.Errorf("%s is not a directory", dir)
 	}
-	return LocalStore{Base: dir, Opt: opt, converters: opt.converters()}, nil
+	converters, err := opt.StorageConverters()
+	if err != nil {
+		return LocalStore{}, err
+	}
+	return LocalStore{Base: dir, Opt: opt, converters: converters}, nil
 }
 
 // GetChunk reads and returns one (compressed!) chunk from the store
@@ -125,6 +129,7 @@ func (s LocalStore) Verify(ctx context.Context, n int, repair bool, w io.Writer)
 
 	// Go through all chunks underneath Base, filtering out other files, then feed
 	// the IDs to the workers
+	extension := s.converters.storageExtension()
 	err := filepath.Walk(s.Base, func(path string, info os.FileInfo, err error) error {
 		// See if we're meant to stop
 		select {
@@ -138,19 +143,12 @@ func (s LocalStore) Verify(ctx context.Context, n int, repair bool, w io.Writer)
 		if info.IsDir() { // Skip dirs
 			return nil
 		}
-		// Skip compressed chunks if this is running in uncompressed mode and vice-versa
-		var sID string
-		if s.Opt.Uncompressed {
-			if !strings.HasSuffix(path, UncompressedChunkExt) {
-				return nil
-			}
-			sID = strings.TrimSuffix(filepath.Base(path), UncompressedChunkExt)
-		} else {
-			if !strings.HasSuffix(path, CompressedChunkExt) {
-				return nil
-			}
-			sID = strings.TrimSuffix(filepath.Base(path), CompressedChunkExt)
+		// Skip chunks that don't match the store's extension, they may use
+		// different compression or encryption settings
+		if !strings.HasSuffix(filepath.Base(path), extension) {
+			return nil
 		}
+		sID := strings.TrimSuffix(filepath.Base(path), extension)
 		// Convert the name into a checksum, if that fails we're probably not looking
 		// at a chunk file and should skip it.
 		id, err := ChunkIDFromString(sID)
@@ -169,6 +167,7 @@ func (s LocalStore) Verify(ctx context.Context, n int, repair bool, w io.Writer)
 // Prune removes any chunks from the store that are not contained in a list
 // of chunks
 func (s LocalStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
+	extension := s.converters.storageExtension()
 	// Go through all chunks underneath Base, filtering out other directories and files
 	err := filepath.Walk(s.Base, func(path string, info os.FileInfo, err error) error {
 		// See if we're meant to stop
@@ -189,20 +188,12 @@ func (s LocalStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 			_ = os.Remove(path)
 			return nil
 		}
-
-		// Skip compressed chunks if this is running in uncompressed mode and vice-versa
-		var sID string
-		if s.Opt.Uncompressed {
-			if !strings.HasSuffix(path, UncompressedChunkExt) {
-				return nil
-			}
-			sID = strings.TrimSuffix(filepath.Base(path), UncompressedChunkExt)
-		} else {
-			if !strings.HasSuffix(path, CompressedChunkExt) {
-				return nil
-			}
-			sID = strings.TrimSuffix(filepath.Base(path), CompressedChunkExt)
+		// Skip chunks that don't match the store's extension, they may use
+		// different compression or encryption settings
+		if !strings.HasSuffix(filepath.Base(path), extension) {
+			return nil
 		}
+		sID := strings.TrimSuffix(filepath.Base(path), extension)
 		// Convert the name into a checksum, if that fails we're probably not looking
 		// at a chunk file and should skip it.
 		id, err := ChunkIDFromString(sID)
@@ -254,11 +245,6 @@ func (s LocalStore) GetChunkSize(id ChunkID) (int64, error) {
 func (s LocalStore) nameFromID(id ChunkID) (dir, name string) {
 	sID := id.String()
 	dir = filepath.Join(s.Base, sID[0:4])
-	name = filepath.Join(dir, sID)
-	if s.Opt.Uncompressed {
-		name += UncompressedChunkExt
-	} else {
-		name += CompressedChunkExt
-	}
+	name = filepath.Join(dir, sID) + s.converters.storageExtension()
 	return
 }

--- a/local.go
+++ b/local.go
@@ -29,6 +29,9 @@ type LocalStore struct {
 	Opt StoreOptions
 
 	converters Converters
+
+	// Chunk file extension, derived from the converters at construction
+	extension string
 }
 
 // NewLocalStore creates an instance of a local castore, it only checks presence
@@ -45,7 +48,7 @@ func NewLocalStore(dir string, opt StoreOptions) (LocalStore, error) {
 	if err != nil {
 		return LocalStore{}, err
 	}
-	return LocalStore{Base: dir, Opt: opt, converters: converters}, nil
+	return LocalStore{Base: dir, Opt: opt, converters: converters, extension: converters.storageExtension()}, nil
 }
 
 // GetChunk reads and returns one (compressed!) chunk from the store
@@ -129,7 +132,6 @@ func (s LocalStore) Verify(ctx context.Context, n int, repair bool, w io.Writer)
 
 	// Go through all chunks underneath Base, filtering out other files, then feed
 	// the IDs to the workers
-	extension := s.converters.storageExtension()
 	err := filepath.Walk(s.Base, func(path string, info os.FileInfo, err error) error {
 		// See if we're meant to stop
 		select {
@@ -145,10 +147,10 @@ func (s LocalStore) Verify(ctx context.Context, n int, repair bool, w io.Writer)
 		}
 		// Skip chunks that don't match the store's extension, they may use
 		// different compression or encryption settings
-		if !strings.HasSuffix(filepath.Base(path), extension) {
+		if !strings.HasSuffix(filepath.Base(path), s.extension) {
 			return nil
 		}
-		sID := strings.TrimSuffix(filepath.Base(path), extension)
+		sID := strings.TrimSuffix(filepath.Base(path), s.extension)
 		// Convert the name into a checksum, if that fails we're probably not looking
 		// at a chunk file and should skip it.
 		id, err := ChunkIDFromString(sID)
@@ -167,7 +169,6 @@ func (s LocalStore) Verify(ctx context.Context, n int, repair bool, w io.Writer)
 // Prune removes any chunks from the store that are not contained in a list
 // of chunks
 func (s LocalStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
-	extension := s.converters.storageExtension()
 	// Go through all chunks underneath Base, filtering out other directories and files
 	err := filepath.Walk(s.Base, func(path string, info os.FileInfo, err error) error {
 		// See if we're meant to stop
@@ -190,10 +191,10 @@ func (s LocalStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 		}
 		// Skip chunks that don't match the store's extension, they may use
 		// different compression or encryption settings
-		if !strings.HasSuffix(filepath.Base(path), extension) {
+		if !strings.HasSuffix(filepath.Base(path), s.extension) {
 			return nil
 		}
-		sID := strings.TrimSuffix(filepath.Base(path), extension)
+		sID := strings.TrimSuffix(filepath.Base(path), s.extension)
 		// Convert the name into a checksum, if that fails we're probably not looking
 		// at a chunk file and should skip it.
 		id, err := ChunkIDFromString(sID)
@@ -245,6 +246,6 @@ func (s LocalStore) GetChunkSize(id ChunkID) (int64, error) {
 func (s LocalStore) nameFromID(id ChunkID) (dir, name string) {
 	sID := id.String()
 	dir = filepath.Join(s.Base, sID[0:4])
-	name = filepath.Join(dir, sID) + s.converters.storageExtension()
+	name = filepath.Join(dir, sID) + s.extension
 	return
 }

--- a/local.go
+++ b/local.go
@@ -145,16 +145,10 @@ func (s LocalStore) Verify(ctx context.Context, n int, repair bool, w io.Writer)
 		if info.IsDir() { // Skip dirs
 			return nil
 		}
-		// Skip chunks that don't match the store's extension, they may use
-		// different compression or encryption settings
-		if !strings.HasSuffix(filepath.Base(path), s.extension) {
-			return nil
-		}
-		sID := strings.TrimSuffix(filepath.Base(path), s.extension)
-		// Convert the name into a checksum, if that fails we're probably not looking
-		// at a chunk file and should skip it.
-		id, err := ChunkIDFromString(sID)
-		if err != nil {
+		// Skip files that aren't chunks matching the store's extension, they
+		// may use different compression or encryption settings
+		id, ok := chunkIDFromFilename(filepath.Base(path), s.extension)
+		if !ok {
 			return nil
 		}
 		// Feed the workers
@@ -189,16 +183,10 @@ func (s LocalStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 			_ = os.Remove(path)
 			return nil
 		}
-		// Skip chunks that don't match the store's extension, they may use
-		// different compression or encryption settings
-		if !strings.HasSuffix(filepath.Base(path), s.extension) {
-			return nil
-		}
-		sID := strings.TrimSuffix(filepath.Base(path), s.extension)
-		// Convert the name into a checksum, if that fails we're probably not looking
-		// at a chunk file and should skip it.
-		id, err := ChunkIDFromString(sID)
-		if err != nil {
+		// Skip files that aren't chunks matching the store's extension, they
+		// may use different compression or encryption settings
+		id, ok := chunkIDFromFilename(filepath.Base(path), s.extension)
+		if !ok {
 			return nil
 		}
 		// See if the chunk we're looking at is in the list we want to keep, if not

--- a/local_test.go
+++ b/local_test.go
@@ -2,7 +2,6 @@ package desync
 
 import (
 	"context"
-	"encoding/hex"
 	"io"
 	"os"
 	"testing"
@@ -263,9 +262,7 @@ func TestLocalStoreCompressedEncrypted(t *testing.T) {
 	require.NoError(t, err)
 
 	// First decrypt it, using the correct key
-	key, err := hex.DecodeString(testEncryptionKey)
-	require.NoError(t, err)
-	dec, err := NewXChaCha20Poly1305(key)
+	dec, err := NewXChaCha20Poly1305(testKey(t, testEncryptionKey))
 	require.NoError(t, err)
 	decrypted, err := dec.fromStorage(b)
 	require.NoError(t, err)

--- a/local_test.go
+++ b/local_test.go
@@ -2,6 +2,7 @@ package desync
 
 import (
 	"context"
+	"encoding/hex"
 	"io"
 	"os"
 	"testing"
@@ -167,4 +168,154 @@ func TestLocalStoreGetChunkReadError(t *testing.T) {
 	require.Error(t, err)
 	require.NotErrorAs(t, err, &ChunkMissing{})
 	require.NotErrorAs(t, err, &ChunkInvalid{})
+}
+
+// Hex-encoded 256-bit keys used in encryption tests.
+const (
+	testEncryptionKey  = "6368616e676520746869732070617373776f726420746f206120736563726574"
+	otherEncryptionKey = "746f74616c6c7920646966666572656e74206b65792075736564206865726521"
+)
+
+func TestLocalStoreUncompressedEncrypted(t *testing.T) {
+	store := t.TempDir()
+
+	s, err := NewLocalStore(store,
+		StoreOptions{
+			Uncompressed:  true,
+			Encryption:    true,
+			EncryptionKey: testEncryptionKey,
+		},
+	)
+	require.NoError(t, err)
+
+	// Make up some data and store it
+	dataIn := []byte("some data")
+
+	chunkIn := NewChunk(dataIn)
+	id := chunkIn.ID()
+
+	err = s.StoreChunk(chunkIn)
+	require.NoError(t, err)
+
+	// Check it's in the store
+	hasChunk, err := s.HasChunk(id)
+	require.NoError(t, err)
+	require.True(t, hasChunk, "chunk not found in store")
+
+	// Pull the data the "official" way
+	chunkOut, err := s.GetChunk(id)
+	require.NoError(t, err)
+
+	dataOut, err := chunkOut.Data()
+	require.NoError(t, err)
+
+	// Compare the data that went in with what came out
+	require.Equal(t, dataIn, dataOut)
+
+	// Now let's look at the file in the store directly to make sure it's actually
+	// encrypted, meaning it should not match the plain (uncompressed) text
+	_, name := s.nameFromID(id)
+	b, err := os.ReadFile(name)
+	require.NoError(t, err)
+	require.NotEqual(t, dataIn, b, "chunk is not encrypted")
+}
+
+func TestLocalStoreCompressedEncrypted(t *testing.T) {
+	store := t.TempDir()
+
+	s, err := NewLocalStore(store,
+		StoreOptions{
+			Uncompressed:  false,
+			Encryption:    true,
+			EncryptionKey: testEncryptionKey,
+		},
+	)
+	require.NoError(t, err)
+
+	// Make up some data and store it
+	dataIn := []byte("some data")
+
+	chunkIn := NewChunk(dataIn)
+	id := chunkIn.ID()
+
+	err = s.StoreChunk(chunkIn)
+	require.NoError(t, err)
+
+	// Check it's in the store
+	hasChunk, err := s.HasChunk(id)
+	require.NoError(t, err)
+	require.True(t, hasChunk, "chunk not found in store")
+
+	// Pull the data the "official" way
+	chunkOut, err := s.GetChunk(id)
+	require.NoError(t, err)
+
+	dataOut, err := chunkOut.Data()
+	require.NoError(t, err)
+
+	// Compare the data that went in with what came out
+	require.Equal(t, dataIn, dataOut)
+
+	// Now let's look at the file in the store directly and confirm it is
+	// compressed and encrypted (in that order!).
+	_, name := s.nameFromID(id)
+	b, err := os.ReadFile(name)
+	require.NoError(t, err)
+
+	// First decrypt it, using the correct key
+	key, err := hex.DecodeString(testEncryptionKey)
+	require.NoError(t, err)
+	dec, err := NewXChaCha20Poly1305(key)
+	require.NoError(t, err)
+	decrypted, err := dec.fromStorage(b)
+	require.NoError(t, err)
+
+	// Now decompress
+	decompressed, err := Decompress(nil, decrypted)
+	require.NoError(t, err)
+
+	// And it should match the original content
+	require.Equal(t, dataIn, decompressed)
+}
+
+func TestLocalStoreKeyMismatch(t *testing.T) {
+	store := t.TempDir()
+
+	// Build 2 stores accessing the same files but with different keys
+	s1, err := NewLocalStore(store,
+		StoreOptions{
+			Encryption:    true,
+			EncryptionKey: testEncryptionKey,
+		},
+	)
+	require.NoError(t, err)
+	s2, err := NewLocalStore(store,
+		StoreOptions{
+			Encryption:    true,
+			EncryptionKey: otherEncryptionKey,
+		},
+	)
+	require.NoError(t, err)
+
+	// Make up some data and store it using the first key
+	dataIn := []byte("some data")
+
+	chunkIn := NewChunk(dataIn)
+	id := chunkIn.ID()
+
+	err = s1.StoreChunk(chunkIn)
+	require.NoError(t, err)
+
+	// Pull the data with the right key and compare it
+	chunkOut, err := s1.GetChunk(id)
+	require.NoError(t, err)
+	dataOut, err := chunkOut.Data()
+	require.NoError(t, err)
+	require.Equal(t, dataIn, dataOut)
+
+	// Try to get the chunk with a different key, expect a not-found
+	// since the chunk extensions are different for different keys.
+	_, err = s2.GetChunk(id)
+	require.Error(t, err)
+	require.ErrorAs(t, err, &ChunkMissing{})
 }

--- a/local_test.go
+++ b/local_test.go
@@ -169,12 +169,6 @@ func TestLocalStoreGetChunkReadError(t *testing.T) {
 	require.NotErrorAs(t, err, &ChunkInvalid{})
 }
 
-// Hex-encoded 256-bit keys used in encryption tests.
-const (
-	testEncryptionKey  = "6368616e676520746869732070617373776f726420746f206120736563726574"
-	otherEncryptionKey = "746f74616c6c7920646966666572656e74206b65792075736564206865726521"
-)
-
 func TestLocalStoreUncompressedEncrypted(t *testing.T) {
 	store := t.TempDir()
 

--- a/protocolserver.go
+++ b/protocolserver.go
@@ -54,16 +54,25 @@ func (s *ProtocolServer) Serve(ctx context.Context) error {
 			}
 			chunk, err := s.store.GetChunk(id)
 			if err != nil {
-				if _, ok := err.(ChunkMissing); ok {
-					if err = s.p.SendMissing(id); err != nil {
-						return errors.Wrap(err, "failed to send to client")
-					}
+				if _, ok := err.(ChunkMissing); !ok {
+					return errors.Wrap(err, "unable to read chunk from store")
 				}
-				return errors.Wrap(err, "unable to read chunk from store")
+				if err = s.p.SendMissing(id); err != nil {
+					return errors.Wrap(err, "failed to send to client")
+				}
+				continue
 			}
 			b, err := chunk.Storage([]converter{Compressor{}})
 			if err != nil {
-				return err
+				// The chunk is in the store but can't be converted to the
+				// wire format, perhaps corrupt or encrypted with a different
+				// key. Report it missing so the client can deal with the one
+				// chunk instead of tearing down the whole session.
+				Log.WithField("chunk", id.String()).WithError(err).Error("unable to convert chunk to wire format")
+				if err = s.p.SendMissing(id); err != nil {
+					return errors.Wrap(err, "failed to send to client")
+				}
+				continue
 			}
 			if err := s.p.SendProtocolChunk(chunk.ID(), CaProtocolChunkCompressed, b); err != nil {
 				return errors.Wrap(err, "failed to send chunk data")

--- a/remotehttp.go
+++ b/remotehttp.go
@@ -26,6 +26,9 @@ type RemoteHTTPBase struct {
 	client     *http.Client
 	opt        StoreOptions
 	converters Converters
+
+	// Chunk file extension, derived from the converters at construction
+	extension string
 }
 
 // RemoteHTTP is a remote casync store accessed via HTTP.
@@ -93,7 +96,7 @@ func NewRemoteHTTPStoreBase(location *url.URL, opt StoreOptions) (*RemoteHTTPBas
 	if err != nil {
 		return nil, err
 	}
-	return &RemoteHTTPBase{location: location, client: client, opt: opt, converters: converters}, nil
+	return &RemoteHTTPBase{location: location, client: client, opt: opt, converters: converters, extension: converters.storageExtension()}, nil
 }
 
 func (r *RemoteHTTPBase) String() string {
@@ -262,6 +265,6 @@ func (r *RemoteHTTP) StoreChunk(chunk *Chunk) error {
 
 func (r *RemoteHTTP) nameFromID(id ChunkID) string {
 	sID := id.String()
-	name := path.Join(sID[0:4], sID) + r.converters.storageExtension()
+	name := path.Join(sID[0:4], sID) + r.extension
 	return name
 }

--- a/remotehttp.go
+++ b/remotehttp.go
@@ -89,7 +89,11 @@ func NewRemoteHTTPStoreBase(location *url.URL, opt StoreOptions) (*RemoteHTTPBas
 	}
 	client := &http.Client{Transport: tr, Timeout: timeout}
 
-	return &RemoteHTTPBase{location: location, client: client, opt: opt, converters: opt.converters()}, nil
+	converters, err := opt.StorageConverters()
+	if err != nil {
+		return nil, err
+	}
+	return &RemoteHTTPBase{location: location, client: client, opt: opt, converters: converters}, nil
 }
 
 func (r *RemoteHTTPBase) String() string {
@@ -258,11 +262,6 @@ func (r *RemoteHTTP) StoreChunk(chunk *Chunk) error {
 
 func (r *RemoteHTTP) nameFromID(id ChunkID) string {
 	sID := id.String()
-	name := path.Join(sID[0:4], sID)
-	if r.opt.Uncompressed {
-		name += UncompressedChunkExt
-	} else {
-		name += CompressedChunkExt
-	}
+	name := path.Join(sID[0:4], sID) + r.converters.storageExtension()
 	return name
 }

--- a/remotehttp_test.go
+++ b/remotehttp_test.go
@@ -1,6 +1,8 @@
 package desync
 
 import (
+	"bytes"
+	"encoding/hex"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -345,4 +347,43 @@ func TestRetryExhaustedError(t *testing.T) {
 	err = s.StoreChunk(chunk)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "service down for maintenance")
+}
+
+func TestRemoteHTTPPutEncrypted(t *testing.T) {
+	body := new(bytes.Buffer)
+
+	// Setup a dummy server that records the request body (raw chunk data)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.Copy(body, r.Body)
+	}))
+	defer ts.Close()
+	u, _ := url.Parse(ts.URL)
+
+	// HTTP client store with encryption and compression
+	httpStore, err := NewRemoteHTTPStore(u, StoreOptions{
+		Uncompressed:  false,
+		Encryption:    true,
+		EncryptionKey: testEncryptionKey,
+	})
+	require.NoError(t, err)
+
+	// Prep a test chunk
+	dataIn := []byte("some data")
+	chunkIn := NewChunk(dataIn)
+
+	// Send the chunk over HTTP
+	err = httpStore.StoreChunk(chunkIn)
+	require.NoError(t, err)
+
+	// If everything worked, the request body should be the chunk data, first
+	// compressed, then encrypted. Unwind it manually to check the layers are in order.
+	key, err := hex.DecodeString(testEncryptionKey)
+	require.NoError(t, err)
+	dec, err := NewXChaCha20Poly1305(key)
+	require.NoError(t, err)
+	decrypted, err := dec.fromStorage(body.Bytes())
+	require.NoError(t, err)
+	uncompressed, err := Decompress(nil, decrypted)
+	require.NoError(t, err)
+	require.Equal(t, dataIn, uncompressed)
 }

--- a/remotehttp_test.go
+++ b/remotehttp_test.go
@@ -2,7 +2,6 @@ package desync
 
 import (
 	"bytes"
-	"encoding/hex"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -377,9 +376,7 @@ func TestRemoteHTTPPutEncrypted(t *testing.T) {
 
 	// If everything worked, the request body should be the chunk data, first
 	// compressed, then encrypted. Unwind it manually to check the layers are in order.
-	key, err := hex.DecodeString(testEncryptionKey)
-	require.NoError(t, err)
-	dec, err := NewXChaCha20Poly1305(key)
+	dec, err := NewXChaCha20Poly1305(testKey(t, testEncryptionKey))
 	require.NoError(t, err)
 	decrypted, err := dec.fromStorage(body.Bytes())
 	require.NoError(t, err)

--- a/remotehttpindex.go
+++ b/remotehttpindex.go
@@ -14,6 +14,9 @@ type RemoteHTTPIndex struct {
 // NewRemoteHTTPIndexStore initializes a new store that pulls the specified index file via HTTP(S) from
 // a remote web server.
 func NewRemoteHTTPIndexStore(location *url.URL, opt StoreOptions) (*RemoteHTTPIndex, error) {
+	if err := opt.ValidateIndexOptions(); err != nil {
+		return nil, err
+	}
 	b, err := NewRemoteHTTPStoreBase(location, opt)
 	if err != nil {
 		return nil, err

--- a/remotessh.go
+++ b/remotessh.go
@@ -24,7 +24,7 @@ func NewRemoteSSHStore(location *url.URL, opt StoreOptions) (*RemoteSSH, error) 
 	// The casync protocol always exchanges compressed chunks, storage
 	// options don't apply here. Reject encryption settings rather than
 	// silently ignoring them.
-	if opt.encryptionConfigured() {
+	if opt.EncryptionConfigured() {
 		return nil, errors.New("encryption is not supported by casync protocol (ssh://) stores")
 	}
 	remote := RemoteSSH{location: location, pool: make(chan *Protocol, opt.N), n: opt.N}

--- a/remotessh.go
+++ b/remotessh.go
@@ -24,7 +24,7 @@ func NewRemoteSSHStore(location *url.URL, opt StoreOptions) (*RemoteSSH, error) 
 	// The casync protocol always exchanges compressed chunks, storage
 	// options don't apply here. Reject encryption settings rather than
 	// silently ignoring them.
-	if opt.Encryption || opt.EncryptionKey != "" || opt.EncryptionAlgorithm != "" {
+	if opt.encryptionConfigured() {
 		return nil, errors.New("encryption is not supported by casync protocol (ssh://) stores")
 	}
 	remote := RemoteSSH{location: location, pool: make(chan *Protocol, opt.N), n: opt.N}

--- a/remotessh.go
+++ b/remotessh.go
@@ -21,6 +21,12 @@ type RemoteSSH struct {
 
 // NewRemoteSSHStore establishes up to n connections with a casync chunk server
 func NewRemoteSSHStore(location *url.URL, opt StoreOptions) (*RemoteSSH, error) {
+	// The casync protocol always exchanges compressed chunks, storage
+	// options don't apply here. Reject encryption settings rather than
+	// silently ignoring them.
+	if opt.Encryption || opt.EncryptionKey != "" || opt.EncryptionAlgorithm != "" {
+		return nil, errors.New("encryption is not supported by casync protocol (ssh://) stores")
+	}
 	remote := RemoteSSH{location: location, pool: make(chan *Protocol, opt.N), n: opt.N}
 	// Start n sessions and put them into the pool (buffered channel)
 	for i := 0; i < remote.n; i++ {

--- a/remotessh_test.go
+++ b/remotessh_test.go
@@ -1,0 +1,18 @@
+package desync
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoteSSHStoreRejectsEncryption(t *testing.T) {
+	u, err := url.Parse("ssh://host/store")
+	require.NoError(t, err)
+
+	// The casync protocol doesn't support encryption, configuring it on an
+	// ssh store needs to fail rather than being silently ignored
+	_, err = NewRemoteSSHStore(u, StoreOptions{Encryption: true, EncryptionKey: testEncryptionKey})
+	require.ErrorContains(t, err, "not supported")
+}

--- a/s3.go
+++ b/s3.go
@@ -183,7 +183,7 @@ func (s S3Store) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 		default:
 		}
 
-		id, err := s.idFromName(object.Key)
+		id, err := chunkIDFromObjectName(object.Key, s.prefix, s.extension)
 		if err != nil {
 			continue
 		}
@@ -202,16 +202,4 @@ func (s S3Store) nameFromID(id ChunkID) string {
 	sID := id.String()
 	name := s.prefix + sID[0:4] + "/" + sID + s.extension
 	return name
-}
-
-func (s S3Store) idFromName(name string) (ChunkID, error) {
-	fragments := strings.Split(strings.TrimPrefix(name, s.prefix), "/")
-	if len(fragments) != 2 || !strings.HasPrefix(fragments[1], fragments[0]) {
-		return ChunkID{}, fmt.Errorf("incorrect chunk name for object %s", name)
-	}
-	id, ok := chunkIDFromFilename(fragments[1], s.extension)
-	if !ok {
-		return ChunkID{}, fmt.Errorf("object %s is not a chunk", name)
-	}
-	return id, nil
 }

--- a/s3.go
+++ b/s3.go
@@ -205,18 +205,13 @@ func (s S3Store) nameFromID(id ChunkID) string {
 }
 
 func (s S3Store) idFromName(name string) (ChunkID, error) {
-	if !strings.HasSuffix(name, s.extension) {
+	fragments := strings.Split(strings.TrimPrefix(name, s.prefix), "/")
+	if len(fragments) != 2 || !strings.HasPrefix(fragments[1], fragments[0]) {
+		return ChunkID{}, fmt.Errorf("incorrect chunk name for object %s", name)
+	}
+	id, ok := chunkIDFromFilename(fragments[1], s.extension)
+	if !ok {
 		return ChunkID{}, fmt.Errorf("object %s is not a chunk", name)
 	}
-	n := strings.TrimSuffix(strings.TrimPrefix(name, s.prefix), s.extension)
-	fragments := strings.Split(n, "/")
-	if len(fragments) != 2 {
-		return ChunkID{}, fmt.Errorf("incorrect chunk name for object %s", name)
-	}
-	idx := fragments[0]
-	sid := fragments[1]
-	if !strings.HasPrefix(sid, idx) {
-		return ChunkID{}, fmt.Errorf("incorrect chunk name for object %s", name)
-	}
-	return ChunkIDFromString(sid)
+	return id, nil
 }

--- a/s3.go
+++ b/s3.go
@@ -33,8 +33,11 @@ type S3Store struct {
 
 // NewS3StoreBase initializes a base object used for chunk or index stores backed by S3.
 func NewS3StoreBase(u *url.URL, s3Creds *credentials.Credentials, region string, opt StoreOptions, lookupType minio.BucketLookupType) (S3StoreBase, error) {
-	var err error
-	s := S3StoreBase{Location: u.String(), opt: opt, converters: opt.converters()}
+	converters, err := opt.StorageConverters()
+	if err != nil {
+		return S3StoreBase{}, err
+	}
+	s := S3StoreBase{Location: u.String(), opt: opt, converters: converters}
 	if !strings.HasPrefix(u.Scheme, "s3+http") {
 		return s, fmt.Errorf("invalid scheme '%s', expected 's3+http' or 's3+https'", u.Scheme)
 	}
@@ -194,28 +197,16 @@ func (s S3Store) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 
 func (s S3Store) nameFromID(id ChunkID) string {
 	sID := id.String()
-	name := s.prefix + sID[0:4] + "/" + sID
-	if s.opt.Uncompressed {
-		name += UncompressedChunkExt
-	} else {
-		name += CompressedChunkExt
-	}
+	name := s.prefix + sID[0:4] + "/" + sID + s.converters.storageExtension()
 	return name
 }
 
 func (s S3Store) idFromName(name string) (ChunkID, error) {
-	var n string
-	if s.opt.Uncompressed {
-		if !strings.HasSuffix(name, UncompressedChunkExt) {
-			return ChunkID{}, fmt.Errorf("object %s is not a chunk", name)
-		}
-		n = strings.TrimSuffix(strings.TrimPrefix(name, s.prefix), UncompressedChunkExt)
-	} else {
-		if !strings.HasSuffix(name, CompressedChunkExt) {
-			return ChunkID{}, fmt.Errorf("object %s is not a chunk", name)
-		}
-		n = strings.TrimSuffix(strings.TrimPrefix(name, s.prefix), CompressedChunkExt)
+	extension := s.converters.storageExtension()
+	if !strings.HasSuffix(name, extension) {
+		return ChunkID{}, fmt.Errorf("object %s is not a chunk", name)
 	}
+	n := strings.TrimSuffix(strings.TrimPrefix(name, s.prefix), extension)
 	fragments := strings.Split(n, "/")
 	if len(fragments) != 2 {
 		return ChunkID{}, fmt.Errorf("incorrect chunk name for object %s", name)

--- a/s3.go
+++ b/s3.go
@@ -24,6 +24,9 @@ type S3StoreBase struct {
 	prefix     string
 	opt        StoreOptions
 	converters Converters
+
+	// Chunk file extension, derived from the converters at construction
+	extension string
 }
 
 // S3Store is a read-write store with S3 backing
@@ -37,7 +40,7 @@ func NewS3StoreBase(u *url.URL, s3Creds *credentials.Credentials, region string,
 	if err != nil {
 		return S3StoreBase{}, err
 	}
-	s := S3StoreBase{Location: u.String(), opt: opt, converters: converters}
+	s := S3StoreBase{Location: u.String(), opt: opt, converters: converters, extension: converters.storageExtension()}
 	if !strings.HasPrefix(u.Scheme, "s3+http") {
 		return s, fmt.Errorf("invalid scheme '%s', expected 's3+http' or 's3+https'", u.Scheme)
 	}
@@ -197,16 +200,15 @@ func (s S3Store) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 
 func (s S3Store) nameFromID(id ChunkID) string {
 	sID := id.String()
-	name := s.prefix + sID[0:4] + "/" + sID + s.converters.storageExtension()
+	name := s.prefix + sID[0:4] + "/" + sID + s.extension
 	return name
 }
 
 func (s S3Store) idFromName(name string) (ChunkID, error) {
-	extension := s.converters.storageExtension()
-	if !strings.HasSuffix(name, extension) {
+	if !strings.HasSuffix(name, s.extension) {
 		return ChunkID{}, fmt.Errorf("object %s is not a chunk", name)
 	}
-	n := strings.TrimSuffix(strings.TrimPrefix(name, s.prefix), extension)
+	n := strings.TrimSuffix(strings.TrimPrefix(name, s.prefix), s.extension)
 	fragments := strings.Split(n, "/")
 	if len(fragments) != 2 {
 		return ChunkID{}, fmt.Errorf("incorrect chunk name for object %s", name)

--- a/s3index.go
+++ b/s3index.go
@@ -22,6 +22,9 @@ type S3IndexStore struct {
 // Credentials are passed in via the environment variables S3_ACCESS_KEY
 // and S3_SECRET_KEY, or via the desync config file.
 func NewS3IndexStore(location *url.URL, s3Creds *credentials.Credentials, region string, opt StoreOptions, lookupType minio.BucketLookupType) (s S3IndexStore, e error) {
+	if err := opt.ValidateIndexOptions(); err != nil {
+		return s, err
+	}
 	b, err := NewS3StoreBase(location, s3Creds, region, opt, lookupType)
 	if err != nil {
 		return s, err

--- a/sftp.go
+++ b/sftp.go
@@ -39,7 +39,11 @@ type SFTPStore struct {
 }
 
 // Creates a base sftp client
-func newSFTPStoreBase(location *url.URL, opt StoreOptions, extension string) (*SFTPStoreBase, error) {
+func newSFTPStoreBase(location *url.URL, opt StoreOptions) (*SFTPStoreBase, error) {
+	converters, err := opt.StorageConverters()
+	if err != nil {
+		return nil, err
+	}
 	sshCmd := os.Getenv("CASYNC_SSH_PATH")
 	if sshCmd == "" {
 		sshCmd = "ssh"
@@ -87,7 +91,7 @@ func newSFTPStoreBase(location *url.URL, opt StoreOptions, extension string) (*S
 		cancel()
 		return nil, errors.Wrapf(err, "failed to stat '%s'", path)
 	}
-	return &SFTPStoreBase{location, path, client, cancel, opt, extension}, nil
+	return &SFTPStoreBase{location, path, client, cancel, opt, converters.storageExtension()}, nil
 }
 
 // StoreObject adds a new object to a writable index or chunk store.
@@ -147,10 +151,9 @@ func NewSFTPStore(location *url.URL, opt StoreOptions) (*SFTPStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	extension := converters.storageExtension()
 	s := &SFTPStore{make(chan *SFTPStoreBase, opt.N), location, opt.N, converters}
 	for i := 0; i < opt.N; i++ {
-		c, err := newSFTPStoreBase(location, opt, extension)
+		c, err := newSFTPStoreBase(location, opt)
 		if err != nil {
 			return nil, err
 		}

--- a/sftp.go
+++ b/sftp.go
@@ -22,11 +22,12 @@ var _ WriteStore = &SFTPStore{}
 
 // SFTPStoreBase is the base object for SFTP chunk and index stores.
 type SFTPStoreBase struct {
-	location *url.URL
-	path     string
-	client   *sftp.Client
-	cancel   context.CancelFunc
-	opt      StoreOptions
+	location  *url.URL
+	path      string
+	client    *sftp.Client
+	cancel    context.CancelFunc
+	opt       StoreOptions
+	extension string
 }
 
 // SFTPStore is a chunk store that uses SFTP over SSH.
@@ -38,7 +39,7 @@ type SFTPStore struct {
 }
 
 // Creates a base sftp client
-func newSFTPStoreBase(location *url.URL, opt StoreOptions) (*SFTPStoreBase, error) {
+func newSFTPStoreBase(location *url.URL, opt StoreOptions, extension string) (*SFTPStoreBase, error) {
 	sshCmd := os.Getenv("CASYNC_SSH_PATH")
 	if sshCmd == "" {
 		sshCmd = "ssh"
@@ -86,7 +87,7 @@ func newSFTPStoreBase(location *url.URL, opt StoreOptions) (*SFTPStoreBase, erro
 		cancel()
 		return nil, errors.Wrapf(err, "failed to stat '%s'", path)
 	}
-	return &SFTPStoreBase{location, path, client, cancel, opt}, nil
+	return &SFTPStoreBase{location, path, client, cancel, opt, extension}, nil
 }
 
 // StoreObject adds a new object to a writable index or chunk store.
@@ -136,20 +137,20 @@ func (s *SFTPStoreBase) String() string {
 // Returns the path for a chunk
 func (s *SFTPStoreBase) nameFromID(id ChunkID) string {
 	sID := id.String()
-	name := s.path + sID[0:4] + "/" + sID
-	if s.opt.Uncompressed {
-		name += UncompressedChunkExt
-	} else {
-		name += CompressedChunkExt
-	}
+	name := s.path + sID[0:4] + "/" + sID + s.extension
 	return name
 }
 
 // NewSFTPStore initializes a chunk store using SFTP over SSH.
 func NewSFTPStore(location *url.URL, opt StoreOptions) (*SFTPStore, error) {
-	s := &SFTPStore{make(chan *SFTPStoreBase, opt.N), location, opt.N, opt.converters()}
+	converters, err := opt.StorageConverters()
+	if err != nil {
+		return nil, err
+	}
+	extension := Converters(converters).storageExtension()
+	s := &SFTPStore{make(chan *SFTPStoreBase, opt.N), location, opt.N, converters}
 	for i := 0; i < opt.N; i++ {
-		c, err := newSFTPStoreBase(location, opt)
+		c, err := newSFTPStoreBase(location, opt, extension)
 		if err != nil {
 			return nil, err
 		}
@@ -218,6 +219,7 @@ func (s *SFTPStore) HasChunk(id ChunkID) (bool, error) {
 // Prune removes any chunks from the store that are not contained in a list
 // of chunks
 func (s *SFTPStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
+	extension := s.converters.storageExtension()
 	c := <-s.pool
 	defer func() { s.pool <- c }()
 	walker := c.client.Walk(c.path)
@@ -237,23 +239,11 @@ func (s *SFTPStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 			continue
 		}
 		path := walker.Path()
-		if !strings.HasSuffix(path, CompressedChunkExt) { // Skip files without chunk extension
+		if !strings.HasSuffix(path, extension) { // Skip files without expected chunk extension
 			continue
 		}
-		// Skip compressed chunks if this is running in uncompressed mode and vice-versa
-		var sID string
-		if c.opt.Uncompressed {
-			if !strings.HasSuffix(path, UncompressedChunkExt) {
-				return nil
-			}
-			sID = strings.TrimSuffix(filepath.Base(path), UncompressedChunkExt)
-		} else {
-			if !strings.HasSuffix(path, CompressedChunkExt) {
-				return nil
-			}
-			sID = strings.TrimSuffix(filepath.Base(path), CompressedChunkExt)
-		}
-		// Convert the name into a checksum, if that fails we're probably not looking
+		sID := strings.TrimSuffix(filepath.Base(path), extension)
+		// Convert the name into a hash, if that fails we're probably not looking
 		// at a chunk file and should skip it.
 		id, err := ChunkIDFromString(sID)
 		if err != nil {

--- a/sftp.go
+++ b/sftp.go
@@ -38,12 +38,10 @@ type SFTPStore struct {
 	converters Converters
 }
 
-// Creates a base sftp client
-func newSFTPStoreBase(location *url.URL, opt StoreOptions) (*SFTPStoreBase, error) {
-	converters, err := opt.StorageConverters()
-	if err != nil {
-		return nil, err
-	}
+// Creates a base sftp client. The extension is the chunk file extension
+// derived from the caller's converters, or empty for index stores which
+// don't use converters.
+func newSFTPStoreBase(location *url.URL, opt StoreOptions, extension string) (*SFTPStoreBase, error) {
 	sshCmd := os.Getenv("CASYNC_SSH_PATH")
 	if sshCmd == "" {
 		sshCmd = "ssh"
@@ -91,7 +89,7 @@ func newSFTPStoreBase(location *url.URL, opt StoreOptions) (*SFTPStoreBase, erro
 		cancel()
 		return nil, errors.Wrapf(err, "failed to stat '%s'", path)
 	}
-	return &SFTPStoreBase{location, path, client, cancel, opt, converters.storageExtension()}, nil
+	return &SFTPStoreBase{location, path, client, cancel, opt, extension}, nil
 }
 
 // StoreObject adds a new object to a writable index or chunk store.
@@ -151,9 +149,10 @@ func NewSFTPStore(location *url.URL, opt StoreOptions) (*SFTPStore, error) {
 	if err != nil {
 		return nil, err
 	}
+	extension := converters.storageExtension()
 	s := &SFTPStore{make(chan *SFTPStoreBase, opt.N), location, opt.N, converters}
 	for i := 0; i < opt.N; i++ {
-		c, err := newSFTPStoreBase(location, opt)
+		c, err := newSFTPStoreBase(location, opt, extension)
 		if err != nil {
 			return nil, err
 		}

--- a/sftp.go
+++ b/sftp.go
@@ -147,7 +147,7 @@ func NewSFTPStore(location *url.URL, opt StoreOptions) (*SFTPStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	extension := Converters(converters).storageExtension()
+	extension := converters.storageExtension()
 	s := &SFTPStore{make(chan *SFTPStoreBase, opt.N), location, opt.N, converters}
 	for i := 0; i < opt.N; i++ {
 		c, err := newSFTPStoreBase(location, opt, extension)
@@ -219,7 +219,6 @@ func (s *SFTPStore) HasChunk(id ChunkID) (bool, error) {
 // Prune removes any chunks from the store that are not contained in a list
 // of chunks
 func (s *SFTPStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
-	extension := s.converters.storageExtension()
 	c := <-s.pool
 	defer func() { s.pool <- c }()
 	walker := c.client.Walk(c.path)
@@ -239,10 +238,10 @@ func (s *SFTPStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 			continue
 		}
 		path := walker.Path()
-		if !strings.HasSuffix(path, extension) { // Skip files without expected chunk extension
+		if !strings.HasSuffix(path, c.extension) { // Skip files without expected chunk extension
 			continue
 		}
-		sID := strings.TrimSuffix(filepath.Base(path), extension)
+		sID := strings.TrimSuffix(filepath.Base(path), c.extension)
 		// Convert the name into a hash, if that fails we're probably not looking
 		// at a chunk file and should skip it.
 		id, err := ChunkIDFromString(sID)

--- a/sftp.go
+++ b/sftp.go
@@ -239,21 +239,16 @@ func (s *SFTPStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 		if info.IsDir() { // Skip dirs
 			continue
 		}
-		path := walker.Path()
-		if !strings.HasSuffix(path, c.extension) { // Skip files without expected chunk extension
-			continue
-		}
-		sID := strings.TrimSuffix(filepath.Base(path), c.extension)
-		// Convert the name into a hash, if that fails we're probably not looking
-		// at a chunk file and should skip it.
-		id, err := ChunkIDFromString(sID)
-		if err != nil {
+		// Skip files that aren't chunks matching the store's extension, they
+		// may use different compression or encryption settings
+		id, ok := chunkIDFromFilename(filepath.Base(walker.Path()), c.extension)
+		if !ok {
 			continue
 		}
 		// See if the chunk we're looking at is in the list we want to keep, if not
 		// remove it.
 		if _, ok := ids[id]; !ok {
-			if err = s.RemoveChunk(id); err != nil {
+			if err := s.RemoveChunk(id); err != nil {
 				return err
 			}
 		}

--- a/sftpindex.go
+++ b/sftpindex.go
@@ -17,7 +17,7 @@ type SFTPIndexStore struct {
 
 // NewSFTPIndexStore initializes and index store backed by SFTP over SSH.
 func NewSFTPIndexStore(location *url.URL, opt StoreOptions) (*SFTPIndexStore, error) {
-	b, err := newSFTPStoreBase(location, opt)
+	b, err := newSFTPStoreBase(location, opt, "")
 	if err != nil {
 		return nil, err
 	}

--- a/sftpindex.go
+++ b/sftpindex.go
@@ -20,7 +20,7 @@ func NewSFTPIndexStore(location *url.URL, opt StoreOptions) (*SFTPIndexStore, er
 	if err := opt.ValidateIndexOptions(); err != nil {
 		return nil, err
 	}
-	b, err := newSFTPStoreBase(location, opt)
+	b, err := newSFTPStoreBase(location, opt, "")
 	if err != nil {
 		return nil, err
 	}

--- a/sftpindex.go
+++ b/sftpindex.go
@@ -17,7 +17,10 @@ type SFTPIndexStore struct {
 
 // NewSFTPIndexStore initializes and index store backed by SFTP over SSH.
 func NewSFTPIndexStore(location *url.URL, opt StoreOptions) (*SFTPIndexStore, error) {
-	b, err := newSFTPStoreBase(location, opt, "")
+	if err := opt.ValidateIndexOptions(); err != nil {
+		return nil, err
+	}
+	b, err := newSFTPStoreBase(location, opt)
 	if err != nil {
 		return nil, err
 	}

--- a/store.go
+++ b/store.go
@@ -124,8 +124,8 @@ func (o *StoreOptions) UnmarshalJSON(data []byte) error {
 // If data is written to storage, the layer's toStorage method is called in
 // the order they are returned. If data is read, the fromStorage method is
 // called in reverse order.
-func (o StoreOptions) StorageConverters() ([]converter, error) {
-	var c []converter
+func (o StoreOptions) StorageConverters() (Converters, error) {
+	var c Converters
 	if !o.Uncompressed {
 		c = append(c, Compressor{})
 	}

--- a/store.go
+++ b/store.go
@@ -129,7 +129,7 @@ func (o StoreOptions) StorageConverters() (Converters, error) {
 	if !o.Uncompressed {
 		c = append(c, Compressor{})
 	}
-	if !o.Encryption && o.encryptionConfigured() {
+	if !o.Encryption && o.EncryptionConfigured() {
 		// Refuse configs that set a key or algorithm without turning encryption
 		// on. Silently writing plaintext chunks is the one failure mode this
 		// feature must not have.
@@ -160,9 +160,9 @@ func (o StoreOptions) StorageConverters() (Converters, error) {
 	return c, nil
 }
 
-// encryptionConfigured returns true if any of the encryption options is set,
+// EncryptionConfigured returns true if any of the encryption options is set,
 // regardless of whether the combination is valid.
-func (o StoreOptions) encryptionConfigured() bool {
+func (o StoreOptions) EncryptionConfigured() bool {
 	return o.Encryption || o.EncryptionKey != "" || o.EncryptionAlgorithm != ""
 }
 
@@ -172,7 +172,7 @@ func (o StoreOptions) encryptionConfigured() bool {
 // than silently ignoring them, which could be mistaken for indexes being
 // stored encrypted.
 func (o StoreOptions) ValidateIndexOptions() error {
-	if o.encryptionConfigured() {
+	if o.EncryptionConfigured() {
 		return errors.New("encryption is not supported by index stores")
 	}
 	return nil

--- a/store.go
+++ b/store.go
@@ -2,7 +2,9 @@ package desync
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -92,6 +94,13 @@ type StoreOptions struct {
 
 	// Store and read chunks uncompressed, without chunk file extension
 	Uncompressed bool `json:"uncompressed"`
+
+	// Encrypt chunks in storage. The key is expected to be a hex-encoded 256-bit
+	// key, for example generated with `openssl rand -hex 32`. Supported algorithms
+	// are xchacha20-poly1305 (default) and aes-256-gcm.
+	Encryption          bool   `json:"encryption,omitempty"`
+	EncryptionAlgorithm string `json:"encryption-algorithm,omitempty"`
+	EncryptionKey       string `json:"encryption-key,omitempty"`
 }
 
 // NewStoreOptionsWithDefaults creates a new StoreOptions struct with the default values set
@@ -109,15 +118,41 @@ func (o *StoreOptions) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, (*Alias)(o))
 }
 
-// Returns data converters that convert between plain and storage-format. Each layer
-// represents a modification such as compression or encryption and is applied in order
-// depending on the direction of data. If data is written to storage, the layer's toStorage
-// method is called in the order they are returned. If data is read, the fromStorage
-// method is called in reverse order.
-func (o *StoreOptions) converters() []converter {
-	var m []converter
+// StorageConverters returns data converters that convert between plain and
+// storage-format. Each layer represents a modification such as compression
+// or encryption and is applied in order depending on the direction of data.
+// If data is written to storage, the layer's toStorage method is called in
+// the order they are returned. If data is read, the fromStorage method is
+// called in reverse order.
+func (o StoreOptions) StorageConverters() ([]converter, error) {
+	var c []converter
 	if !o.Uncompressed {
-		m = append(m, Compressor{})
+		c = append(c, Compressor{})
 	}
-	return m
+	if o.Encryption {
+		if o.EncryptionKey == "" {
+			return nil, errors.New("no encryption key configured")
+		}
+		key, err := hex.DecodeString(o.EncryptionKey)
+		if err != nil {
+			return nil, fmt.Errorf("invalid encryption key, expected hex-encoded 256-bit key: %w", err)
+		}
+		switch o.EncryptionAlgorithm {
+		case "", "xchacha20-poly1305":
+			enc, err := NewXChaCha20Poly1305(key)
+			if err != nil {
+				return nil, err
+			}
+			c = append(c, enc)
+		case "aes-256-gcm":
+			enc, err := NewAES256GCM(key)
+			if err != nil {
+				return nil, err
+			}
+			c = append(c, enc)
+		default:
+			return nil, fmt.Errorf("unsupported encryption algorithm %q", o.EncryptionAlgorithm)
+		}
+	}
+	return c, nil
 }

--- a/store.go
+++ b/store.go
@@ -129,7 +129,7 @@ func (o StoreOptions) StorageConverters() (Converters, error) {
 	if !o.Uncompressed {
 		c = append(c, Compressor{})
 	}
-	if !o.Encryption && (o.EncryptionKey != "" || o.EncryptionAlgorithm != "") {
+	if !o.Encryption && o.encryptionConfigured() {
 		// Refuse configs that set a key or algorithm without turning encryption
 		// on. Silently writing plaintext chunks is the one failure mode this
 		// feature must not have.
@@ -143,22 +143,37 @@ func (o StoreOptions) StorageConverters() (Converters, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid encryption key, expected hex-encoded 256-bit key: %w", err)
 		}
+		newAEAD := NewXChaCha20Poly1305
 		switch o.EncryptionAlgorithm {
 		case "", "xchacha20-poly1305":
-			enc, err := NewXChaCha20Poly1305(key)
-			if err != nil {
-				return nil, err
-			}
-			c = append(c, enc)
 		case "aes-256-gcm":
-			enc, err := NewAES256GCM(key)
-			if err != nil {
-				return nil, err
-			}
-			c = append(c, enc)
+			newAEAD = NewAES256GCM
 		default:
 			return nil, fmt.Errorf("unsupported encryption algorithm %q", o.EncryptionAlgorithm)
 		}
+		enc, err := newAEAD(key)
+		if err != nil {
+			return nil, err
+		}
+		c = append(c, enc)
 	}
 	return c, nil
+}
+
+// encryptionConfigured returns true if any of the encryption options is set,
+// regardless of whether the combination is valid.
+func (o StoreOptions) encryptionConfigured() bool {
+	return o.Encryption || o.EncryptionKey != "" || o.EncryptionAlgorithm != ""
+}
+
+// ValidateIndexOptions returns an error if the options contain settings that
+// don't apply to index stores. Encryption only covers chunks, indexes are
+// always stored in plain form. Index stores reject encryption options rather
+// than silently ignoring them, which could be mistaken for indexes being
+// stored encrypted.
+func (o StoreOptions) ValidateIndexOptions() error {
+	if o.encryptionConfigured() {
+		return errors.New("encryption is not supported by index stores")
+	}
+	return nil
 }

--- a/store.go
+++ b/store.go
@@ -129,6 +129,12 @@ func (o StoreOptions) StorageConverters() ([]converter, error) {
 	if !o.Uncompressed {
 		c = append(c, Compressor{})
 	}
+	if !o.Encryption && (o.EncryptionKey != "" || o.EncryptionAlgorithm != "") {
+		// Refuse configs that set a key or algorithm without turning encryption
+		// on. Silently writing plaintext chunks is the one failure mode this
+		// feature must not have.
+		return nil, errors.New("encryption-key or encryption-algorithm configured without setting encryption to true")
+	}
 	if o.Encryption {
 		if o.EncryptionKey == "" {
 			return nil, errors.New("no encryption key configured")

--- a/types.go
+++ b/types.go
@@ -3,6 +3,7 @@ package desync
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -50,6 +51,22 @@ func chunkIDFromFilename(name, extension string) (ChunkID, bool) {
 		return ChunkID{}, false
 	}
 	return id, true
+}
+
+// chunkIDFromObjectName extracts the chunk ID from the name of an object in
+// a bucket store such as S3 or GCS, which is expected to be the store prefix
+// followed by the first four characters of the ID, a slash, and the chunk
+// filename.
+func chunkIDFromObjectName(name, prefix, extension string) (ChunkID, error) {
+	fragments := strings.Split(strings.TrimPrefix(name, prefix), "/")
+	if len(fragments) != 2 || !strings.HasPrefix(fragments[1], fragments[0]) {
+		return ChunkID{}, fmt.Errorf("incorrect chunk name for object %s", name)
+	}
+	id, ok := chunkIDFromFilename(fragments[1], extension)
+	if !ok {
+		return ChunkID{}, fmt.Errorf("object %s is not a chunk", name)
+	}
+	return id, nil
 }
 
 func (c *ChunkID) MarshalJSON() ([]byte, error) {

--- a/types.go
+++ b/types.go
@@ -3,6 +3,7 @@ package desync
 import (
 	"encoding/hex"
 	"encoding/json"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -32,6 +33,23 @@ func ChunkIDFromString(id string) (ChunkID, error) {
 
 func (c *ChunkID) String() string {
 	return hex.EncodeToString(c[:])
+}
+
+// chunkIDFromFilename extracts the chunk ID from the base filename of a
+// chunk, which is expected to be the hex-encoded ID followed by the given
+// storage extension. Returns false if the name doesn't match that format,
+// for example for chunks stored with different compression or encryption
+// settings.
+func chunkIDFromFilename(name, extension string) (ChunkID, bool) {
+	sID, ok := strings.CutSuffix(name, extension)
+	if !ok {
+		return ChunkID{}, false
+	}
+	id, err := ChunkIDFromString(sID)
+	if err != nil {
+		return ChunkID{}, false
+	}
+	return id, true
 }
 
 func (c *ChunkID) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Revives #182, rebased onto the current codebase and reworked based on the discussion in that PR.

Chunks can be encrypted at rest on a per-store basis using XChaCha20-Poly1305 (default) or AES-256-GCM. Encryption is implemented as a converter layer on top of the framework from #181: it is applied after compression when writing to a store and reversed when reading. Encrypted chunks are stored with a file extension containing the algorithm and a key ID (the leading 4 bytes of SHA256 of the key), e.g. `<hash>.cacnk.xchacha20-poly1305-e1e2b9f0`, so chunks with different settings or keys can coexist in the same store. `prune` and `verify` only consider chunks matching the store's configured extension.

The main change compared to #182: instead of deriving the key from a password with SHA256, the user provides the raw 256-bit key hex-encoded (e.g. generated with `openssl rand -hex 32`). As discussed in the original PR, password-derived keys are only as strong as the password and can be brute-forced cheaply, especially since the key ID in the chunk file name acts as a fast verification oracle. Requiring the full-entropy key eliminates that class of problem, and makes the key ID in the extension harmless.

Configuration:
- `encryption`, `encryption-key`, and `encryption-algorithm` in `store-options`
- `DESYNC_ENCRYPTION_KEY` environment variable as fallback for the key, to keep it out of config files
- `chunk-server --encryption` / `--encryption-key` to serve/accept encrypted chunks, independent of how the upstream store is configured. The env variable supplies the key but never enables encryption on its own, and enabling encryption without a key is an error

Also included from the rebase: the converter interface now determines chunk file extensions (`storageExtension()`), replacing the `CompressedChunkExt`/`UncompressedChunkExt` constants, and the now-unused `hasCompression()` helper was removed.

Note: encryption protects chunk contents only. Chunk file names remain content hashes of the plain data, so an observer who already knows a plaintext can confirm its presence in a store. Integrity comes from the regular chunk content validation rather than from the AEAD, which authenticates ciphertext under the key but does not bind it to the chunk name. Both properties are documented in the README, including the guidance to only use skip-verify where a downstream reader still validates.

