### PR TITLE
Apply directory metadata only after the directory was populated

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -182,7 +182,10 @@ loop:
 				a.last = c
 				break loop
 			}
-			a.dir = filepath.Dir(a.dir)
+			// path.Dir, not filepath.Dir: node names are slash-separated
+			// (built with path.Join below) and have to stay that way on
+			// Windows too, where filepath.Dir would rewrite the separators.
+			a.dir = path.Dir(a.dir)
 		case nil:
 			return nil, nil
 

--- a/cmd/desync/untar.go
+++ b/cmd/desync/untar.go
@@ -53,7 +53,7 @@ the output can be set to GNU tar, either an archive or STDOUT with '-'.
 	return cmd
 }
 
-func runUntar(ctx context.Context, opt untarOptions, args []string) error {
+func runUntar(ctx context.Context, opt untarOptions, args []string) (err error) {
 	if err := opt.cmdStoreOptions.validate(); err != nil {
 		return err
 	}
@@ -65,14 +65,17 @@ func runUntar(ctx context.Context, opt untarOptions, args []string) error {
 	target := args[1]
 
 	// Prepare output
-	var (
-		fs  desync.FilesystemWriter
-		err error
-	)
+	var fs desync.FilesystemWriter
 	switch opt.outFormat {
 	case "disk": // Local filesystem
 		lfs := desync.NewLocalFS(target, opt.LocalFSOptions)
-		defer lfs.Close()
+		// Closing applies any directory metadata that is still outstanding,
+		// which is the case when the extraction failed part-way through.
+		defer func() {
+			if cerr := lfs.Close(); cerr != nil && err == nil {
+				err = cerr
+			}
+		}()
 		fs = lfs
 	case "gnu-tar": // GNU tar, either file or STDOUT
 		var w *os.File

--- a/filesystem.go
+++ b/filesystem.go
@@ -20,6 +20,16 @@ type FilesystemWriter interface {
 	CreateDevice(n NodeDevice) error
 }
 
+// FilesystemFinalizer is implemented by filesystems that defer part of their
+// work, such as directory metadata that can only be applied once a directory
+// has been populated, until the whole archive has been written. UnTar calls
+// Finalize when it reaches the end of the archive. It is not called when the
+// archive can't be read to the end, so implementations that leave the target
+// in an intermediate state until then should apply what they can on Close().
+type FilesystemFinalizer interface {
+	Finalize() error
+}
+
 // FilesystemReader is an interface for source filesystem to be used during
 // tar operations. Next() is expected to return files and directories in a
 // consistent and stable order and return io.EOF when no further files are available.

--- a/localfs.go
+++ b/localfs.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"sync"
 	"time"
 )
@@ -28,6 +30,12 @@ type LocalFS struct {
 	wroot    *os.Root
 	wErr     error
 	rootReal string
+
+	// Directories whose metadata (owner, xattrs, permissions and timestamps)
+	// hasn't been applied yet because they may still be populated. Held in
+	// the order they were created, i.e. a directory is always preceded by its
+	// parent.
+	pending []NodeDirectory
 }
 
 // LocalFSOptions influence the behavior of the filesystem when reading from or writing to it.
@@ -72,13 +80,72 @@ func (fs *LocalFS) writeRoot() (*os.Root, error) {
 	return fs.wroot, fs.wErr
 }
 
-// Close releases the os.Root handle used for writing. It is safe to call even
-// if no write operation was ever performed.
+// Close applies any outstanding directory metadata on a best-effort basis and
+// releases the os.Root handle used for writing. It is safe to call even if no
+// write operation was ever performed. On a successful untar the metadata has
+// normally been applied by Finalize() already.
 func (fs *LocalFS) Close() error {
+	err := fs.Finalize()
 	if fs.wroot != nil {
-		return fs.wroot.Close()
+		if cerr := fs.wroot.Close(); err == nil {
+			err = cerr
+		}
+	}
+	return err
+}
+
+// Finalize applies the deferred metadata of all directories that are still
+// pending, deepest first. It's called at the end of an untar operation, once
+// no further entries can be written. Safe to call more than once.
+func (fs *LocalFS) Finalize() error {
+	var err error
+	for _, n := range slices.Backward(fs.pending) {
+		if e := fs.applyDirMetadata(n); e != nil && err == nil {
+			err = e
+		}
+	}
+	fs.pending = nil
+	return err
+}
+
+// contains reports whether name refers to something inside the directory dir.
+// Both are clean slash-separated paths relative to the extraction root, with
+// "." being the root itself.
+func contains(dir, name string) bool {
+	return dir == "." || strings.HasPrefix(name, dir+"/")
+}
+
+// completeDirs applies the deferred metadata of every pending directory that
+// doesn't contain name, deepest first. Those directories are complete since
+// entries arrive depth-first.
+func (fs *LocalFS) completeDirs(name string) error {
+	for len(fs.pending) > 0 {
+		n := fs.pending[len(fs.pending)-1]
+		if contains(n.Name, name) {
+			return nil
+		}
+		fs.pending = fs.pending[:len(fs.pending)-1]
+		if err := fs.applyDirMetadata(n); err != nil {
+			return err
+		}
 	}
 	return nil
+}
+
+// applyDirMetadata sets owner, xattrs, permissions and timestamps of a
+// directory that has been fully populated.
+func (fs *LocalFS) applyDirMetadata(n NodeDirectory) error {
+	r, err := fs.writeRoot()
+	if err != nil {
+		return err
+	}
+	if err := fs.SetDirPermissions(n); err != nil {
+		return err
+	}
+	if n.MTime == time.Unix(0, 0) {
+		return nil
+	}
+	return r.Chtimes(n.Name, n.MTime, n.MTime)
 }
 
 func (fs *LocalFS) CreateDir(n NodeDirectory) error {
@@ -87,32 +154,53 @@ func (fs *LocalFS) CreateDir(n NodeDirectory) error {
 		return err
 	}
 
+	// Everything that isn't an ancestor of this new directory is complete now.
+	if err := fs.completeDirs(n.Name); err != nil {
+		return err
+	}
+
 	// Let's see if there is a dir with the same name already
+	var restricted bool
 	if info, err := r.Lstat(n.Name); err == nil {
 		if !info.IsDir() {
 			return fmt.Errorf("%s exists and is not a directory", n.Name)
 		}
+		// An existing directory may not be writable or searchable by us.
+		restricted = info.Mode().Perm()&0300 != 0300
 	} else {
 		// Stat error'ed out, presumably because the dir doesn't exist. Create it.
 		// (n.Name == "." is the extraction root itself, which already exists.)
+		// The mode from the archive is not applied here, so whatever the umask
+		// allows of 0777 remains until the directory has been populated.
 		if err := r.Mkdir(n.Name, 0777); err != nil {
 			return fmt.Errorf("%s: %w", n.Name, err)
 		}
 	}
 
-	if err := fs.SetDirPermissions(n); err != nil {
-		return err
+	// The directory needs to be writable and searchable by us while its
+	// contents are being written. Temporarily grant ourselves those
+	// permissions, same as GNU tar does. Best-effort only, if this fails the
+	// write that needs it reports the real error. Not done when the archive
+	// permissions are ignored anyway, since there'd be nothing to restore the
+	// mode from later.
+	if restricted && !fs.opts.NoSamePermissions {
+		_ = r.Chmod(n.Name, n.Mode.Perm()|0700)
 	}
 
-	if n.MTime == time.Unix(0, 0) {
-		return nil
-	}
-	return r.Chtimes(n.Name, n.MTime, n.MTime)
+	// The remaining metadata is applied once the directory is complete. Doing
+	// it now would not only prevent writing into a read-only directory, it'd
+	// also see the timestamps overwritten by those very writes.
+	fs.pending = append(fs.pending, n)
+	return nil
 }
 
 func (fs *LocalFS) CreateFile(n NodeFile) error {
 	r, err := fs.writeRoot()
 	if err != nil {
+		return err
+	}
+
+	if err := fs.completeDirs(n.Name); err != nil {
 		return err
 	}
 
@@ -141,6 +229,10 @@ func (fs *LocalFS) CreateFile(n NodeFile) error {
 func (fs *LocalFS) CreateSymlink(n NodeSymlink) error {
 	r, err := fs.writeRoot()
 	if err != nil {
+		return err
+	}
+
+	if err := fs.completeDirs(n.Name); err != nil {
 		return err
 	}
 

--- a/localfs.go
+++ b/localfs.go
@@ -56,6 +56,7 @@ type LocalFSOptions struct {
 
 var _ FilesystemWriter = &LocalFS{}
 var _ FilesystemReader = &LocalFS{}
+var _ FilesystemFinalizer = &LocalFS{}
 
 // writeRoot lazily creates the extraction root directory and opens an os.Root
 // handle anchored to it. Every write/metadata operation goes through the
@@ -124,10 +125,12 @@ func (fs *LocalFS) completeDirs(name string) error {
 		if contains(n.Name, name) {
 			return nil
 		}
-		fs.pending = fs.pending[:len(fs.pending)-1]
+		// Only drop it once it's done, so a failure here can still be retried
+		// by the best-effort Finalize() in Close().
 		if err := fs.applyDirMetadata(n); err != nil {
 			return err
 		}
+		fs.pending = fs.pending[:len(fs.pending)-1]
 	}
 	return nil
 }
@@ -160,32 +163,34 @@ func (fs *LocalFS) CreateDir(n NodeDirectory) error {
 	}
 
 	// Let's see if there is a dir with the same name already
-	var restricted bool
+	var (
+		created  bool
+		existing os.FileMode
+	)
 	if info, err := r.Lstat(n.Name); err == nil {
 		if !info.IsDir() {
 			return fmt.Errorf("%s exists and is not a directory", n.Name)
 		}
-		// An existing directory may not be writable or searchable by us.
-		restricted = info.Mode().Perm()&0300 != 0300
+		existing = info.Mode().Perm()
 	} else {
 		// Stat error'ed out, presumably because the dir doesn't exist. Create it.
 		// (n.Name == "." is the extraction root itself, which already exists.)
-		// The mode from the archive is not applied here, so whatever the umask
-		// allows of 0777 remains until the directory has been populated.
-		if err := r.Mkdir(n.Name, 0777); err != nil {
+		// The mode from the archive is the upper bound of what the directory
+		// gets here, so its contents are never written into a directory more
+		// permissive than the archive says. The exact mode, including any
+		// setuid/setgid/sticky bits, is applied by prepareDirWrite below and
+		// again by applyDirMetadata once the directory is complete.
+		mode := os.FileMode(0777)
+		if !fs.opts.NoSamePermissions {
+			mode = n.Mode.Perm() | 0700
+		}
+		if err := r.Mkdir(n.Name, mode); err != nil {
 			return fmt.Errorf("%s: %w", n.Name, err)
 		}
+		created = true
 	}
 
-	// The directory needs to be writable and searchable by us while its
-	// contents are being written. Temporarily grant ourselves those
-	// permissions, same as GNU tar does. Best-effort only, if this fails the
-	// write that needs it reports the real error. Not done when the archive
-	// permissions are ignored anyway, since there'd be nothing to restore the
-	// mode from later.
-	if restricted && !fs.opts.NoSamePermissions {
-		_ = r.Chmod(n.Name, n.Mode.Perm()|0700)
-	}
+	fs.prepareDirWrite(r, n, existing, created)
 
 	// The remaining metadata is applied once the directory is complete. Doing
 	// it now would not only prevent writing into a read-only directory, it'd

--- a/localfs_dirmeta_test.go
+++ b/localfs_dirmeta_test.go
@@ -1,0 +1,174 @@
+//go:build !windows
+
+package desync
+
+import (
+	"bytes"
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeWritableOnCleanup ensures a tree containing read-only directories can be
+// removed again when the test ends.
+func makeWritableOnCleanup(t *testing.T, root string) {
+	t.Helper()
+	t.Cleanup(func() {
+		filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err == nil && d.IsDir() {
+				os.Chmod(path, 0755)
+			}
+			return nil
+		})
+	})
+}
+
+// tarDir archives a directory tree into a catar in memory.
+func tarDir(t *testing.T, dir string) *bytes.Buffer {
+	t.Helper()
+	b := new(bytes.Buffer)
+	require.NoError(t, Tar(context.Background(), b, NewLocalFS(dir, LocalFSOptions{})))
+	return b
+}
+
+// TestUnTarReadOnlyDir extracts an archive containing read-only directories
+// that hold further directories and files. The mode from the archive can only
+// be applied once a directory has been populated, see issue #376.
+func TestUnTarReadOnlyDir(t *testing.T) {
+	src := t.TempDir()
+	makeWritableOnCleanup(t, src)
+
+	for _, d := range []string{"ro/sub1", "ro/sub2/deep"} {
+		require.NoError(t, os.MkdirAll(filepath.Join(src, d), 0755))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(src, "ro/sub1/file"), []byte("content"), 0644))
+	require.NoError(t, os.Symlink("file", filepath.Join(src, "ro/sub1/link")))
+	// Every directory in the tree is read-only, including the root
+	require.NoError(t, os.Chmod(filepath.Join(src, "ro/sub2/deep"), 0555))
+	require.NoError(t, os.Chmod(filepath.Join(src, "ro/sub2"), 0555))
+	require.NoError(t, os.Chmod(filepath.Join(src, "ro/sub1"), 0555))
+	require.NoError(t, os.Chmod(filepath.Join(src, "ro"), 0555))
+	require.NoError(t, os.Chmod(src, 0555))
+
+	b := tarDir(t, src)
+
+	dst := filepath.Join(t.TempDir(), "out")
+	makeWritableOnCleanup(t, dst)
+	fs := NewLocalFS(dst, LocalFSOptions{NoSameOwner: true})
+	defer fs.Close()
+	require.NoError(t, UnTar(context.Background(), b, fs))
+
+	// The archive permissions need to be in place afterwards
+	for _, d := range []string{".", "ro", "ro/sub1", "ro/sub2", "ro/sub2/deep"} {
+		info, err := os.Stat(filepath.Join(dst, d))
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0555), info.Mode().Perm(), "mode of dir %s", d)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dst, "ro/sub1/file"))
+	require.NoError(t, err)
+	assert.Equal(t, "content", string(content))
+
+	target, err := os.Readlink(filepath.Join(dst, "ro/sub1/link"))
+	require.NoError(t, err)
+	assert.Equal(t, "file", target)
+}
+
+// TestUnTarDirMTime confirms that directory timestamps survive the writing of
+// their contents, which would otherwise update them.
+func TestUnTarDirMTime(t *testing.T) {
+	src := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "dir/sub"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "dir/file"), []byte("content"), 0644))
+
+	mtime := time.Unix(1577872800, 0) // 2020-01-01
+	for _, name := range []string{"dir/file", "dir/sub", "dir", "."} {
+		require.NoError(t, os.Chtimes(filepath.Join(src, name), mtime, mtime))
+	}
+
+	b := tarDir(t, src)
+
+	dst := filepath.Join(t.TempDir(), "out")
+	fs := NewLocalFS(dst, LocalFSOptions{NoSameOwner: true})
+	defer fs.Close()
+	require.NoError(t, UnTar(context.Background(), b, fs))
+
+	for _, name := range []string{".", "dir", "dir/sub", "dir/file"} {
+		info, err := os.Stat(filepath.Join(dst, name))
+		require.NoError(t, err)
+		assert.Equal(t, mtime.Unix(), info.ModTime().Unix(), "mtime of %s", name)
+	}
+}
+
+// TestUnTarReadOnlyDirNoSamePermissions extracts the same archive while
+// ignoring the permissions in it. That has to work as well, and must not apply
+// the archive mode to the directories.
+func TestUnTarReadOnlyDirNoSamePermissions(t *testing.T) {
+	src := t.TempDir()
+	makeWritableOnCleanup(t, src)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "ro/sub"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "ro/sub/file"), []byte("content"), 0644))
+	require.NoError(t, os.Chmod(filepath.Join(src, "ro/sub"), 0555))
+	require.NoError(t, os.Chmod(filepath.Join(src, "ro"), 0555))
+
+	b := tarDir(t, src)
+
+	dst := filepath.Join(t.TempDir(), "out")
+	fs := NewLocalFS(dst, LocalFSOptions{NoSameOwner: true, NoSamePermissions: true})
+	defer fs.Close()
+	require.NoError(t, UnTar(context.Background(), b, fs))
+
+	for _, d := range []string{"ro", "ro/sub"} {
+		info, err := os.Stat(filepath.Join(dst, d))
+		require.NoError(t, err)
+		assert.NotEqual(t, os.FileMode(0555), info.Mode().Perm(), "mode of dir %s", d)
+	}
+}
+
+// TestUnTarIntoReadOnlyDir extracts into a target directory that exists
+// already and isn't writable.
+func TestUnTarIntoReadOnlyDir(t *testing.T) {
+	src := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src, "file"), []byte("content"), 0644))
+
+	b := tarDir(t, src)
+
+	dst := filepath.Join(t.TempDir(), "out")
+	makeWritableOnCleanup(t, dst)
+	require.NoError(t, os.Mkdir(dst, 0555))
+
+	fs := NewLocalFS(dst, LocalFSOptions{NoSameOwner: true})
+	defer fs.Close()
+	require.NoError(t, UnTar(context.Background(), b, fs))
+
+	content, err := os.ReadFile(filepath.Join(dst, "file"))
+	require.NoError(t, err)
+	assert.Equal(t, "content", string(content))
+}
+
+func TestContains(t *testing.T) {
+	tests := []struct {
+		dir, name string
+		want      bool
+	}{
+		{".", "dir", true},
+		{".", "dir/sub", true},
+		{"dir", "dir/sub", true},
+		{"dir", "dir/sub/file", true},
+		{"dir", "dir", false},
+		{"dir", "dirx/file", false},
+		{"dir/sub", "dir/file", false},
+		{"dir/sub", "other", false},
+	}
+	for _, test := range tests {
+		assert.Equal(t, test.want, contains(test.dir, test.name), "contains(%q, %q)", test.dir, test.name)
+	}
+}

