### PR TITLE
Compare mtime with Equal() rather than ==

### DIFF
--- a/localfs.go
+++ b/localfs.go
@@ -145,7 +145,9 @@ func (fs *LocalFS) applyDirMetadata(n NodeDirectory) error {
 	if err := fs.SetDirPermissions(n); err != nil {
 		return err
 	}
-	if n.MTime == time.Unix(0, 0) {
+	// Use Equal() rather than ==, which also compares the monotonic reading
+	// and the location and would miss an epoch mtime in a different location.
+	if n.MTime.Equal(time.Unix(0, 0)) {
 		return nil
 	}
 	return r.Chtimes(n.Name, n.MTime, n.MTime)
@@ -225,7 +227,7 @@ func (fs *LocalFS) CreateFile(n NodeFile) error {
 		return err
 	}
 
-	if n.MTime == time.Unix(0, 0) {
+	if n.MTime.Equal(time.Unix(0, 0)) {
 		return nil
 	}
 	return r.Chtimes(n.Name, n.MTime, n.MTime)

--- a/localfs_other.go
+++ b/localfs_other.go
@@ -187,7 +187,7 @@ func (fs *LocalFS) CreateDevice(n NodeDevice) error {
 			return fmt.Errorf("chmod %s: %w", n.Name, err)
 		}
 	}
-	if n.MTime == time.Unix(0, 0) {
+	if n.MTime.Equal(time.Unix(0, 0)) {
 		return nil
 	}
 	return r.Chtimes(n.Name, n.MTime, n.MTime)


### PR DESCRIPTION
The LocalFS writers skip setting timestamps when the node's mtime is the epoch, treating that as "unset". The check used `n.MTime == time.Unix(0, 0)`.

`==` on `time.Time` compares the wall clock, the monotonic reading *and* the location pointer, so it only matches an epoch mtime that happens to carry `time.Local`. The same instant in UTC or any other location falls through to `Chtimes()` and the entry gets its timestamps set to 1970 rather than being left alone.

Switched the three sites to `Equal()`, which compares the instant only:

- `localfs.go` — `applyDirMetadata()` and `CreateFile()`
- `localfs_other.go` — `CreateDevice()`

Found by `staticcheck`'s QF1009 (enabled by default in golangci-lint, but not in the `staticcheck` run in CI).