### PR TITLE
Apply the timeout store option to S3 stores

### DIFF
--- a/s3.go
+++ b/s3.go
@@ -100,9 +100,16 @@ func (s S3Store) GetChunk(id ChunkID) (*Chunk, error) {
 	var attempt int
 retry:
 	attempt++
-	obj, err := s.client.GetObject(context.Background(), s.bucket, name, minio.GetObjectOptions{})
+	// The context bounds the whole attempt, not just the request setup: the
+	// object body is read below, and GetObject only issues the request on the
+	// first read. Each attempt gets its own, mirroring the per-request timeout
+	// the HTTP stores get from their client.
+	ctx, cancel := s.opt.contextWithTimeout(context.Background())
+	defer cancel()
+	obj, err := s.client.GetObject(ctx, s.bucket, name, minio.GetObjectOptions{})
 	if err != nil {
 		if attempt <= s.opt.ErrorRetry {
+			cancel()
 			time.Sleep(time.Duration(attempt) * s.opt.ErrorRetryBaseInterval)
 			goto retry
 		}
@@ -125,6 +132,7 @@ retry:
 		}
 		if attempt <= s.opt.ErrorRetry {
 			obj.Close()
+			cancel()
 			time.Sleep(time.Duration(attempt) * s.opt.ErrorRetryBaseInterval)
 			goto retry
 		}
@@ -144,6 +152,7 @@ retry:
 				"attempt": attempt,
 			}).WithError(err).Info("chunk failed validation, retrying")
 			obj.Close()
+			cancel()
 			time.Sleep(time.Duration(attempt) * s.opt.ErrorRetryBaseInterval)
 			goto retry
 		}
@@ -163,9 +172,12 @@ func (s S3Store) StoreChunk(chunk *Chunk) error {
 	var attempt int
 retry:
 	attempt++
-	_, err = s.client.PutObject(context.Background(), s.bucket, name, bytes.NewReader(b), int64(len(b)), minio.PutObjectOptions{ContentType: contentType})
+	ctx, cancel := s.opt.contextWithTimeout(context.Background())
+	defer cancel()
+	_, err = s.client.PutObject(ctx, s.bucket, name, bytes.NewReader(b), int64(len(b)), minio.PutObjectOptions{ContentType: contentType})
 	if err != nil {
 		if attempt < s.opt.ErrorRetry {
+			cancel()
 			time.Sleep(time.Duration(attempt) * s.opt.ErrorRetryBaseInterval)
 			goto retry
 		}
@@ -176,7 +188,9 @@ retry:
 // HasChunk returns true if the chunk is in the store
 func (s S3Store) HasChunk(id ChunkID) (bool, error) {
 	name := s.nameFromID(id)
-	_, err := s.client.StatObject(context.Background(), s.bucket, name, minio.StatObjectOptions{})
+	ctx, cancel := s.opt.contextWithTimeout(context.Background())
+	defer cancel()
+	_, err := s.client.StatObject(ctx, s.bucket, name, minio.StatObjectOptions{})
 	return err == nil, nil
 }
 
@@ -184,7 +198,9 @@ func (s S3Store) HasChunk(id ChunkID) (bool, error) {
 // Used when verifying and repairing caches.
 func (s S3Store) RemoveChunk(id ChunkID) error {
 	name := s.nameFromID(id)
-	return s.client.RemoveObject(context.Background(), s.bucket, name, minio.RemoveObjectOptions{})
+	ctx, cancel := s.opt.contextWithTimeout(context.Background())
+	defer cancel()
+	return s.client.RemoveObject(ctx, s.bucket, name, minio.RemoveObjectOptions{})
 }
 
 // Prune removes any chunks from the store that are not contained in a list (map)

--- a/s3_test.go
+++ b/s3_test.go
@@ -445,3 +445,49 @@ func TestS3StoreGetMissingChunk(t *testing.T) {
 	require.ErrorAs(t, err, &missing)
 	require.EqualValues(t, 1, atomic.LoadInt32(&requests), "missing chunk should not be retried")
 }
+
+// A store configured with a timeout must give up on an endpoint that never
+// responds. S3 stores previously ignored the timeout option entirely and would
+// block for as long as the server held the connection open.
+func TestS3StoreTimeout(t *testing.T) {
+	chunkId, err := ChunkIDFromString("dda036db05bc2b99b6b9303d28496000c34b246457ae4bbf00fe625b5cabd7cd")
+	require.NoError(t, err)
+	provider := MockCredProvider{}
+
+	release := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+	}))
+	// Unblock the handler before shutting the server down, since Close waits
+	// for outstanding requests.
+	defer ts.Close()
+	defer close(release)
+
+	u, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+
+	endpoint := url.URL{Scheme: "s3+http", Host: u.Host, Path: "/doomsdaydevices/blob1.store/"}
+	store, err := NewS3Store(&endpoint, credentials.New(&provider), "vertucon-central",
+		StoreOptions{Timeout: 100 * time.Millisecond}, minio.BucketLookupAuto)
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := store.GetChunk(chunkId)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "expected the request to be cut short by the timeout")
+	case <-time.After(30 * time.Second):
+		require.FailNow(t, "GetChunk did not observe the store timeout")
+	}
+
+	// A negative timeout means infinite, which must produce a context with no
+	// deadline rather than one that has already expired.
+	ctx, cancel := StoreOptions{Timeout: -1}.contextWithTimeout(context.Background())
+	defer cancel()
+	_, hasDeadline := ctx.Deadline()
+	require.False(t, hasDeadline, "a negative timeout means no deadline")
+}

