### PR TITLE
Drop the dead reader assignment in untar

### DIFF
--- a/cmd/desync/untar.go
+++ b/cmd/desync/untar.go
@@ -102,7 +102,6 @@ func runUntar(ctx context.Context, opt untarOptions, args []string) (err error) 
 			return err
 		}
 		defer f.Close()
-		var r io.Reader = f
 		pb := desync.NewProgressBar("Unpacking ")
 		// Get the file size to initialize the progress bar
 		info, err := f.Stat()
@@ -112,8 +111,7 @@ func runUntar(ctx context.Context, opt untarOptions, args []string) (err error) 
 		pb.SetTotal(int(info.Size()))
 		pb.Start()
 		defer pb.Finish()
-		r = io.TeeReader(f, pb)
-		return desync.UnTar(ctx, r, fs)
+		return desync.UnTar(ctx, io.TeeReader(f, pb), fs)
 	}
 
 	s, err := MultiStoreWithCache(opt.cmdStoreOptions, opt.cache, opt.stores...)


### PR DESCRIPTION
In the catar branch of `runUntar()`, `r` was declared as the opened file and then overwritten with the `io.TeeReader` wrapping that same file, before `r` was ever read. The initial value was always dead.

Dropped the variable and passed the `TeeReader` directly to `UnTar()`. No behaviour change.

Reported by `ineffassign` (part of golangci-lint's default set).