### PR TITLE
Fix data race on chunks shared by WriteDedupQueue

### DIFF
--- a/writededupqueue.go
+++ b/writededupqueue.go
@@ -36,7 +36,11 @@ func (q *WriteDedupQueue) GetChunk(id ChunkID) (*Chunk, error) {
 		case nil:
 			return nil, err
 		case *Chunk:
-			return b, err
+			// The chunk in the request is shared with all waiters. Chunk
+			// materializes its plain data and ID lazily without locking,
+			// so hand every caller its own copy. The copies still share
+			// the underlying (read-only) chunk data.
+			return b.clone(), err
 		default:
 			return nil, fmt.Errorf("internal error: unexpected type %T", data)
 		}
@@ -63,8 +67,10 @@ func (q *WriteDedupQueue) StoreChunk(chunk *Chunk) error {
 	err := q.S.StoreChunk(chunk)
 
 	// Signal to any others that wait for us that we're done, they'll use our data
-	// and don't need to hit the store themselves
-	req.markDone(chunk, err)
+	// and don't need to hit the store themselves. Publish a copy of the chunk,
+	// detached from the one the caller passed in and keeps using, so the copy
+	// stays untouched while waiters read from it.
+	req.markDone(chunk.clone(), err)
 
 	// We're done, drop the request from the queue to avoid keeping all the chunk data
 	// in memory after the request is done

--- a/writededupqueue_test.go
+++ b/writededupqueue_test.go
@@ -1,10 +1,12 @@
 package desync
 
 import (
+	"sync"
 	"testing"
 	"testing/synctest"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,5 +44,64 @@ func TestWriteDedupQueueParallelReadWrite(t *testing.T) {
 
 		// Wait for the read to finish, all goroutines must be done before the test returns
 		<-done
+	})
+}
+
+func TestWriteDedupQueueChunkNotShared(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		data := []byte("some data")
+		compressed, err := Compress(data)
+		require.NoError(t, err)
+		id := NewChunk(data).ID()
+
+		// Use a chunk in storage form, its plain data is materialized (and
+		// cached) lazily when the readers ask for it
+		chunkIn, err := NewChunkFromStorage(id, compressed, Converters{Compressor{}}, true)
+		require.NoError(t, err)
+
+		inFlight := make(chan struct{})
+		store := &TestStore{
+			StoreChunkFunc: func(chunk *Chunk) error {
+				close(inFlight)
+				// The fake clock only advances once all other goroutines are
+				// blocked, so this guarantees the readers registered as
+				// waiters on this request before it completes
+				time.Sleep(time.Millisecond)
+				return nil
+			},
+		}
+		q := NewWriteDedupQueue(store)
+
+		// Store a chunk while several readers request the same chunk ID. Every
+		// reader must get its own copy since accessing the plain data modifies
+		// the chunk, and the writer keeps using the original. Run with -race
+		// to confirm the callers don't share state.
+		var wg sync.WaitGroup
+		chunks := make(chan *Chunk, 10)
+		wg.Go(func() {
+			assert.NoError(t, q.StoreChunk(chunkIn))
+		})
+		<-inFlight
+		for range 10 {
+			wg.Go(func() {
+				c, err := q.GetChunk(id)
+				if !assert.NoError(t, err) {
+					return
+				}
+				b, err := c.Data()
+				assert.NoError(t, err)
+				assert.Equal(t, data, b)
+				chunks <- c
+			})
+		}
+		wg.Wait()
+		close(chunks)
+
+		seen := map[*Chunk]struct{}{chunkIn: {}}
+		for c := range chunks {
+			_, shared := seen[c]
+			assert.False(t, shared, "the same *Chunk was handed to multiple callers")
+			seen[c] = struct{}{}
+		}
 	})
 }


### PR DESCRIPTION
Follow-up to #372, which fixed the same defect in `DedupQueue.GetChunk` but missed the sibling path: `WriteDedupQueue.GetChunk` returns the chunk of an in-flight `StoreChunk` request for the same ID to every waiting reader. That chunk is the exact `*Chunk` the storing caller passed in and continues to use, and `Chunk.Data()`/`ID()` memoize internal fields without synchronization — so concurrent readers race with each other and with the writer.

Same fix shape as #372: `StoreChunk` publishes a shallow copy detached from the caller's chunk via `markDone`, and each waiting reader receives its own copy of that master. The master is never handed out or mutated, `markDone`'s channel close provides the happens-before edge, and the copies share the underlying read-only data so nothing is duplicated.

The added test stores a chunk while ten readers request the same ID (deterministically interleaved with `testing/synctest`): without the fix it fails under `-race` and on the shared-pointer assertion; with the fix the full library suite passes under `-race`.