--- a/localfs_dirmeta_test.go
+++ b/localfs_dirmeta_test.go
@@ -3,13 +3,12 @@
 package desync
 
 import (
-	"bytes"
 	"context"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,14 +26,6 @@ func makeWritableOnCleanup(t *testing.T, root string) {
 			return nil
 		})
 	})
-}
-
-// tarDir archives a directory tree into a catar in memory.
-func tarDir(t *testing.T, dir string) *bytes.Buffer {
-	t.Helper()
-	b := new(bytes.Buffer)
-	require.NoError(t, Tar(context.Background(), b, NewLocalFS(dir, LocalFSOptions{})))
-	return b
 }
 
 // TestUnTarReadOnlyDir extracts an archive containing read-only directories
@@ -60,9 +51,9 @@ func TestUnTarReadOnlyDir(t *testing.T) {
 
 	dst := filepath.Join(t.TempDir(), "out")
 	makeWritableOnCleanup(t, dst)
-	fs := NewLocalFS(dst, LocalFSOptions{NoSameOwner: true})
-	defer fs.Close()
-	require.NoError(t, UnTar(context.Background(), b, fs))
+	lfs := NewLocalFS(dst, LocalFSOptions{NoSameOwner: true})
+	defer lfs.Close()
+	require.NoError(t, UnTar(context.Background(), b, lfs))
 
 	// The archive permissions need to be in place afterwards
 	for _, d := range []string{".", "ro", "ro/sub1", "ro/sub2", "ro/sub2/deep"} {
@@ -80,31 +71,61 @@ func TestUnTarReadOnlyDir(t *testing.T) {
 	assert.Equal(t, "file", target)
 }
 
-// TestUnTarDirMTime confirms that directory timestamps survive the writing of
-// their contents, which would otherwise update them.
-func TestUnTarDirMTime(t *testing.T) {
-	src := t.TempDir()
-
-	require.NoError(t, os.MkdirAll(filepath.Join(src, "dir/sub"), 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(src, "dir/file"), []byte("content"), 0644))
-
-	mtime := time.Unix(1577872800, 0) // 2020-01-01
-	for _, name := range []string{"dir/file", "dir/sub", "dir", "."} {
-		require.NoError(t, os.Chtimes(filepath.Join(src, name), mtime, mtime))
-	}
-
-	b := tarDir(t, src)
-
+// TestLocalFSDirModeWhilePopulated confirms a directory is never more
+// permissive than the archive says, not even in the window between its
+// creation and the point where it's complete. Only the permissions needed to
+// write the contents are added.
+func TestLocalFSDirModeWhilePopulated(t *testing.T) {
 	dst := filepath.Join(t.TempDir(), "out")
-	fs := NewLocalFS(dst, LocalFSOptions{NoSameOwner: true})
-	defer fs.Close()
-	require.NoError(t, UnTar(context.Background(), b, fs))
+	makeWritableOnCleanup(t, dst)
 
-	for _, name := range []string{".", "dir", "dir/sub", "dir/file"} {
-		info, err := os.Stat(filepath.Join(dst, name))
+	lfs := NewLocalFS(dst, LocalFSOptions{NoSameOwner: true})
+	defer lfs.Close()
+
+	require.NoError(t, lfs.CreateDir(NodeDirectory{Name: ".", Mode: 0755 | os.ModeDir}))
+	require.NoError(t, lfs.CreateDir(NodeDirectory{Name: "priv", Mode: 0700 | os.ModeDir}))
+	require.NoError(t, lfs.CreateDir(NodeDirectory{Name: "priv/ro", Mode: 0500 | os.ModeDir}))
+
+	// Not world-readable at any point, and 0500 only gained what it takes to
+	// write into it
+	info, err := os.Stat(filepath.Join(dst, "priv"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0700), info.Mode().Perm(), "mode of priv while being populated")
+
+	info, err = os.Stat(filepath.Join(dst, "priv/ro"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0700), info.Mode().Perm(), "mode of priv/ro while being populated")
+
+	require.NoError(t, lfs.CreateFile(NodeFile{Name: "priv/ro/file", Mode: 0600, Data: strings.NewReader("content")}))
+	require.NoError(t, lfs.Finalize())
+
+	for d, want := range map[string]os.FileMode{"priv": 0700, "priv/ro": 0500} {
+		info, err := os.Stat(filepath.Join(dst, d))
 		require.NoError(t, err)
-		assert.Equal(t, mtime.Unix(), info.ModTime().Unix(), "mtime of %s", name)
+		assert.Equal(t, want, info.Mode().Perm(), "final mode of %s", d)
 	}
+}
+
+// TestLocalFSDirSetgidWhilePopulated confirms the setgid bit is in place while
+// the contents of a directory are written, so they inherit its group.
+func TestLocalFSDirSetgidWhilePopulated(t *testing.T) {
+	dst := filepath.Join(t.TempDir(), "out")
+
+	lfs := NewLocalFS(dst, LocalFSOptions{NoSameOwner: true})
+	defer lfs.Close()
+
+	require.NoError(t, lfs.CreateDir(NodeDirectory{Name: ".", Mode: 0755 | os.ModeDir}))
+	require.NoError(t, lfs.CreateDir(NodeDirectory{Name: "shared", Mode: 0775 | os.ModeDir | os.ModeSetgid}))
+
+	info, err := os.Stat(filepath.Join(dst, "shared"))
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&os.ModeSetgid, "setgid while the directory is populated")
+
+	require.NoError(t, lfs.Finalize())
+
+	info, err = os.Stat(filepath.Join(dst, "shared"))
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&os.ModeSetgid, "setgid after finalizing")
 }
 
 // TestUnTarReadOnlyDirNoSamePermissions extracts the same archive while
@@ -122,15 +143,45 @@ func TestUnTarReadOnlyDirNoSamePermissions(t *testing.T) {
 	b := tarDir(t, src)
 
 	dst := filepath.Join(t.TempDir(), "out")
-	fs := NewLocalFS(dst, LocalFSOptions{NoSameOwner: true, NoSamePermissions: true})
-	defer fs.Close()
-	require.NoError(t, UnTar(context.Background(), b, fs))
+	lfs := NewLocalFS(dst, LocalFSOptions{NoSameOwner: true, NoSamePermissions: true})
+	defer lfs.Close()
+	require.NoError(t, UnTar(context.Background(), b, lfs))
 
+	// Writable by the current user, i.e. not what the archive says
 	for _, d := range []string{"ro", "ro/sub"} {
 		info, err := os.Stat(filepath.Join(dst, d))
 		require.NoError(t, err)
-		assert.NotEqual(t, os.FileMode(0555), info.Mode().Perm(), "mode of dir %s", d)
+		assert.Equal(t, os.FileMode(0700), info.Mode().Perm()&0700, "mode of dir %s", d)
 	}
+}
+
+// TestUnTarNoSamePermissionsOverReadOnlyTree extracts over a tree that was
+// written by an earlier extraction and contains read-only directories.
+func TestUnTarNoSamePermissionsOverReadOnlyTree(t *testing.T) {
+	src := t.TempDir()
+	makeWritableOnCleanup(t, src)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "ro/sub"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "ro/sub/file"), []byte("content"), 0644))
+	require.NoError(t, os.Chmod(filepath.Join(src, "ro/sub"), 0555))
+	require.NoError(t, os.Chmod(filepath.Join(src, "ro"), 0555))
+
+	dst := filepath.Join(t.TempDir(), "out")
+	makeWritableOnCleanup(t, dst)
+
+	// First pass, applying the archive permissions
+	first := NewLocalFS(dst, LocalFSOptions{NoSameOwner: true})
+	require.NoError(t, UnTar(context.Background(), tarDir(t, src), first))
+	require.NoError(t, first.Close())
+
+	// Second pass over the now read-only tree, ignoring the archive permissions
+	second := NewLocalFS(dst, LocalFSOptions{NoSameOwner: true, NoSamePermissions: true})
+	defer second.Close()
+	require.NoError(t, UnTar(context.Background(), tarDir(t, src), second))
+
+	content, err := os.ReadFile(filepath.Join(dst, "ro/sub/file"))
+	require.NoError(t, err)
+	assert.Equal(t, "content", string(content))
 }
 
 // TestUnTarIntoReadOnlyDir extracts into a target directory that exists
