### PR TITLE
Use the platform's own device number encoding

### DIFF
--- a/localfs_mkdev_test.go
+++ b/localfs_mkdev_test.go
@@ -1,0 +1,100 @@
+//go:build !windows
+
+package desync
+
+import (
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// The major/minor pairs used here stay within 8 bits so that they survive a
+// round-trip on every supported platform. The encodings differ in how many
+// bits each component gets: FreeBSD gives the minor 8, Darwin gives the major
+// 8, Linux is wider than both.
+var devTestCases = []struct {
+	major, minor uint64
+}{
+	{0, 0},
+	{1, 3},
+	{5, 1},
+	{8, 0},
+	{10, 229},
+	{253, 255},
+}
+
+// TestMkdev checks that a major/minor pair encoded for the running platform is
+// split back into the same pair by that platform's own accessors. desync used
+// to encode with Linux's layout everywhere, which produced wrong device
+// numbers on Darwin and FreeBSD.
+func TestMkdev(t *testing.T) {
+	for _, tc := range devTestCases {
+		dev, err := mkdev(tc.major, tc.minor)
+		require.NoError(t, err)
+		assert.Equal(t, tc.major, uint64(unix.Major(dev)), "major of %d:%d", tc.major, tc.minor)
+		assert.Equal(t, tc.minor, uint64(unix.Minor(dev)), "minor of %d:%d", tc.major, tc.minor)
+	}
+}
+
+// TestMkdevOutOfRange checks that a major or minor too large to encode is
+// rejected rather than silently truncated.
+func TestMkdevOutOfRange(t *testing.T) {
+	_, err := mkdev(math.MaxUint32+1, 0)
+	require.Error(t, err)
+
+	_, err = mkdev(0, math.MaxUint32+1)
+	require.Error(t, err)
+
+	_, err = mkdev(math.MaxUint32, math.MaxUint32)
+	require.NoError(t, err)
+}
+
+// TestCreateDeviceRoundTrip creates real device nodes and reads them back
+// through LocalFS, confirming that the major/minor written to disk are the
+// ones the archive asked for. Requires root, so it only runs where the tests
+// are executed as root.
+func TestCreateDeviceRoundTrip(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("creating device nodes requires root")
+	}
+	for _, tc := range devTestCases {
+		dir := t.TempDir()
+		fs := NewLocalFS(dir, LocalFSOptions{})
+		n := NodeDevice{
+			Name:  "dev",
+			Mode:  os.ModeDevice | os.ModeCharDevice | 0666,
+			Major: tc.major,
+			Minor: tc.minor,
+		}
+		require.NoError(t, fs.CreateDevice(n))
+		require.NoError(t, fs.Close())
+
+		var st unix.Stat_t
+		require.NoError(t, unix.Lstat(filepath.Join(dir, "dev"), &st))
+		assert.Equal(t, tc.major, uint64(unix.Major(uint64(st.Rdev))), "major of %d:%d", tc.major, tc.minor)
+		assert.Equal(t, tc.minor, uint64(unix.Minor(uint64(st.Rdev))), "minor of %d:%d", tc.major, tc.minor)
+
+		// Read it back the way tar does, which must report the same pair.
+		src := NewLocalFS(dir, LocalFSOptions{})
+		var found *File
+		for {
+			f, err := src.Next()
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+			if f.IsDevice() {
+				found = f
+			}
+		}
+		require.NotNil(t, found, "device not returned by LocalFS")
+		assert.Equal(t, tc.major, found.DevMajor, "DevMajor of %d:%d", tc.major, tc.minor)
+		assert.Equal(t, tc.minor, found.DevMinor, "DevMinor of %d:%d", tc.major, tc.minor)
+	}
+}

