### PR TITLE
Stop calling desync a drop-in replacement for casync

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Content-addressed binary distribution, reimplemented in Go.
 [![CI](https://github.com/folbricht/desync/actions/workflows/validate.yaml/badge.svg)](https://github.com/folbricht/desync/actions/workflows/validate.yaml)
 [![License](https://img.shields.io/github/license/folbricht/desync)](LICENSE)
 
-desync is a Go library and CLI tool that re-implements [casync](https://github.com/systemd/casync) features for content-addressed binary distribution. It chunks large files using a rolling hash, deduplicates and compresses chunks with [zstd](https://github.com/facebook/zstd), and distributes them via multiple store backends. It maintains compatibility with casync's data structures, protocols and types (chunk stores, index files, archives) to function as a drop-in replacement.
+desync is a Go library and CLI tool that re-implements [casync](https://github.com/systemd/casync) features for content-addressed binary distribution. It chunks large files using a rolling hash, deduplicates and compresses chunks with [zstd](https://github.com/facebook/zstd), and distributes them via multiple store backends. It maintains compatibility with casync's data structures, protocols and types (chunk stores, index files, archives), so both tools can be used against the same data. It is not a drop-in replacement on the command line: the options differ, and desync has commands casync doesn't.
 
 ## Key Features
 
@@ -1101,7 +1101,7 @@ desync info --seed local_index.caibx --format=json update.caibx
 - **Cross-platform over platform-specific features** — where upstream casync takes full advantage of Linux platform features, desync implements a minimum feature set. High-value platform-specific features (such as Btrfs reflinks) are added while maintaining the ability to build on other platforms.
 - **Hash functions** — both SHA512/256 and SHA256 are supported.
 - **Compression** — only zstd compression and uncompressed stores are supported.
-- **casync as drop-in replacement** — desync can serve as a drop-in replacement for casync on SSH servers for read-only chunk serving. Set `CASYNC_REMOTE_PATH=desync` on the client.
+- **Serving casync clients** — desync can stand in for the casync binary on SSH servers for read-only chunk serving. Set `CASYNC_REMOTE_PATH=desync` on the client.
 - **catar limitations** — SELinux and ACLs in existing catar files are ignored and won't be present in newly created catars. FCAPs are supported only as a verbatim copy of the `security.capability` XAttr.
 
 ## Links


### PR DESCRIPTION
The intro claimed compatibility with casync's data structures "to function as a drop-in replacement". The data compatibility part is real and worth keeping — chunk stores, indexes and archives are interchangeable, and since #393 `make` produces byte-identical blob indexes — but the CLI is not interchangeable: the options differ and desync has commands casync doesn't.

The CLI Reference section already says "It does not match upstream casync's syntax exactly, but tries to be similar", so the intro was contradicting a caveat further down the same page.

```diff
-... (chunk stores, index files, archives) to function as a drop-in replacement.
+... (chunk stores, index files, archives), so both tools can be used against the
+same data. It is not a drop-in replacement on the command line: the options
+differ, and desync has commands casync doesn't.
```

## The other mention is accurate and stays

Design Philosophy has a second "drop-in replacement" reference, and that one is true — desync can stand in for the casync *binary* on an SSH server serving chunks read-only, which is exactly what the `pull` command implements (`desync pull - - - <store>`, selected by `CASYNC_REMOTE_PATH=desync` on the client). Only its bold lead-in, "casync as drop-in replacement", read like the general claim out of context, so it's now scoped to what it describes:

```diff
-- **casync as drop-in replacement** — desync can serve as a drop-in replacement for casync on SSH servers ...
+- **Serving casync clients** — desync can stand in for the casync binary on SSH servers ...
```

The same wording in `desync pull --help` is left alone — it's already scoped to SSH remote stores and is correct there.