--- a/s3index.go
+++ b/s3index.go
@@ -36,11 +36,28 @@ func NewS3IndexStore(location *url.URL, s3Creds *credentials.Credentials, region
 // GetIndexReader returns a reader for an index from an S3 store. Fails if the specified index
 // file does not exist.
 func (s S3IndexStore) GetIndexReader(name string) (r io.ReadCloser, e error) {
-	obj, err := s.client.GetObject(context.Background(), s.bucket, s.prefix+name, minio.GetObjectOptions{})
+	// The index is read by the caller, after this returns, so the timeout has
+	// to cover the lifetime of the reader rather than just this call. Tie the
+	// context to Close instead of cancelling it here.
+	ctx, cancel := s.opt.contextWithTimeout(context.Background())
+	obj, err := s.client.GetObject(ctx, s.bucket, s.prefix+name, minio.GetObjectOptions{})
 	if err != nil {
+		cancel()
 		return r, errors.Wrap(err, s.String())
 	}
-	return obj, nil
+	return cancelOnClose{ReadCloser: obj, cancel: cancel}, nil
+}
+
+// cancelOnClose releases a context when the reader it guards is closed.
+type cancelOnClose struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (c cancelOnClose) Close() error {
+	err := c.ReadCloser.Close()
+	c.cancel()
+	return err
 }
 
 // GetIndex returns an Index structure from the store
@@ -63,6 +80,9 @@ func (s S3IndexStore) StoreIndex(name string, idx Index) error {
 		idx.WriteTo(w)
 	}()
 
-	_, err := s.client.PutObject(context.Background(), s.bucket, s.prefix+name, r, -1, minio.PutObjectOptions{ContentType: contentType})
+	ctx, cancel := s.opt.contextWithTimeout(context.Background())
+	defer cancel()
+
+	_, err := s.client.PutObject(ctx, s.bucket, s.prefix+name, r, -1, minio.PutObjectOptions{ContentType: contentType})
 	return errors.Wrap(err, path.Base(s.Location))
 }

--- a/store.go
+++ b/store.go
@@ -210,6 +210,18 @@ func (o StoreOptions) tlsClientConfig() (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
+// contextWithTimeout derives a context bound to the store's timeout option,
+// for clients that take a context per operation rather than a timeout on the
+// HTTP client. A store configured for an infinite timeout gets a context that
+// is only cancellable. The returned cancel function must always be called.
+func (o StoreOptions) contextWithTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	timeout := o.effectiveTimeout()
+	if timeout <= 0 {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, timeout)
+}
+
 // effectiveTimeout returns the HTTP client timeout for a network store. If no
 // timeout was given in config (set to 0), then use 1 minute. If timeout is
 // negative, use 0 to set an infinite timeout.


### PR DESCRIPTION
The `timeout` store option is documented as the time limit for chunk read/write, but S3 stores ignored it. The HTTP and OCI stores set it on their `http.Client`; the minio client instead takes a context per operation, and was being handed `context.Background()`. An endpoint that accepted the connection and then went quiet would hang indefinitely.

`StoreOptions.contextWithTimeout` derives a context from the same `effectiveTimeout()` the HTTP stores use. The one trap worth calling out: `effectiveTimeout()` returns `0` to mean *infinite* (for `http.Client.Timeout`), and `context.WithTimeout(ctx, 0)` is already expired — so a negative configured timeout has to produce a plain cancellable context instead.

Where it applies:

- **Chunk read/write** — a fresh timeout per attempt, so it bounds each try rather than the whole retry sequence. It also covers reading the body, since minio only issues the request on the first read of the returned object.
- **Index read** — `GetIndexReader` hands the reader back for the caller to consume, so cancelling on return would break it. The context is cancelled when the reader is closed instead.
- **`Prune`'s listing** — left on the caller's context. A per-object timeout has no sensible meaning for an operation that walks the whole store.

**Behaviour change.** Existing S3 users get a one-minute default deadline where previously there was none, which matches what HTTP store users already have. Chunks are at most 256KB so the default is generous, but a slow link pushing a large index could newly hit it. A negative `timeout` restores the old behaviour.

**Tests.** `TestS3StoreTimeout` points a store at a server that never responds and asserts `GetChunk` gives up, then checks that a negative timeout yields a context with no deadline. Confirmed it fails without the change — it runs into the test's own 30s guard.

Also exercised against a real MinIO: a normal round-trip under the default timeout, an `extract` with `"timeout": -1`, and `"timeout": 1` (1ns) failing fast with `context deadline exceeded`.