--- a/localfs_mknod_freebsd.go
+++ b/localfs_mknod_freebsd.go
@@ -16,10 +16,14 @@ import (
 // name that has no path separators, so it cannot escape Root. FreeBSD's
 // mknodat takes the device number as uint64, unlike the int taken on Linux.
 func (fs *LocalFS) createDeviceNode(r *os.Root, n NodeDevice) error {
+	dev, err := mkdev(n.Major, n.Minor)
+	if err != nil {
+		return err
+	}
 	df, err := r.Open(path.Dir(n.Name))
 	if err != nil {
 		return err
 	}
 	defer df.Close()
-	return unix.Mknodat(int(df.Fd()), path.Base(n.Name), FilemodeToStatMode(n.Mode)|0666, mkdev(n.Major, n.Minor))
+	return unix.Mknodat(int(df.Fd()), path.Base(n.Name), FilemodeToStatMode(n.Mode)|0666, dev)
 }

--- a/localfs_mknod_linux.go
+++ b/localfs_mknod_linux.go
@@ -15,10 +15,14 @@ import (
 // that directory fd with a base name that has no path separators, so it
 // cannot escape Root.
 func (fs *LocalFS) createDeviceNode(r *os.Root, n NodeDevice) error {
+	dev, err := mkdev(n.Major, n.Minor)
+	if err != nil {
+		return err
+	}
 	df, err := r.Open(path.Dir(n.Name))
 	if err != nil {
 		return err
 	}
 	defer df.Close()
-	return unix.Mknodat(int(df.Fd()), path.Base(n.Name), FilemodeToStatMode(n.Mode)|0666, int(mkdev(n.Major, n.Minor)))
+	return unix.Mknodat(int(df.Fd()), path.Base(n.Name), FilemodeToStatMode(n.Mode)|0666, int(dev))
 }

--- a/localfs_mknod_other.go
+++ b/localfs_mknod_other.go
@@ -18,11 +18,15 @@ import (
 // single-threaded, so there is no concurrent attacker able to swap a
 // component between this check and the mknod call.
 func (fs *LocalFS) createDeviceNode(r *os.Root, n NodeDevice) error {
+	dev, err := mkdev(n.Major, n.Minor)
+	if err != nil {
+		return err
+	}
 	df, err := r.Open(path.Dir(n.Name))
 	if err != nil {
 		return err
 	}
 	df.Close()
 	dst := filepath.Join(fs.rootReal, n.Name)
-	return unix.Mknod(dst, FilemodeToStatMode(n.Mode)|0666, int(mkdev(n.Major, n.Minor)))
+	return unix.Mknod(dst, FilemodeToStatMode(n.Mode)|0666, int(dev))
 }

--- a/localfs_other.go
+++ b/localfs_other.go
@@ -6,6 +6,7 @@ package desync
 import (
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/pkg/xattr"
+	"golang.org/x/sys/unix"
 )
 
 // NewLocalFS initializes a new instance of a local filesystem that
@@ -193,12 +195,14 @@ func (fs *LocalFS) CreateDevice(n NodeDevice) error {
 	return r.Chtimes(n.Name, n.MTime, n.MTime)
 }
 
-func mkdev(major, minor uint64) uint64 {
-	dev := (major & 0x00000fff) << 8
-	dev |= (major & 0xfffff000) << 32
-	dev |= (minor & 0x000000ff) << 0
-	dev |= (minor & 0xffffff00) << 12
-	return dev
+// mkdev encodes a major/minor pair from a catar into a device number. The
+// layout of dev_t differs between operating systems, so this defers to
+// x/sys/unix rather than hard-coding one platform's encoding.
+func mkdev(major, minor uint64) (uint64, error) {
+	if major > math.MaxUint32 || minor > math.MaxUint32 {
+		return 0, fmt.Errorf("device number %d:%d out of range", major, minor)
+	}
+	return unix.Mkdev(uint32(major), uint32(minor)), nil
 }
 
 // Next returns the next filesystem entry or io.EOF when done. The caller is responsible
@@ -224,8 +228,11 @@ func (fs *LocalFS) Next() (*File, error) {
 	case *syscall.Stat_t:
 		uid = int(sys.Uid)
 		gid = int(sys.Gid)
-		major = uint64((sys.Rdev >> 8) & 0xfff)
-		minor = (uint64(sys.Rdev) % 256) | ((uint64(sys.Rdev) & 0xfff00000) >> 12)
+		// As with mkdev, the split of dev_t into major/minor is
+		// platform-specific. Both accessors mask the value, so the
+		// sign-extension of the signed dev_t on Darwin is harmless.
+		major = uint64(unix.Major(uint64(sys.Rdev)))
+		minor = uint64(unix.Minor(uint64(sys.Rdev)))
 	default:
 		panic("unsupported platform")
 	}


### PR DESCRIPTION
`mkdev` built device numbers with Linux's `dev_t` layout on every platform, and the read side in `localfs_other.go` split `Rdev` with Linux's layout too. Those encodings differ between operating systems, so on macOS this produced wrong device nodes:

- A catar entry for major 1, minor 3 was created as major 0, minor 259. Linux packs the major at `<<8`, Darwin at `<<24`.
- Reading `/dev/null` back reported major 0, minor 12290 instead of 3, 2.

FreeBSD's encoding happens to agree with Linux's for the small major/minor values in practical use (`(major << 8) | minor` in both), so it was unaffected — this is a macOS bug in practice, though the code was wrong in principle everywhere.

The fix defers to `x/sys/unix`, which implements `Mkdev`, `Major` and `Minor` per platform. On Linux the write encoding is byte-for-byte what it was; the read path there additionally stops truncating majors above 12 bits and minors above 20.

`mkdev` now also returns an error when a major or minor from the archive is too large for the platform to represent, rather than silently truncating it into a different device.

**Tests**

- `TestMkdev` round-trips major/minor through the platform's own accessors. It runs everywhere without privileges, and fails on macOS under the old layout — so the macOS leg of CI is what demonstrates the fix.
- `TestMkdevOutOfRange` covers the new range check.
- `TestCreateDeviceRoundTrip` creates real device nodes and reads them back through `LocalFS`, both the `Rdev` on disk and the `DevMajor`/`DevMinor` that `tar` would see. Creating device nodes needs root, so it runs in the FreeBSD VM job and skips elsewhere. Verified locally on Linux under sudo.

Cross-compiles and vets clean for darwin (amd64/arm64), freebsd, linux/arm64 and windows; full suite and `-race` pass on Linux.