### PR TITLE
Simplify a negated comparison and an mtree escape write

### DIFF
--- a/mtreefs.go
+++ b/mtreefs.go
@@ -103,7 +103,7 @@ func mtreeFilename(s string) string {
 	for _, c := range []byte(s) {
 		switch {
 		case c == '\\' || c == '#' || c == ' ' || c < 32 || c > 126:
-			b.WriteString(fmt.Sprintf("\\%03o", c))
+			fmt.Fprintf(&b, "\\%03o", c)
 		default:
 			b.WriteByte(c)
 		}

--- a/tar.go
+++ b/tar.go
@@ -105,7 +105,7 @@ func tar(ctx context.Context, enc FormatEncoder, fs *fsBufReader, f *File) (n in
 			}
 
 			// End of the current dir?
-			if !(path.Dir(f.Path) == dir) {
+			if path.Dir(f.Path) != dir {
 				fs.Buffer(f)
 				break
 			}


### PR DESCRIPTION
Two `staticcheck` quickfix suggestions, both no-ops behaviourally:

- `tar.go:108` (QF1001) — `!(path.Dir(f.Path) == dir)` reads better as `path.Dir(f.Path) != dir`.
- `mtreefs.go:106` (QF1012) — `mtreeFilename()` built each escape sequence as a temporary string via `fmt.Sprintf` before appending it. `strings.Builder` is an `io.Writer`, so format straight into it with `fmt.Fprintf` and skip the intermediate allocation.

The remaining QF findings are the `opt.cmdStoreOptions.validate()` embedded-field selectors (QF1008), one QF1006 in `fileseed.go` and one QF1001 in `tar.go:54`, all left alone as the current spelling is clearer.