### PR TITLE
Add a version command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,11 @@ before:
 
 builds:
   - main: ./cmd/desync
+    ldflags:
+      - -s -w
+      - -X main.version={{.Tag}}
+      - -X main.commit={{.FullCommit}}
+      - -X main.date={{.Date}}
     goos:
       - linux
       - darwin

--- a/README.md
+++ b/README.md
@@ -502,6 +502,7 @@ The CLI tool uses the desync library and makes most features available in a cons
 | Command | Description |
 | --- | --- |
 | `config` | Show or write the config file |
+| `version` | Show the version, commit and build details. `--version` prints just the version |
 | `manpage` | Generate manpages for desync |
 
 <details>
@@ -516,6 +517,7 @@ Not all options apply to all commands.
 | `--config <file>` | Path to config file. Default: `$HOME/.config/desync/config.json`. |
 | `--digest <algorithm>` | Digest algorithm: `sha512-256` (default) or `sha256`. |
 | `--verbose` | Enable verbose/debug logging. |
+| `--version` | Print the version and exit. See the `version` command for build details. |
 
 **Store options:**
 

--- a/cmd/desync/main.go
+++ b/cmd/desync/main.go
@@ -63,6 +63,7 @@ func main() {
 		newVerifyCommand(ctx),
 		newVerifyIndexCommand(ctx),
 		newMtreeCommand(ctx),
+		newVersionCommand(),
 		newManpageCommand(ctx, rootCmd),
 	)
 