@@ -145,30 +196,11 @@ func TestUnTarIntoReadOnlyDir(t *testing.T) {
 	makeWritableOnCleanup(t, dst)
 	require.NoError(t, os.Mkdir(dst, 0555))
 
-	fs := NewLocalFS(dst, LocalFSOptions{NoSameOwner: true})
-	defer fs.Close()
-	require.NoError(t, UnTar(context.Background(), b, fs))
+	lfs := NewLocalFS(dst, LocalFSOptions{NoSameOwner: true})
+	defer lfs.Close()
+	require.NoError(t, UnTar(context.Background(), b, lfs))
 
 	content, err := os.ReadFile(filepath.Join(dst, "file"))
 	require.NoError(t, err)
 	assert.Equal(t, "content", string(content))
-}
-
-func TestContains(t *testing.T) {
-	tests := []struct {
-		dir, name string
-		want      bool
-	}{
-		{".", "dir", true},
-		{".", "dir/sub", true},
-		{"dir", "dir/sub", true},
-		{"dir", "dir/sub/file", true},
-		{"dir", "dir", false},
-		{"dir", "dirx/file", false},
-		{"dir/sub", "dir/file", false},
-		{"dir/sub", "other", false},
-	}
-	for _, test := range tests {
-		assert.Equal(t, test.want, contains(test.dir, test.name), "contains(%q, %q)", test.dir, test.name)
-	}
 }

