### PR TITLE
Use value receivers for `ChunkID` `String` and `MarshalJSON`

### DIFF
--- a/assemble.go
+++ b/assemble.go
@@ -73,7 +73,7 @@ func writeChunk(c IndexChunk, ss *selfSeed, f *os.File, blocksize uint64, s Stor
 	}
 	// Might as well verify the chunk size while we're at it
 	if c.Size != uint64(len(b)) {
-		return fmt.Errorf("unexpected size for chunk %s", c.ID.String())
+		return fmt.Errorf("unexpected size for chunk %s", c.ID)
 	}
 	// Write the decompressed chunk into the file at the right position
 	if _, err = f.WriteAt(b, int64(c.Start)); err != nil {
@@ -218,7 +218,7 @@ func AssembleFile(ctx context.Context, name string, idx Index, s Store, seeds []
 						if sum != c.ID {
 							if options.InvalidSeedAction == InvalidSeedActionRegenerate {
 								// Try harder before giving up and aborting
-								Log.WithField("ID", c.ID.String()).Info("The seed may have changed during processing, trying to take the chunk from the self seed or the store")
+								Log.WithField("ID", c.ID).Info("The seed may have changed during processing, trying to take the chunk from the self seed or the store")
 								if err := writeChunk(c, ss, f, blocksize, s, stats, isBlank, buf); err != nil {
 									return err
 								}

--- a/cmd/desync/list.go
+++ b/cmd/desync/list.go
@@ -43,7 +43,7 @@ func runList(ctx context.Context, opt listOptions, args []string) error {
 	}
 	// Write the list of chunk IDs to STDOUT
 	for _, chunk := range c.Chunks {
-		fmt.Fprintln(stdout, chunk.ID.String())
+		fmt.Fprintln(stdout, chunk.ID)
 		// See if we're meant to stop
 		select {
 		case <-ctx.Done():

--- a/errors.go
+++ b/errors.go
@@ -13,7 +13,7 @@ type NoSuchObject struct {
 }
 
 func (e ChunkMissing) Error() string {
-	return fmt.Sprintf("chunk %s missing from store", e.ID.String())
+	return fmt.Sprintf("chunk %s missing from store", e.ID)
 }
 
 func (e NoSuchObject) Error() string {
@@ -33,9 +33,9 @@ type ChunkInvalid struct {
 
 func (e ChunkInvalid) Error() string {
 	if e.Err != nil {
-		return fmt.Sprintf("invalid chunk %s: %s", e.ID.String(), e.Err)
+		return fmt.Sprintf("invalid chunk %s: %s", e.ID, e.Err)
 	}
-	return fmt.Sprintf("chunk id %s does not match its hash %s", e.ID.String(), e.Sum.String())
+	return fmt.Sprintf("chunk id %s does not match its hash %s", e.ID, e.Sum)
 }
 
 func (e ChunkInvalid) Unwrap() error {

--- a/protocolserver.go
+++ b/protocolserver.go
@@ -68,7 +68,7 @@ func (s *ProtocolServer) Serve(ctx context.Context) error {
 				// wire format, perhaps corrupt or encrypted with a different
 				// key. Report it missing so the client can deal with the one
 				// chunk instead of tearing down the whole session.
-				Log.WithField("chunk", id.String()).WithError(err).Error("unable to convert chunk to wire format")
+				Log.WithField("chunk", id).WithError(err).Error("unable to convert chunk to wire format")
 				if err = s.p.SendMissing(id); err != nil {
 					return errors.Wrap(err, "failed to send to client")
 				}

--- a/readseeker.go
+++ b/readseeker.go
@@ -122,7 +122,7 @@ func (ip *IndexPos) loadChunk() error {
 	// zero-progress loop. AssembleFile performs the same check.
 	if uint64(len(ip.curChunk)) != ip.Index.Chunks[ip.curChunkIdx].Size {
 		ip.curChunk = nil
-		return fmt.Errorf("unexpected size for chunk %s", ip.curChunkID.String())
+		return fmt.Errorf("unexpected size for chunk %s", ip.curChunkID)
 	}
 	return nil
 }

--- a/types.go
+++ b/types.go
@@ -32,7 +32,7 @@ func ChunkIDFromString(id string) (ChunkID, error) {
 	return ChunkIDFromSlice(b)
 }
 
-func (c *ChunkID) String() string {
+func (c ChunkID) String() string {
 	return hex.EncodeToString(c[:])
 }
 
@@ -69,7 +69,7 @@ func chunkIDFromObjectName(name, prefix, extension string) (ChunkID, error) {
 	return id, nil
 }
 
-func (c *ChunkID) MarshalJSON() ([]byte, error) {
+func (c ChunkID) MarshalJSON() ([]byte, error) {
 	return json.Marshal(c.String())
 }
 

--- a/untar.go
+++ b/untar.go
@@ -88,7 +88,7 @@ func UnTarIndex(ctx context.Context, fs FilesystemWriter, index Index, s Store, 
 				// Might as well verify the chunk size while we're at it
 				if r.chunk.Size != uint64(len(b)) {
 					close(r.data)
-					return fmt.Errorf("unexpected size for chunk %s", r.chunk.ID.String())
+					return fmt.Errorf("unexpected size for chunk %s", r.chunk.ID)
 				}
 				r.data <- b
 				close(r.data)


### PR DESCRIPTION
`ChunkID.String()` was switched to a pointer receiver in #273, so only `*ChunkID` implemented `fmt.Stringer`. A `ChunkID` value passed to `%s` or `%v` was rendered by `fmt`'s byte-array fallback, printing the 32 raw bytes instead of hex. This affected error and log messages in `s3.go`, `gcs.go`, `httphandler.go`, and `cmd/desync/info.go`, plus test failure messages in `s3_test.go`.

Switching `String()` to a value receiver puts it in the method set of both `ChunkID` and `*ChunkID`, fixing all format call sites at once. The same change to `MarshalJSON` removes the addressability trap where `json.Marshal` of a non-addressable `ChunkID` would emit a number array instead of a hex string. `UnmarshalJSON` keeps its pointer receiver as it mutates the receiver.

Also drop explicit `.String()` calls in `fmt` and `logrus` arguments where the `Stringer` is now picked up automatically; calls that produce an actual string value (path building, string-typed parameters) remain.