--- a/cmd/desync/root.go
+++ b/cmd/desync/root.go
@@ -24,7 +24,12 @@ Store locations, used with options like -s/--store and -c/--cache, can be:
 Commands that accept multiple stores try them in the order given. Several
 stores can also be combined into one failover group by separating them with
 '|', for example -s "http://server1/store|http://server2/store".`,
+		// Makes cobra provide --version. The 'version' command prints more.
+		Version: currentBuild().Version,
 	}
+	// Registered here so cobra doesn't claim -v as its shorthand, which users
+	// would reasonably expect to mean --verbose.
+	cmd.Flags().Bool("version", false, "print the version and exit")
 	cmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default $HOME/.config/desync/config.json)")
 	cmd.PersistentFlags().StringVar(&digestAlgorithm, "digest", "sha512-256", "digest algorithm, sha512-256 or sha256")
 	cmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "verbose mode")

--- a/cmd/desync/version.go
+++ b/cmd/desync/version.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+
+	"github.com/spf13/cobra"
+)
+
+// Populated with -ldflags at release time, for example by goreleaser. When
+// they are empty, which is the case for 'go install' and for local builds, the
+// values come from the build information the toolchain embeds instead.
+var (
+	version string
+	commit  string
+	date    string
+)
+
+// buildInfo describes the running binary.
+type buildInfo struct {
+	Version   string `json:"version"`
+	Commit    string `json:"commit,omitempty"`
+	Date      string `json:"date,omitempty"`
+	GoVersion string `json:"go-version"`
+	OS        string `json:"os"`
+	Arch      string `json:"arch"`
+}
+
+// currentBuild describes the running binary, preferring values injected at
+// link time and falling back to what the toolchain embedded. A module
+// installed with 'go install' carries its version, and a build from a checkout
+// carries the revision and its timestamp, so in practice only a build from a
+// source tarball has nothing to report.
+func currentBuild() buildInfo {
+	b := buildInfo{
+		Version:   version,
+		Commit:    commit,
+		Date:      date,
+		GoVersion: runtime.Version(),
+		OS:        runtime.GOOS,
+		Arch:      runtime.GOARCH,
+	}
+
+	// Whether the version was injected at link time rather than derived below.
+	linked := b.Version != ""
+
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		if b.Version == "" {
+			b.Version = bi.Main.Version
+		}
+		var modified bool
+		for _, s := range bi.Settings {
+			switch s.Key {
+			case "vcs.revision":
+				if b.Commit == "" {
+					b.Commit = s.Value
+				}
+			case "vcs.time":
+				if b.Date == "" {
+					b.Date = s.Value
+				}
+			case "vcs.modified":
+				modified = s.Value == "true"
+			}
+		}
+		// Built from a tree with uncommitted changes, which is worth knowing
+		// when the version is quoted in a bug report. Only needed for a linked
+		// version, since the toolchain already marks a derived one.
+		if modified && linked {
+			b.Version += "+dirty"
+		}
+	}
+
+	if b.Version == "" {
+		b.Version = "unknown"
+	}
+	return b
+}
+
+type versionOptions struct {
+	format string
+}
+
+func newVersionCommand() *cobra.Command {
+	var opt versionOptions
+
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Show the desync version",
+		Long: `Prints the version of desync along with the commit it was built from, the
+build time, and the Go toolchain and platform used.`,
+		Example: `  desync version
+  desync version --format=json`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runVersion(opt)
+		},
+		SilenceUsage: true,
+	}
+	cmd.Flags().StringVarP(&opt.format, "format", "f", "plain", "output format, plain or json")
+	return cmd
+}
+
+func runVersion(opt versionOptions) error {
+	b := currentBuild()
+	switch opt.format {
+	case "json":
+		return printJSON(stdout, b)
+	case "plain", "":
+		fmt.Fprintf(stdout, "desync version %s\n", b.Version)
+		if b.Commit != "" {
+			fmt.Fprintf(stdout, "commit:  %s\n", b.Commit)
+		}
+		if b.Date != "" {
+			fmt.Fprintf(stdout, "built:   %s\n", b.Date)
+		}
+		fmt.Fprintf(stdout, "go:      %s\n", b.GoVersion)
+		fmt.Fprintf(stdout, "os/arch: %s/%s\n", b.OS, b.Arch)
+		return nil
+	default:
+		return fmt.Errorf("invalid output format '%s'", opt.format)
+	}
+}

--- a/cmd/desync/version_test.go
+++ b/cmd/desync/version_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The version has to be reported even without link-time values, which is the
+// case for 'go install' and for local builds, where it comes from the build
+// information the toolchain embeds.
+func TestVersionCommand(t *testing.T) {
+	run := func(t *testing.T, args ...string) string {
+		t.Helper()
+		cmd := newVersionCommand()
+		cmd.SetArgs(args)
+		b := new(bytes.Buffer)
+		stdout = b
+		cmd.SetOutput(io.Discard)
+		_, err := cmd.ExecuteC()
+		require.NoError(t, err)
+		return b.String()
+	}
+
+	require.Contains(t, run(t), "desync version ")
+
+	var got buildInfo
+	require.NoError(t, json.Unmarshal([]byte(run(t, "--format=json")), &got))
+	require.NotEmpty(t, got.Version)
+	require.NotEqual(t, "unknown", got.Version, "expected a version from the embedded build info")
+	require.Equal(t, runtime.Version(), got.GoVersion)
+	require.Equal(t, runtime.GOOS, got.OS)
+	require.Equal(t, runtime.GOARCH, got.Arch)
+}


### PR DESCRIPTION
There was no way to tell which build of desync was running — `desync --version` failed with `unknown flag`. That makes a bug report hard to place, and gives deployment scripts nothing to check.

```
$ desync version
desync version v1.1.0
commit:  1aeccdc64c044afa9bffa359892a6a4a68ccd11e
built:   2026-08-29T13:01:26Z
go:      go1.27.0
os/arch: linux/amd64
```

`--format=json` emits the same fields for scripting, and `--version` on the root command prints just the first line.

**Where the version comes from.** Link-time values are preferred, with the build information the toolchain embeds as the fallback, so every install path reports something useful without needing a build step:

| Install path | Result |
| --- | --- |
| `go install …@v1.1.0` | `v1.1.0` — no ldflags, but the module version is embedded |
| build from a checkout | `v1.1.1-0.20260829122901-1aeccdc64c04`, from the last tag plus `vcs.revision`/`vcs.time`; `+dirty` if the tree is modified |
| release binary | the exact tag, from ldflags |
| source tarball | the toolchain's own `(devel)` — nothing better exists, so it isn't faked |

`.goreleaser.yml` now sets the ldflags explicitly instead of relying on goreleaser's implicit defaults, using `{{.Tag}}` rather than `{{.Version}}` so releases report the same `v`-prefixed form as the fallback rather than dropping the `v`.

**`--version` is registered explicitly** rather than left to cobra, which would otherwise claim `-v` as its shorthand. With a `--verbose` flag on the same command, `-v` meaning "version" is a trap worth avoiding, and it leaves the shorthand free.

**Verified:** the `go install` and checkout paths by inspecting the embedded build info, and the release path by running `goreleaser build --snapshot` and checking the resulting binary (output above is from that build). `goreleaser check` passes on the config. One test covers both output formats and asserts the fallback produces a real version rather than `unknown`.