--- a/localfs_dirmtime_test.go
+++ b/localfs_dirmtime_test.go
@@ -1,0 +1,71 @@
+package desync
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// tarDir archives a directory tree into a catar in memory.
+func tarDir(t *testing.T, dir string) *bytes.Buffer {
+	t.Helper()
+	b := new(bytes.Buffer)
+	require.NoError(t, Tar(context.Background(), b, NewLocalFS(dir, LocalFSOptions{})))
+	return b
+}
+
+// TestUnTarDirMTime confirms that directory timestamps survive the writing of
+// their contents, which would otherwise update them. Runs on all platforms
+// since the deferral this relies on has to work with either path separator.
+func TestUnTarDirMTime(t *testing.T) {
+	src := t.TempDir()
+
+	// Deep enough for the decoder to walk back up more than one level
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "dir/sub/deep"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "dir/sub/file"), []byte("content"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "dir/file"), []byte("content"), 0644))
+
+	mtime := time.Unix(1577872800, 0) // 2020-01-01
+	names := []string{"dir/sub/deep", "dir/sub/file", "dir/sub", "dir/file", "dir", "."}
+	for _, name := range names {
+		require.NoError(t, os.Chtimes(filepath.Join(src, name), mtime, mtime))
+	}
+
+	b := tarDir(t, src)
+
+	dst := filepath.Join(t.TempDir(), "out")
+	fs := NewLocalFS(dst, LocalFSOptions{NoSameOwner: true})
+	defer fs.Close()
+	require.NoError(t, UnTar(context.Background(), b, fs))
+
+	for _, name := range names {
+		info, err := os.Stat(filepath.Join(dst, name))
+		require.NoError(t, err)
+		assert.Equal(t, mtime.Unix(), info.ModTime().Unix(), "mtime of %s", name)
+	}
+}
+
+func TestContains(t *testing.T) {
+	tests := []struct {
+		dir, name string
+		want      bool
+	}{
+		{".", "dir", true},
+		{".", "dir/sub", true},
+		{"dir", "dir/sub", true},
+		{"dir", "dir/sub/file", true},
+		{"dir", "dir", false},
+		{"dir", "dirx/file", false},
+		{"dir/sub", "dir/file", false},
+		{"dir/sub", "other", false},
+	}
+	for _, test := range tests {
+		assert.Equal(t, test.want, contains(test.dir, test.name), "contains(%q, %q)", test.dir, test.name)
+	}
+}

--- a/localfs_other.go
+++ b/localfs_other.go
@@ -137,6 +137,10 @@ func (fs *LocalFS) CreateDevice(n NodeDevice) error {
 		return err
 	}
 
+	if err := fs.completeDirs(n.Name); err != nil {
+		return err
+	}
+
 	if err := r.Remove(n.Name); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("%s: %w", n.Name, err)
 	}

--- a/localfs_other.go
+++ b/localfs_other.go
@@ -62,6 +62,29 @@ func (fs *LocalFS) setXattrsNoFollow(name string, xattrs Xattrs) error {
 	return nil
 }
 
+// prepareDirWrite gives us the permissions needed to populate a directory,
+// which the mode in the archive may not include. GNU tar does the same. The
+// mode from the archive is restored by applyDirMetadata() once the directory
+// is complete. Best-effort, if it fails the write that needs the permissions
+// reports the real error.
+func (fs *LocalFS) prepareDirWrite(r *os.Root, n NodeDirectory, existing os.FileMode, created bool) {
+	if fs.opts.NoSamePermissions {
+		// Nothing to restore later, so only relax what has to be relaxed.
+		// Newly created directories use the umask default and are writable.
+		if !created && existing&0300 != 0300 {
+			_ = r.Chmod(n.Name, existing|0700)
+		}
+		return
+	}
+	// Newly created directories are chmod'ed as well, both to undo a umask
+	// that stripped the bits we need and to set the setuid/setgid/sticky bits
+	// that mkdir doesn't apply. A setgid directory has to carry that bit while
+	// its contents are created for them to inherit the group.
+	if created || existing&0300 != 0300 {
+		_ = r.Chmod(n.Name, n.Mode|0700)
+	}
+}
+
 func (fs *LocalFS) SetDirPermissions(n NodeDirectory) error {
 	r, err := fs.writeRoot()
 	if err != nil {

--- a/localfs_windows.go
+++ b/localfs_windows.go
@@ -19,6 +19,12 @@ func NewLocalFS(root string, opts LocalFSOptions) *LocalFS {
 	}
 }
 
+// prepareDirWrite does nothing on Windows. Permission attributes are ignored
+// here, and chmod'ing a directory would only clear the read-only attribute
+// that SetDirPermissions never restores.
+func (fs *LocalFS) prepareDirWrite(r *os.Root, n NodeDirectory, existing os.FileMode, created bool) {
+}
+
 func (fs *LocalFS) SetDirPermissions(n NodeDirectory) error {
 	// Permission attributes are ignored on Windows
 	return nil

--- a/untar.go
+++ b/untar.go
@@ -12,6 +12,11 @@ import (
 
 // UnTar implements the untar command, decoding a catar file and writing the
 // contained tree to a target directory.
+//
+// Filesystems implementing FilesystemFinalizer have Finalize() called on them
+// once the end of the archive is reached. That doesn't happen when UnTar
+// returns an error, so the caller should still close the filesystem to have
+// any deferred operations applied to what was extracted.
 func UnTar(ctx context.Context, r io.Reader, fs FilesystemWriter) error {
 	dec := NewArchiveDecoder(r)
 loop:
@@ -48,7 +53,7 @@ loop:
 	// Filesystems that defer directory metadata (permissions, timestamps)
 	// until a directory has been fully populated need to be told that no
 	// further entries are coming.
-	if f, ok := fs.(interface{ Finalize() error }); ok {
+	if f, ok := fs.(FilesystemFinalizer); ok {
 		return f.Finalize()
 	}
 	return nil

--- a/untar.go
+++ b/untar.go
@@ -44,6 +44,13 @@ loop:
 			return err
 		}
 	}
+
+	// Filesystems that defer directory metadata (permissions, timestamps)
+	// until a directory has been fully populated need to be told that no
+	// further entries are coming.
+	if f, ok := fs.(interface{ Finalize() error }); ok {
+		return f.Finalize()
+	}
 	return nil
 }
 


### PR DESCRIPTION
Fixes #376.

`desync untar` failed with `Error: <dir>: mkdirat <dir>: permission denied` (or `openat <file>: permission denied`) when the archive contained a read-only directory that holds further directories or files:

```
mkdir -p test/test
chmod -R 0555 test
desync tar test.catar test
desync untar test.catar test2
```

`LocalFS.CreateDir()` applied the mode from the archive immediately after creating the directory, making it impossible to write the contents that follow.

Directory metadata (owner, xattrs, permissions and timestamps) is now deferred until the directory has been fully populated, which is the case when an entry outside of it arrives, or when the archive ends. Directories that aren't writable and searchable by the current user are temporarily given those permissions while their contents are being written, the same way GNU tar handles this. `UnTar()` signals the end of the archive through an optional `Finalize()` method, so the other `FilesystemWriter` implementations (tar, mtree) are unaffected. `LocalFS.Close()` applies whatever is still outstanding on a best-effort basis, for the case an extraction is aborted.

Deferring the timestamps fixes a second issue found while testing this: directory mtimes were not preserved since writing the contents of a directory updates its mtime. GNU tar delays this for the same reason. Extracting a tree with directories dated 2020 now gives the same result as `tar xp` rather than dating them to the time of extraction.