### PR TITLE
Support storing indexes in OCI registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Indexes are stored as their own artifact, a blob holding the index referenced by
 
 Indexes and chunks can share a repository. `prune` only ever deletes chunk artifacts, so indexes in the same repository are left alone, and a chunk lookup is never satisfied by an index. Keeping them in separate repositories is still tidier, since registry UIs list one version per tag:
 
-```text
+```sh
 desync make -s oci+https://ghcr.io/myuser/chunks \
   oci+https://ghcr.io/myuser/indexes/file.iso.caibx file.iso
 ```
@@ -340,6 +340,8 @@ desync make -s oci+https://ghcr.io/myuser/chunks \
 Because the index name is used as a tag it has to fit the OCI tag grammar: word characters, dots and dashes, not starting with a dot or dash, at most 128 characters. `file.iso.caibx` and `rootfs-v2.caidx` are fine, a name containing `/` is not. Note also that pushing an index that already exists overwrites the tag, which registries configured for immutable tags will reject, and that removing an index needs the same manifest deletion support described under [Pruning](#pruning).
 
 Storing an index in a registry does not keep its chunks alive there. It doesn't need to: every chunk already has its own tagged manifest holding a reference to its blob.
+
+Two things to be aware of when indexes and chunks share a repository. Store options are looked up by location, so a `store-options` entry for the repository applies to the index as well as the chunks; if that entry enables encryption, index operations fail, as described under [Chunk Encryption](#chunk-encryption). Keep the indexes in a separate repository in that case, or add a more specific entry without encryption for them. The `timeout` option is applied differently too: for indexes it bounds the wait for a response rather than the whole transfer, so a large index isn't cut off part way through by the one minute default.
 
 #### Authentication
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ catar archives can also be extracted to GNU tar archive streams. All files in th
 | Use as cache | yes | yes | yes | yes | yes | no | yes |
 | Prune | yes | yes | yes | no | yes | no | yes |
 | Verify | yes | no | no | no | no | no | no |
+| Store indexes | yes | yes | yes | yes | yes | no | yes |
 
 ### Store Architecture
 
@@ -274,7 +275,7 @@ oci+https://ghcr.io/myuser/mystore
 oci+http://127.0.0.1:5000/test/store
 ```
 
-An OCI store supports reading, writing, pruning, and use as a cache, so it works with `make`, `extract`, `chop`, `cache`, `info`, `prune` and every other command that takes a `-s` store. Note that index files (`.caibx`/`.caidx`) cannot be stored in a registry, only chunks — distribute the index via an [index store](#remote-indexes) or any other file transfer.
+An OCI store supports reading, writing, pruning, and use as a cache, so it works with `make`, `extract`, `chop`, `cache`, `info`, `prune` and every other command that takes a `-s` store. Indexes can be kept in a registry too, so a registry can hold everything needed to distribute a file — see [Indexes in a registry](#indexes-in-a-registry) below.
 
 #### How chunks are stored
 
@@ -312,6 +313,33 @@ This layout has a few important properties:
 Be aware that registry UIs show one tag (or "package version") per chunk, so a store with many chunks makes for a noisy listing. Using a repository dedicated to the chunk store is recommended, although unrelated artifacts sharing the repository are safe, even from `prune`.
 
 Reading a chunk takes two requests (manifest by tag, then blob), an existence check takes one, and writing takes three. desync requests chunks concurrently, which hides much of the added round-trip latency, but combining a registry store with a local cache (`-c`) is still more worthwhile than for most other store types.
+
+#### Indexes in a registry
+
+Indexes can be stored in a registry as well, which means a registry can hold everything needed to distribute a file, with no other server or file transfer involved. The index location is the repository followed by the index name, and the name becomes the tag:
+
+```sh
+# Chunk the file, storing chunks and the index in the registry
+desync make -s oci+https://ghcr.io/myuser/mystore \
+  oci+https://ghcr.io/myuser/mystore/file.iso.caibx file.iso
+
+# On another machine, reassemble it from the registry alone
+desync extract -s oci+https://ghcr.io/myuser/mystore \
+  oci+https://ghcr.io/myuser/mystore/file.iso.caibx file.iso
+```
+
+Indexes are stored as their own artifact, a blob holding the index referenced by a manifest tagged with the index name and carrying the artifact type `application/vnd.desync.index.v1`. The manifest also records the number of chunks, the size of the indexed blob, and the chunk sizes as annotations, so the shape of an index can be read without fetching it.
+
+Indexes and chunks can share a repository. `prune` only ever deletes chunk artifacts, so indexes in the same repository are left alone, and a chunk lookup is never satisfied by an index. Keeping them in separate repositories is still tidier, since registry UIs list one version per tag:
+
+```text
+desync make -s oci+https://ghcr.io/myuser/chunks \
+  oci+https://ghcr.io/myuser/indexes/file.iso.caibx file.iso
+```
+
+Because the index name is used as a tag it has to fit the OCI tag grammar: word characters, dots and dashes, not starting with a dot or dash, at most 128 characters. `file.iso.caibx` and `rootfs-v2.caidx` are fine, a name containing `/` is not. Note also that pushing an index that already exists overwrites the tag, which registries configured for immutable tags will reject, and that removing an index needs the same manifest deletion support described under [Pruning](#pruning).
+
+Storing an index in a registry does not keep its chunks alive there. It doesn't need to: every chunk already has its own tagged manifest holding a reference to its blob.
 
 #### Authentication
 
@@ -439,7 +467,7 @@ Encryption provides confidentiality, while integrity comes from desync's regular
 
 ### Remote Indexes
 
-Indexes can be stored and retrieved from remote locations via SFTP, S3, and HTTP. Storing indexes remotely is optional and deliberately separate from chunk storage. While it's possible to store indexes in the same location as chunks in the case of SFTP and S3, this should only be done in secured environments. The built-in HTTP chunk store (`chunk-server` command) can not be used as index server. Use the `index-server` command instead to start an index server that serves indexes and can optionally store them as well (with `-w`).
+Indexes can be stored and retrieved from remote locations via SFTP, S3, GCS, HTTP, and OCI registries. Storing indexes remotely is optional and deliberately separate from chunk storage. While it's possible to store indexes in the same location as chunks in the case of SFTP, S3 and OCI registries, this should only be done in secured environments. The built-in HTTP chunk store (`chunk-server` command) can not be used as index server. Use the `index-server` command instead to start an index server that serves indexes and can optionally store them as well (with `-w`).
 
 Using remote indexes, it is possible to use desync completely file-less. For example when wanting to share a large file with `mount-index`, one could read the index from an index store like this:
 

--- a/README.md
+++ b/README.md
@@ -341,7 +341,9 @@ Because the index name is used as a tag it has to fit the OCI tag grammar: word 
 
 Storing an index in a registry does not keep its chunks alive there. It doesn't need to: every chunk already has its own tagged manifest holding a reference to its blob.
 
-Two things to be aware of when indexes and chunks share a repository. Store options are looked up by location, so a `store-options` entry for the repository applies to the index as well as the chunks; if that entry enables encryption, index operations fail, as described under [Chunk Encryption](#chunk-encryption). Keep the indexes in a separate repository in that case, or add a more specific entry without encryption for them. The `timeout` option is applied differently too: for indexes it bounds the wait for a response rather than the whole transfer, so a large index isn't cut off part way through by the one minute default.
+Two things to be aware of when indexes and chunks share a repository. Store options are looked up by location, so a `store-options` entry for the repository applies to the index as well as the chunks; if that entry enables encryption, index operations fail, as described under [Chunk Encryption](#chunk-encryption). Keep the indexes in a separate repository in that case, or add a more specific entry without encryption for them. The `timeout` option is applied differently too: for indexes it bounds how long a transfer may make no progress rather than how long it may take, so a large index isn't cut off part way through by the one minute default while a registry that stops responding mid-transfer still fails.
+
+Indexes over 32 MiB, which is about 840,000 chunks, roughly a 50 GB blob at the default chunk size, are streamed to the registry rather than serialized into memory first. The request body can't be rewound in that case, so `error-retry` doesn't apply to the upload and an access token that expires part way through surfaces as a `401` instead of being renewed. Registry tokens are often short-lived, so for indexes that big prefer credentials that don't expire mid-push, or split the input across several smaller indexes.
 
 #### Authentication
 

--- a/cmd/desync/make.go
+++ b/cmd/desync/make.go
@@ -57,6 +57,10 @@ func runMake(ctx context.Context, opt makeOptions, args []string) error {
 	indexFile := args[0]
 	dataFile := args[1]
 
+	if err := validateIndexLocation(indexFile); err != nil {
+		return err
+	}
+
 	// Open the target store if one was given
 	var s desync.WriteStore
 	if opt.store != "" {

--- a/cmd/desync/store.go
+++ b/cmd/desync/store.go
@@ -254,7 +254,14 @@ func indexStoreFromLocation(location string, cmdOpt cmdStoreOptions) (desync.Ind
 	case "ssh":
 		return nil, "", errors.New("Index storage is not supported by ssh remote stores")
 	case "oci+https", "oci+http":
-		return nil, "", errors.New("Index storage is not supported by oci registry stores")
+		creds, err := cfg.GetOCICredentialsFor(&p)
+		if err != nil {
+			return nil, "", err
+		}
+		s, err = desync.NewOCIIndexStore(&p, creds, opt)
+		if err != nil {
+			return nil, "", err
+		}
 	case "sftp":
 		s, err = desync.NewSFTPIndexStore(&p, opt)
 		if err != nil {

--- a/cmd/desync/store.go
+++ b/cmd/desync/store.go
@@ -193,8 +193,8 @@ func readCaibxFile(location string, cmdOpt cmdStoreOptions) (c desync.Index, err
 func validateIndexLocation(location string) error {
 	loc, err := url.Parse(location)
 	if err != nil {
-		// Not a URL, so it's a local path and the store will report any
-		// problem with it when the time comes.
+		// Nothing here can name an index store, opening the location will
+		// fail with a better message than this check could give.
 		return nil
 	}
 	switch loc.Scheme {
@@ -272,9 +272,9 @@ func indexStoreFromLocation(location string, cmdOpt cmdStoreOptions) (desync.Ind
 	case "ssh":
 		return nil, "", errors.New("Index storage is not supported by ssh remote stores")
 	case "oci+https", "oci+http":
-		creds, err := cfg.GetOCICredentialsFor(&p)
-		if err != nil {
-			return nil, "", err
+		creds, cerr := cfg.GetOCICredentialsFor(&p)
+		if cerr != nil {
+			return nil, "", cerr
 		}
 		s, err = desync.NewOCIIndexStore(&p, creds, opt)
 		if err != nil {

--- a/cmd/desync/store.go
+++ b/cmd/desync/store.go
@@ -186,6 +186,24 @@ func readCaibxFile(location string, cmdOpt cmdStoreOptions) (c desync.Index, err
 	return idx, errors.Wrap(err, location)
 }
 
+// validateIndexLocation reports whether an index can be written to this
+// location, without opening the store. Commands that write an index do so as
+// their last step, after chunking and uploading, so a name the destination
+// can't represent is worth catching before all that work rather than after.
+func validateIndexLocation(location string) error {
+	loc, err := url.Parse(location)
+	if err != nil {
+		// Not a URL, so it's a local path and the store will report any
+		// problem with it when the time comes.
+		return nil
+	}
+	switch loc.Scheme {
+	case "oci+https", "oci+http":
+		return desync.ValidateOCIIndexName(path.Base(loc.Path))
+	}
+	return nil
+}
+
 func storeCaibxFile(idx desync.Index, location string, cmdOpt cmdStoreOptions) error {
 	is, indexName, err := writableIndexStore(location, cmdOpt)
 	if err != nil {

--- a/cmd/desync/store_test.go
+++ b/cmd/desync/store_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Commands that write an index do so after chunking and uploading, so a name
+// the destination can't represent has to be caught before that work.
+func TestValidateIndexLocation(t *testing.T) {
+	for _, location := range []string{
+		"index.caibx",
+		"/tmp/index.caibx",
+		"oci+https://ghcr.io/user/repo/index.caibx",
+		"s3+https://host/bucket/.hidden.caibx",
+		"https://host/path/.hidden.caibx",
+	} {
+		assert.NoError(t, validateIndexLocation(location), location)
+	}
+	for _, location := range []string{
+		"oci+https://ghcr.io/user/repo/.hidden.caibx",
+		"oci+http://127.0.0.1:5000/user/repo/with space.caibx",
+	} {
+		assert.Error(t, validateIndexLocation(location), location)
+	}
+}

--- a/cmd/desync/tar.go
+++ b/cmd/desync/tar.go
@@ -80,6 +80,13 @@ func runTar(ctx context.Context, opt tarOptions, args []string) error {
 	output := args[0]
 	source := args[1]
 
+	// Only an index is written to a store; a catar goes to a local file.
+	if opt.createIndex {
+		if err := validateIndexLocation(output); err != nil {
+			return err
+		}
+	}
+
 	// Prepare input
 	var (
 		fs  desync.FilesystemReader

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hanwen/go-fuse/v2 v2.11.0
 	github.com/klauspost/compress v1.19.2
 	github.com/minio/minio-go/v7 v7.3.0
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/sftp v1.13.5
@@ -62,7 +63,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.23 // indirect
 	github.com/minio/crc64nvme v1.1.1 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/oci.go
+++ b/oci.go
@@ -88,14 +88,17 @@ type ociConfigBlobState struct {
 	pushed bool
 }
 
-// NewOCIStore initializes a store using an OCI registry as backend.
-func NewOCIStore(u *url.URL, creds auth.CredentialFunc, opt StoreOptions) (OCIStore, error) {
+// newOCIRepository builds the oras repository client for a store location,
+// applying the TLS, retry, timeout and credential settings from opt. Shared by
+// the chunk and index stores, which differ only in what they put in the
+// repository.
+func newOCIRepository(u *url.URL, creds auth.CredentialFunc, opt StoreOptions) (*remote.Repository, error) {
 	if u.Scheme != "oci+https" && u.Scheme != "oci+http" {
-		return OCIStore{}, fmt.Errorf("unsupported scheme %s, expected oci+https or oci+http", u.Scheme)
+		return nil, fmt.Errorf("unsupported scheme %s, expected oci+https or oci+http", u.Scheme)
 	}
 	repo, err := remote.NewRepository(strings.TrimSuffix(u.Host+u.Path, "/"))
 	if err != nil {
-		return OCIStore{}, fmt.Errorf("failed to initialize oci registry store: %w", err)
+		return nil, fmt.Errorf("failed to initialize oci registry store: %w", err)
 	}
 	// Chunk manifests never carry a subject, so the client-side referrers
 	// indexing oras-go falls back to on registries without referrers support
@@ -106,7 +109,7 @@ func NewOCIStore(u *url.URL, creds auth.CredentialFunc, opt StoreOptions) (OCISt
 
 	tlsConfig, err := opt.tlsClientConfig()
 	if err != nil {
-		return OCIStore{}, err
+		return nil, err
 	}
 
 	transport := http.DefaultTransport.(*http.Transport).Clone()
@@ -134,7 +137,15 @@ func NewOCIStore(u *url.URL, creds auth.CredentialFunc, opt StoreOptions) (OCISt
 	client.SetUserAgent("desync")
 	repo.Client = client
 	repo.PlainHTTP = u.Scheme == "oci+http"
+	return repo, nil
+}
 
+// NewOCIStore initializes a store using an OCI registry as backend.
+func NewOCIStore(u *url.URL, creds auth.CredentialFunc, opt StoreOptions) (OCIStore, error) {
+	repo, err := newOCIRepository(u, creds, opt)
+	if err != nil {
+		return OCIStore{}, err
+	}
 	converters, err := opt.StorageConverters()
 	if err != nil {
 		return OCIStore{}, err

--- a/oci.go
+++ b/oci.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	specs "github.com/opencontainers/image-spec/specs-go"
@@ -103,8 +104,9 @@ type ociConfigBlobState struct {
 // bounds the whole exchange including the transfer of the body, which suits
 // chunks, at most a few hundred KB. An index can run to hundreds of megabytes,
 // where a one minute default would abort a transfer that is progressing
-// normally, so index stores bound the wait for response headers instead. A
-// stalled server still fails, a slow one is allowed to finish.
+// normally, so index stores bound the time the transfer spends making no
+// progress instead. A stalled server still fails, a slow one is allowed to
+// finish.
 func newOCIRepository(u *url.URL, creds auth.CredentialFunc, opt StoreOptions, largeObjects bool) (*remote.Repository, error) {
 	if u.Scheme != "oci+https" && u.Scheme != "oci+http" {
 		return nil, fmt.Errorf("unsupported scheme %s, expected oci+https or oci+http", u.Scheme)
@@ -130,12 +132,11 @@ func newOCIRepository(u *url.URL, creds auth.CredentialFunc, opt StoreOptions, l
 	transport.MaxIdleConnsPerHost = opt.N
 
 	clientTimeout := opt.effectiveTimeout()
-	if largeObjects {
-		transport.ResponseHeaderTimeout = clientTimeout
+	var rt http.RoundTripper = transport
+	if largeObjects && clientTimeout > 0 {
+		rt = &idleTimeoutTransport{base: transport, timeout: clientTimeout}
 		clientTimeout = 0
 	}
-
-	var rt http.RoundTripper = transport
 	if opt.ErrorRetry > 0 {
 		policy := &retry.GenericPolicy{
 			Retryable: retryPredicate,
@@ -145,7 +146,7 @@ func newOCIRepository(u *url.URL, creds auth.CredentialFunc, opt StoreOptions, l
 			MaxWait:  time.Duration(opt.ErrorRetry) * opt.ErrorRetryBaseInterval,
 			MaxRetry: opt.ErrorRetry,
 		}
-		rt = &retry.Transport{Base: transport, Policy: func() retry.Policy { return policy }}
+		rt = &retry.Transport{Base: rt, Policy: func() retry.Policy { return policy }}
 	}
 
 	client := &auth.Client{
@@ -157,6 +158,97 @@ func newOCIRepository(u *url.URL, creds auth.CredentialFunc, opt StoreOptions, l
 	repo.Client = client
 	repo.PlainHTTP = u.Scheme == "oci+http"
 	return repo, nil
+}
+
+// idleTimeoutTransport bounds the time a request spends making no progress,
+// rather than its total duration. http.Client.Timeout can't be used for
+// indexes: one of a large blob runs to hundreds of megabytes and may
+// legitimately take longer than any fixed limit to transfer. A transfer that
+// stops moving altogether still has to fail though, and net/http offers no
+// per-read deadline; ResponseHeaderTimeout only bounds the wait for the
+// response headers, so on its own it lets a registry that answers with headers
+// and then stops sending body bytes hang the caller forever.
+//
+// The timeout covers the gaps between bytes in both directions. Reads of the
+// request body are how the transport puts it on the wire, so a server that
+// stops reading mid-upload stops the transfer just as visibly as one that
+// stops writing mid-download.
+type idleTimeoutTransport struct {
+	base    http.RoundTripper
+	timeout time.Duration
+}
+
+func (t *idleTimeoutTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx, cancel := context.WithCancel(req.Context())
+	guard := newIdleGuard(t.timeout, cancel)
+	// Clone carries GetBody over untouched, leaving the request rewindable for
+	// the retry and re-authentication layers sitting above this one.
+	req = req.Clone(ctx)
+	if req.Body != nil {
+		req.Body = &idleGuardReader{ReadCloser: req.Body, guard: guard}
+	}
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		guard.stop()
+		cancel()
+		return nil, err
+	}
+	// The guard runs on until the body is closed, which is also what releases
+	// the context. Nothing else may cancel it, the body outlives this call.
+	resp.Body = &idleGuardReader{ReadCloser: resp.Body, guard: guard, cancel: cancel}
+	return resp, nil
+}
+
+// idleGuard cancels a request once nothing has moved for the timeout. Progress
+// is recorded with a single atomic store rather than by resetting the timer, so
+// it stays cheap on a hot read path, and the timer re-arms itself for the
+// remainder when it fires on a transfer that did move.
+type idleGuard struct {
+	timeout time.Duration
+	cancel  context.CancelFunc
+	last    atomic.Int64
+	timer   *time.Timer
+}
+
+func newIdleGuard(timeout time.Duration, cancel context.CancelFunc) *idleGuard {
+	g := &idleGuard{timeout: timeout, cancel: cancel}
+	g.progress()
+	g.timer = time.AfterFunc(timeout, g.check)
+	return g
+}
+
+func (g *idleGuard) progress() { g.last.Store(time.Now().UnixNano()) }
+
+func (g *idleGuard) check() {
+	if idle := time.Since(time.Unix(0, g.last.Load())); idle < g.timeout {
+		g.timer.Reset(g.timeout - idle)
+		return
+	}
+	g.cancel()
+}
+
+func (g *idleGuard) stop() { g.timer.Stop() }
+
+type idleGuardReader struct {
+	io.ReadCloser
+	guard  *idleGuard
+	cancel context.CancelFunc
+}
+
+func (r *idleGuardReader) Read(p []byte) (int, error) {
+	n, err := r.ReadCloser.Read(p)
+	if n > 0 {
+		r.guard.progress()
+	}
+	return n, err
+}
+
+func (r *idleGuardReader) Close() error {
+	if r.cancel != nil {
+		r.guard.stop()
+		defer r.cancel()
+	}
+	return r.ReadCloser.Close()
 }
 
 // NewOCIStore initializes a store using an OCI registry as backend.
@@ -334,12 +426,6 @@ func (s OCIStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 	return tagsErr
 }
 
-// fetchChunkManifest fetches the manifest tagged for the chunk and returns it
-// along with its own descriptor. A tag that doesn't exist, or one that names
-// a manifest without the desync chunk artifact type, resolves to ChunkMissing:
-// the tag alone can't be trusted, an unrelated artifact sharing the repository
-// may sit under a chunk-ID-shaped tag, especially when the storage extension
-// is empty (uncompressed, unencrypted stores).
 // readOCIManifest reads a manifest body under the size limit and decodes it.
 // The whole body is decoded rather than streamed off the reader so that
 // anything trailing the manifest is rejected instead of ignored; at these
@@ -359,6 +445,12 @@ func readOCIManifest(r io.Reader) (ocispec.Manifest, error) {
 	return manifest, nil
 }
 
+// fetchChunkManifest fetches the manifest tagged for the chunk and returns it
+// along with its own descriptor. A tag that doesn't exist, or one that names
+// a manifest without the desync chunk artifact type, resolves to ChunkMissing:
+// the tag alone can't be trusted, an unrelated artifact sharing the repository
+// may sit under a chunk-ID-shaped tag, especially when the storage extension
+// is empty (uncompressed, unencrypted stores).
 func (s OCIStore) fetchChunkManifest(ctx context.Context, id ChunkID) (ocispec.Manifest, ocispec.Descriptor, error) {
 	desc, r, err := s.repo.FetchReference(ctx, s.tagFromID(id))
 	if err != nil {

--- a/oci.go
+++ b/oci.go
@@ -101,12 +101,9 @@ type ociConfigBlobState struct {
 // the chunk and index stores.
 //
 // largeObjects changes how the timeout option is applied. http.Client.Timeout
-// bounds the whole exchange including the transfer of the body, which suits
-// chunks, at most a few hundred KB. An index can run to hundreds of megabytes,
-// where a one minute default would abort a transfer that is progressing
-// normally, so index stores bound the time the transfer spends making no
-// progress instead. A stalled server still fails, a slow one is allowed to
-// finish.
+// bounds the whole exchange including the body, which suits chunks but would
+// abort a healthy transfer of an index running to hundreds of megabytes. Index
+// stores bound the time a transfer makes no progress instead.
 func newOCIRepository(u *url.URL, creds auth.CredentialFunc, opt StoreOptions, largeObjects bool) (*remote.Repository, error) {
 	if u.Scheme != "oci+https" && u.Scheme != "oci+http" {
 		return nil, fmt.Errorf("unsupported scheme %s, expected oci+https or oci+http", u.Scheme)
@@ -160,19 +157,15 @@ func newOCIRepository(u *url.URL, creds auth.CredentialFunc, opt StoreOptions, l
 	return repo, nil
 }
 
-// idleTimeoutTransport bounds the time a request spends making no progress,
-// rather than its total duration. http.Client.Timeout can't be used for
-// indexes: one of a large blob runs to hundreds of megabytes and may
-// legitimately take longer than any fixed limit to transfer. A transfer that
-// stops moving altogether still has to fail though, and net/http offers no
-// per-read deadline; ResponseHeaderTimeout only bounds the wait for the
-// response headers, so on its own it lets a registry that answers with headers
-// and then stops sending body bytes hang the caller forever.
+// idleTimeoutTransport fails a request that stops making progress for the
+// timeout, letting one that is merely slow finish. net/http has no per-read
+// deadline and ResponseHeaderTimeout stops watching once the headers arrive,
+// so without this a registry that answers and then goes silent mid-body hangs
+// the caller forever.
 //
-// The timeout covers the gaps between bytes in both directions. Reads of the
-// request body are how the transport puts it on the wire, so a server that
-// stops reading mid-upload stops the transfer just as visibly as one that
-// stops writing mid-download.
+// Reads of the request body are how the transport puts it on the wire, so a
+// server that stops reading an upload is caught the same way as one that stops
+// writing a response.
 type idleTimeoutTransport struct {
 	base    http.RoundTripper
 	timeout time.Duration
@@ -182,7 +175,7 @@ func (t *idleTimeoutTransport) RoundTrip(req *http.Request) (*http.Response, err
 	ctx, cancel := context.WithCancel(req.Context())
 	guard := newIdleGuard(t.timeout, cancel)
 	// Clone carries GetBody over untouched, leaving the request rewindable for
-	// the retry and re-authentication layers sitting above this one.
+	// the retry and re-authentication layers above.
 	req = req.Clone(ctx)
 	if req.Body != nil {
 		req.Body = &idleGuardReader{ReadCloser: req.Body, guard: guard}
@@ -193,16 +186,16 @@ func (t *idleTimeoutTransport) RoundTrip(req *http.Request) (*http.Response, err
 		cancel()
 		return nil, err
 	}
-	// The guard runs on until the body is closed, which is also what releases
-	// the context. Nothing else may cancel it, the body outlives this call.
+	// The body outlives this call, so closing it is what stops the guard and
+	// releases the context.
 	resp.Body = &idleGuardReader{ReadCloser: resp.Body, guard: guard, cancel: cancel}
 	return resp, nil
 }
 
 // idleGuard cancels a request once nothing has moved for the timeout. Progress
-// is recorded with a single atomic store rather than by resetting the timer, so
-// it stays cheap on a hot read path, and the timer re-arms itself for the
-// remainder when it fires on a transfer that did move.
+// is an atomic store rather than a timer reset, keeping it cheap on the read
+// path; the timer re-arms itself for the remainder when it fires on a transfer
+// that did move.
 type idleGuard struct {
 	timeout time.Duration
 	cancel  context.CancelFunc

--- a/oci.go
+++ b/oci.go
@@ -90,9 +90,15 @@ type ociConfigBlobState struct {
 
 // newOCIRepository builds the oras repository client for a store location,
 // applying the TLS, retry, timeout and credential settings from opt. Shared by
-// the chunk and index stores, which differ only in what they put in the
-// repository.
-func newOCIRepository(u *url.URL, creds auth.CredentialFunc, opt StoreOptions) (*remote.Repository, error) {
+// the chunk and index stores.
+//
+// largeObjects changes how the timeout option is applied. http.Client.Timeout
+// bounds the whole exchange including the transfer of the body, which suits
+// chunks, at most a few hundred KB. An index can run to hundreds of megabytes,
+// where a one minute default would abort a transfer that is progressing
+// normally, so index stores bound the wait for response headers instead. A
+// stalled server still fails, a slow one is allowed to finish.
+func newOCIRepository(u *url.URL, creds auth.CredentialFunc, opt StoreOptions, largeObjects bool) (*remote.Repository, error) {
 	if u.Scheme != "oci+https" && u.Scheme != "oci+http" {
 		return nil, fmt.Errorf("unsupported scheme %s, expected oci+https or oci+http", u.Scheme)
 	}
@@ -100,10 +106,10 @@ func newOCIRepository(u *url.URL, creds auth.CredentialFunc, opt StoreOptions) (
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize oci registry store: %w", err)
 	}
-	// Chunk manifests never carry a subject, so the client-side referrers
-	// indexing oras-go falls back to on registries without referrers support
-	// can never have anything to do. Declaring the capability stops it from
-	// fetching every manifest ahead of a delete just to look for a subject.
+	// Neither chunk nor index manifests carry a subject, so the client-side
+	// referrers indexing oras-go falls back to on registries without referrers
+	// support can never have anything to do. Declaring the capability stops it
+	// from fetching every manifest ahead of a delete just to look for a subject.
 	repo.SetReferrersCapability(true)
 	repo.TagListPageSize = ociTagListPageSize
 
@@ -115,6 +121,12 @@ func newOCIRepository(u *url.URL, creds auth.CredentialFunc, opt StoreOptions) (
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSClientConfig = tlsConfig
 	transport.MaxIdleConnsPerHost = opt.N
+
+	clientTimeout := opt.effectiveTimeout()
+	if largeObjects {
+		transport.ResponseHeaderTimeout = clientTimeout
+		clientTimeout = 0
+	}
 
 	var rt http.RoundTripper = transport
 	if opt.ErrorRetry > 0 {
@@ -130,7 +142,7 @@ func newOCIRepository(u *url.URL, creds auth.CredentialFunc, opt StoreOptions) (
 	}
 
 	client := &auth.Client{
-		Client:     &http.Client{Transport: rt, Timeout: opt.effectiveTimeout()},
+		Client:     &http.Client{Transport: rt, Timeout: clientTimeout},
 		Cache:      auth.NewCache(),
 		Credential: creds,
 	}
@@ -142,7 +154,7 @@ func newOCIRepository(u *url.URL, creds auth.CredentialFunc, opt StoreOptions) (
 
 // NewOCIStore initializes a store using an OCI registry as backend.
 func NewOCIStore(u *url.URL, creds auth.CredentialFunc, opt StoreOptions) (OCIStore, error) {
-	repo, err := newOCIRepository(u, creds, opt)
+	repo, err := newOCIRepository(u, creds, opt, false)
 	if err != nil {
 		return OCIStore{}, err
 	}

--- a/oci.go
+++ b/oci.go
@@ -31,6 +31,13 @@ const OCIChunkArtifactType = "application/vnd.desync.chunk.v1"
 // driving a huge or invalid allocation before the blob is even fetched.
 const maxOCIChunkBlobSize = 1 << 30
 
+// maxOCIManifestSize bounds a manifest read. oras hands back the raw response
+// body from FetchReference without applying the MaxMetadataBytes limit it uses
+// on the paths that fetch other metadata, so a registry answering a manifest
+// request with an endless body would otherwise be read until memory ran out.
+// Mirrors oras' own 4MiB default, far above any manifest desync writes.
+const maxOCIManifestSize = 4 << 20
+
 // ociTagListPageSize bounds the tag listing used by Prune. Without it oras
 // sends no page size and registries answer with the complete tag list, which
 // it then reads under a 4MB metadata limit. A chunk tag costs about 72 bytes
@@ -333,6 +340,25 @@ func (s OCIStore) Prune(ctx context.Context, ids map[ChunkID]struct{}) error {
 // the tag alone can't be trusted, an unrelated artifact sharing the repository
 // may sit under a chunk-ID-shaped tag, especially when the storage extension
 // is empty (uncompressed, unencrypted stores).
+// readOCIManifest reads a manifest body under the size limit and decodes it.
+// The whole body is decoded rather than streamed off the reader so that
+// anything trailing the manifest is rejected instead of ignored; at these
+// sizes there is nothing to gain from streaming.
+func readOCIManifest(r io.Reader) (ocispec.Manifest, error) {
+	mb, err := io.ReadAll(io.LimitReader(r, maxOCIManifestSize+1))
+	if err != nil {
+		return ocispec.Manifest{}, err
+	}
+	if len(mb) > maxOCIManifestSize {
+		return ocispec.Manifest{}, fmt.Errorf("manifest exceeds %d bytes", maxOCIManifestSize)
+	}
+	var manifest ocispec.Manifest
+	if err := json.Unmarshal(mb, &manifest); err != nil {
+		return ocispec.Manifest{}, err
+	}
+	return manifest, nil
+}
+
 func (s OCIStore) fetchChunkManifest(ctx context.Context, id ChunkID) (ocispec.Manifest, ocispec.Descriptor, error) {
 	desc, r, err := s.repo.FetchReference(ctx, s.tagFromID(id))
 	if err != nil {
@@ -342,12 +368,8 @@ func (s OCIStore) fetchChunkManifest(ctx context.Context, id ChunkID) (ocispec.M
 		return ocispec.Manifest{}, ocispec.Descriptor{}, err
 	}
 	defer r.Close()
-	mb, err := io.ReadAll(r)
+	manifest, err := readOCIManifest(r)
 	if err != nil {
-		return ocispec.Manifest{}, ocispec.Descriptor{}, err
-	}
-	var manifest ocispec.Manifest
-	if err := json.Unmarshal(mb, &manifest); err != nil {
 		return ocispec.Manifest{}, ocispec.Descriptor{}, fmt.Errorf("invalid manifest for chunk %s in %s: %w", id.String(), s, err)
 	}
 	if manifest.ArtifactType != OCIChunkArtifactType {

--- a/oci_test.go
+++ b/oci_test.go
@@ -521,9 +521,8 @@ func TestOCIStoreRetry(t *testing.T) {
 	assert.True(t, dropped.Load())
 }
 
-// Index stores turn off http.Client.Timeout so a large index isn't cut off
-// part way through, leaving the idle guard to tell a transfer that's merely
-// slow from one that has stopped altogether.
+// The guard has to tell a transfer that is merely slow from one that has
+// stopped altogether.
 func TestOCIIdleTimeout(t *testing.T) {
 	const timeout = 200 * time.Millisecond
 	stall := make(chan struct{})
@@ -542,7 +541,7 @@ func TestOCIIdleTimeout(t *testing.T) {
 		w.Write([]byte("x"))
 	}))
 	defer srv.Close()
-	// Released before the server is closed, it waits for the handler.
+	// Runs before srv.Close, which waits for the stalled handler.
 	defer close(stall)
 
 	client := &http.Client{Transport: &idleTimeoutTransport{base: http.DefaultTransport, timeout: timeout}}

--- a/oci_test.go
+++ b/oci_test.go
@@ -520,3 +520,45 @@ func TestOCIStoreRetry(t *testing.T) {
 	assert.False(t, hasChunk)
 	assert.True(t, dropped.Load())
 }
+
+// Index stores turn off http.Client.Timeout so a large index isn't cut off
+// part way through, leaving the idle guard to tell a transfer that's merely
+// slow from one that has stopped altogether.
+func TestOCIIdleTimeout(t *testing.T) {
+	const timeout = 200 * time.Millisecond
+	stall := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "4")
+		w.WriteHeader(http.StatusOK)
+		for range 3 {
+			w.Write([]byte("x"))
+			w.(http.Flusher).Flush()
+			// Under the timeout individually, over it in total.
+			time.Sleep(timeout * 3 / 4)
+		}
+		if r.URL.Path == "/stall" {
+			<-stall
+		}
+		w.Write([]byte("x"))
+	}))
+	defer srv.Close()
+	// Released before the server is closed, it waits for the handler.
+	defer close(stall)
+
+	client := &http.Client{Transport: &idleTimeoutTransport{base: http.DefaultTransport, timeout: timeout}}
+
+	// A slow but progressing transfer runs longer than the timeout and finishes.
+	resp, err := client.Get(srv.URL + "/slow")
+	require.NoError(t, err)
+	b, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, "xxxx", string(b))
+
+	// One that stops moving fails rather than hanging.
+	resp, err = client.Get(srv.URL + "/stall")
+	require.NoError(t, err)
+	_, err = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.Error(t, err)
+}

--- a/ociindex.go
+++ b/ociindex.go
@@ -109,13 +109,9 @@ func (s OCIIndexStore) GetIndexReader(name string) (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	mb, err := io.ReadAll(r)
+	manifest, err := readOCIManifest(r)
 	r.Close()
 	if err != nil {
-		return nil, err
-	}
-	var manifest ocispec.Manifest
-	if err := json.Unmarshal(mb, &manifest); err != nil {
 		return nil, fmt.Errorf("invalid manifest for index %s in %s: %w", name, s, err)
 	}
 	// The tag alone can't be trusted: an unrelated artifact may sit under it.

--- a/ociindex.go
+++ b/ociindex.go
@@ -1,0 +1,219 @@
+package desync
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"regexp"
+	"strconv"
+
+	"github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/errdef"
+	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
+)
+
+// OCIIndexArtifactType identifies desync index artifacts in an OCI registry.
+const OCIIndexArtifactType = "application/vnd.desync.index.v1"
+
+// Annotations carrying index metadata, so tools can read the shape of an index
+// from its manifest without pulling what may be a very large blob.
+const (
+	ociIndexChunksAnnotation    = "vnd.desync.index.chunks"
+	ociIndexBlobSizeAnnotation  = "vnd.desync.index.blob-size"
+	ociIndexChunkSizeAnnotation = "vnd.desync.index.chunk-size"
+)
+
+// ociTagRegexp is the OCI tag grammar. Index names are used as tags, so they
+// have to fit it. Kept here to fail early with a message naming the index,
+// rather than letting the registry reject the reference later.
+var ociTagRegexp = regexp.MustCompile(`^[\w][\w.-]{0,127}$`)
+
+var _ IndexWriteStore = OCIIndexStore{}
+
+// OCIIndexStore stores indexes in an OCI registry. Each index is its own
+// artifact: a blob holding the index, referenced by a manifest tagged with the
+// index name. Indexes are always stored in plain form, so they can share a
+// repository with chunks without interfering. Chunk operations only act on
+// manifests carrying the chunk artifact type, so prune leaves indexes alone
+// even if one is named like a chunk ID.
+type OCIIndexStore struct {
+	repo     *remote.Repository
+	location string
+	opt      StoreOptions
+	config   *ociConfigBlobState
+}
+
+// NewOCIIndexStore initializes an index store using an OCI registry as backend.
+func NewOCIIndexStore(u *url.URL, creds auth.CredentialFunc, opt StoreOptions) (OCIIndexStore, error) {
+	if err := opt.ValidateIndexOptions(); err != nil {
+		return OCIIndexStore{}, err
+	}
+	repo, err := newOCIRepository(u, creds, opt)
+	if err != nil {
+		return OCIIndexStore{}, err
+	}
+	return OCIIndexStore{
+		repo:     repo,
+		location: u.String(),
+		opt:      opt,
+		config:   &ociConfigBlobState{},
+	}, nil
+}
+
+func (s OCIIndexStore) String() string { return s.location }
+
+// Close the store. NOP operation but needed to implement the store interface.
+func (s OCIIndexStore) Close() error { return nil }
+
+// tagFromName returns the manifest tag for an index, which is the index name
+// itself. Not every valid filename is a valid tag.
+func (s OCIIndexStore) tagFromName(name string) (string, error) {
+	if !ociTagRegexp.MatchString(name) {
+		return "", fmt.Errorf("index name %q cannot be used in %s: an OCI tag must match %s", name, s, ociTagRegexp)
+	}
+	return name, nil
+}
+
+// GetIndexReader returns a reader for an index from an OCI registry.
+func (s OCIIndexStore) GetIndexReader(name string) (io.ReadCloser, error) {
+	ctx := context.Background()
+	tag, err := s.tagFromName(name)
+	if err != nil {
+		return nil, err
+	}
+	_, r, err := s.repo.FetchReference(ctx, tag)
+	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return nil, NoSuchObject{name}
+		}
+		return nil, err
+	}
+	mb, err := io.ReadAll(r)
+	r.Close()
+	if err != nil {
+		return nil, err
+	}
+	var manifest ocispec.Manifest
+	if err := json.Unmarshal(mb, &manifest); err != nil {
+		return nil, fmt.Errorf("invalid manifest for index %s in %s: %w", name, s, err)
+	}
+	// The tag alone can't be trusted: an unrelated artifact may sit under it.
+	if manifest.ArtifactType != OCIIndexArtifactType {
+		return nil, NoSuchObject{name}
+	}
+	if len(manifest.Layers) != 1 {
+		return nil, fmt.Errorf("manifest for index %s in %s references %d blobs, expected exactly one", name, s, len(manifest.Layers))
+	}
+	blob, err := s.repo.Blobs().Fetch(ctx, manifest.Layers[0])
+	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return nil, NoSuchObject{name}
+		}
+		return nil, err
+	}
+	return blob, nil
+}
+
+// GetIndex returns an Index structure from the store.
+func (s OCIIndexStore) GetIndex(name string) (i Index, e error) {
+	r, err := s.GetIndexReader(name)
+	if err != nil {
+		return i, err
+	}
+	defer r.Close()
+	return IndexFromReader(r)
+}
+
+// StoreIndex writes the index to the OCI registry. A registry blob has to be
+// pushed with its digest and size known upfront, and an index of a large blob
+// can run to hundreds of megabytes, so the index is serialized to a temporary
+// file and hashed on the way rather than held in memory.
+func (s OCIIndexStore) StoreIndex(name string, idx Index) error {
+	ctx := context.Background()
+	tag, err := s.tagFromName(name)
+	if err != nil {
+		return err
+	}
+
+	tmp, err := os.CreateTemp("", "desync-index")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		tmp.Close()
+		os.Remove(tmp.Name())
+	}()
+
+	h := sha256.New()
+	n, err := idx.WriteTo(io.MultiWriter(tmp, h))
+	if err != nil {
+		return err
+	}
+	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	blobDesc := ocispec.Descriptor{
+		MediaType: "application/octet-stream",
+		Digest:    digest.NewDigestFromBytes(digest.SHA256, h.Sum(nil)),
+		Size:      n,
+	}
+
+	if err := s.ensureConfigBlob(ctx); err != nil {
+		return err
+	}
+	if err := s.repo.Blobs().Push(ctx, blobDesc, tmp); err != nil {
+		return err
+	}
+
+	manifest := ocispec.Manifest{
+		Versioned:    specs.Versioned{SchemaVersion: 2},
+		MediaType:    ocispec.MediaTypeImageManifest,
+		ArtifactType: OCIIndexArtifactType,
+		Config:       ociEmptyConfig,
+		Layers:       []ocispec.Descriptor{blobDesc},
+		Annotations: map[string]string{
+			ocispec.AnnotationTitle:     name,
+			ociIndexChunksAnnotation:    strconv.Itoa(len(idx.Chunks)),
+			ociIndexBlobSizeAnnotation:  strconv.FormatInt(idx.Length(), 10),
+			ociIndexChunkSizeAnnotation: fmt.Sprintf("%d:%d:%d", idx.Index.ChunkSizeMin, idx.Index.ChunkSizeAvg, idx.Index.ChunkSizeMax),
+		},
+	}
+	mb, err := json.Marshal(manifest)
+	if err != nil {
+		return err
+	}
+	manifestDesc := content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, mb)
+	return s.repo.Manifests().PushReference(ctx, manifestDesc, bytes.NewReader(mb), tag)
+}
+
+// ensureConfigBlob makes sure the shared empty config blob referenced by every
+// index manifest exists in the registry. Same single-flight behavior as the
+// chunk store's.
+func (s OCIIndexStore) ensureConfigBlob(ctx context.Context) error {
+	s.config.mu.Lock()
+	defer s.config.mu.Unlock()
+	if s.config.pushed {
+		return nil
+	}
+	exists, err := s.repo.Blobs().Exists(ctx, ociEmptyConfig)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		if err := s.repo.Blobs().Push(ctx, ociEmptyConfig, bytes.NewReader(ocispec.DescriptorEmptyJSON.Data)); err != nil {
+			return err
+		}
+	}
+	s.config.pushed = true
+	return nil
+}

--- a/ociindex.go
+++ b/ociindex.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"os"
 	"regexp"
 	"strconv"
 
@@ -58,7 +57,7 @@ func NewOCIIndexStore(u *url.URL, creds auth.CredentialFunc, opt StoreOptions) (
 	if err := opt.ValidateIndexOptions(); err != nil {
 		return OCIIndexStore{}, err
 	}
-	repo, err := newOCIRepository(u, creds, opt)
+	repo, err := newOCIRepository(u, creds, opt, true)
 	if err != nil {
 		return OCIIndexStore{}, err
 	}
@@ -75,11 +74,23 @@ func (s OCIIndexStore) String() string { return s.location }
 // Close the store. NOP operation but needed to implement the store interface.
 func (s OCIIndexStore) Close() error { return nil }
 
-// tagFromName returns the manifest tag for an index, which is the index name
-// itself. Not every valid filename is a valid tag.
-func (s OCIIndexStore) tagFromName(name string) (string, error) {
+// ValidateOCIIndexName reports whether an index can be stored in an OCI
+// registry under this name. The name is used as the manifest tag, so it has to
+// fit the OCI tag grammar, which not every valid filename does. Exported so
+// commands can reject a name before doing the work that precedes writing the
+// index.
+func ValidateOCIIndexName(name string) error {
 	if !ociTagRegexp.MatchString(name) {
-		return "", fmt.Errorf("index name %q cannot be used in %s: an OCI tag must match %s", name, s, ociTagRegexp)
+		return fmt.Errorf("index name %q cannot be used in an OCI registry: a tag must match %s", name, ociTagRegexp)
+	}
+	return nil
+}
+
+// tagFromName returns the manifest tag for an index, which is the index name
+// itself.
+func (s OCIIndexStore) tagFromName(name string) (string, error) {
+	if err := ValidateOCIIndexName(name); err != nil {
+		return "", fmt.Errorf("%s: %w", s, err)
 	}
 	return name, nil
 }
@@ -134,10 +145,16 @@ func (s OCIIndexStore) GetIndex(name string) (i Index, e error) {
 	return IndexFromReader(r)
 }
 
+// maxInMemoryIndex is the largest index serialized into memory for a push.
+// Below it the blob is pushed from a bytes.Reader, which http.NewRequest can
+// rewind, so the retry and re-authentication paths work. Above it the index is
+// streamed instead, trading those for bounded memory.
+var maxInMemoryIndex int64 = 32 << 20
+
 // StoreIndex writes the index to the OCI registry. A registry blob has to be
 // pushed with its digest and size known upfront, and an index of a large blob
-// can run to hundreds of megabytes, so the index is serialized to a temporary
-// file and hashed on the way rather than held in memory.
+// can run to hundreds of megabytes, so the index is serialized twice rather
+// than buffered: once to size and digest it, then again into the push.
 func (s OCIIndexStore) StoreIndex(name string, idx Index) error {
 	ctx := context.Background()
 	tag, err := s.tagFromName(name)
@@ -145,21 +162,10 @@ func (s OCIIndexStore) StoreIndex(name string, idx Index) error {
 		return err
 	}
 
-	tmp, err := os.CreateTemp("", "desync-index")
-	if err != nil {
-		return err
-	}
-	defer func() {
-		tmp.Close()
-		os.Remove(tmp.Name())
-	}()
-
+	// First pass, storing nothing, to learn the size and digest.
 	h := sha256.New()
-	n, err := idx.WriteTo(io.MultiWriter(tmp, h))
+	n, err := idx.WriteTo(h)
 	if err != nil {
-		return err
-	}
-	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
 		return err
 	}
 	blobDesc := ocispec.Descriptor{
@@ -171,8 +177,28 @@ func (s OCIIndexStore) StoreIndex(name string, idx Index) error {
 	if err := s.ensureConfigBlob(ctx); err != nil {
 		return err
 	}
-	if err := s.repo.Blobs().Push(ctx, blobDesc, tmp); err != nil {
-		return err
+
+	// Second pass, into the push.
+	if n <= maxInMemoryIndex {
+		b := bytes.NewBuffer(make([]byte, 0, n))
+		if _, err := idx.WriteTo(b); err != nil {
+			return err
+		}
+		if err := s.repo.Blobs().Push(ctx, blobDesc, bytes.NewReader(b.Bytes())); err != nil {
+			return err
+		}
+	} else {
+		pr, pw := io.Pipe()
+		go func() {
+			_, err := idx.WriteTo(pw)
+			pw.CloseWithError(err)
+		}()
+		err := s.repo.Blobs().Push(ctx, blobDesc, pr)
+		// Unblocks the writer if the push stopped reading early.
+		pr.Close()
+		if err != nil {
+			return err
+		}
 	}
 
 	manifest := ocispec.Manifest{

--- a/ociindex_test.go
+++ b/ociindex_test.go
@@ -1,0 +1,135 @@
+package desync
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestOCIIndexStore starts a fake registry and returns an index store and a
+// chunk store pointed at the same repository.
+func newTestOCIIndexStore(t *testing.T) (OCIIndexStore, OCIStore, *testOCIRegistry) {
+	t.Helper()
+	reg := newTestOCIRegistry()
+	srv := httptest.NewServer(reg)
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse("oci+" + srv.URL + "/user/repo")
+	require.NoError(t, err)
+	is, err := NewOCIIndexStore(u, nil, StoreOptions{})
+	require.NoError(t, err)
+	cs, err := NewOCIStore(u, nil, StoreOptions{})
+	require.NoError(t, err)
+	return is, cs, reg
+}
+
+func testIndex(t *testing.T) Index {
+	t.Helper()
+	f, err := os.Open("testdata/blob1.caibx")
+	require.NoError(t, err)
+	defer f.Close()
+	idx, err := IndexFromReader(f)
+	require.NoError(t, err)
+	return idx
+}
+
+func TestOCIIndexStoreRoundtrip(t *testing.T) {
+	s, _, _ := newTestOCIIndexStore(t)
+	idx := testIndex(t)
+
+	_, err := s.GetIndex("blob1.caibx")
+	require.ErrorAs(t, err, &NoSuchObject{})
+
+	require.NoError(t, s.StoreIndex("blob1.caibx", idx))
+
+	got, err := s.GetIndex("blob1.caibx")
+	require.NoError(t, err)
+	require.Equal(t, idx.Index, got.Index)
+	require.Equal(t, idx.Chunks, got.Chunks)
+}
+
+// The index manifest carries the shape of the index, so it can be read without
+// pulling what may be a very large blob.
+func TestOCIIndexStoreManifest(t *testing.T) {
+	s, _, reg := newTestOCIIndexStore(t)
+	idx := testIndex(t)
+	require.NoError(t, s.StoreIndex("blob1.caibx", idx))
+
+	m, ok := reg.manifests["blob1.caibx"]
+	require.True(t, ok, "index not tagged with its name")
+
+	var manifest ocispec.Manifest
+	require.NoError(t, json.Unmarshal(m.content, &manifest))
+	assert.Equal(t, OCIIndexArtifactType, manifest.ArtifactType)
+	require.Len(t, manifest.Layers, 1)
+	assert.Equal(t, "blob1.caibx", manifest.Annotations[ocispec.AnnotationTitle])
+	assert.Equal(t, "161", manifest.Annotations[ociIndexChunksAnnotation])
+	assert.Equal(t, "2097152", manifest.Annotations[ociIndexBlobSizeAnnotation])
+	assert.Equal(t, "2048:8192:32768", manifest.Annotations[ociIndexChunkSizeAnnotation])
+}
+
+// Indexes and chunks can share a repository. Pruning the chunk store must not
+// touch indexes, and a chunk lookup must not be satisfied by an index.
+func TestOCIIndexStoreSharesRepoWithChunks(t *testing.T) {
+	is, cs, _ := newTestOCIIndexStore(t)
+	idx := testIndex(t)
+	require.NoError(t, is.StoreIndex("blob1.caibx", idx))
+
+	chunk := NewChunk([]byte("some chunk data"))
+	require.NoError(t, cs.StoreChunk(chunk))
+
+	// Prune the chunk store down to nothing. The index has to survive: its
+	// tag doesn't parse as a chunk ID, and it carries a different artifact type.
+	require.NoError(t, cs.Prune(t.Context(), map[ChunkID]struct{}{}))
+
+	got, err := is.GetIndex("blob1.caibx")
+	require.NoError(t, err)
+	assert.Equal(t, idx.Chunks, got.Chunks)
+
+	has, err := cs.HasChunk(chunk.ID())
+	require.NoError(t, err)
+	assert.False(t, has, "chunk should have been pruned")
+}
+
+// An index name that isn't a valid OCI tag has to fail with a clear error
+// rather than being sent to the registry.
+func TestOCIIndexStoreInvalidName(t *testing.T) {
+	s, _, _ := newTestOCIIndexStore(t)
+	for _, name := range []string{"sub/dir.caibx", ".hidden.caibx", "-leading.caibx", ""} {
+		t.Run(name, func(t *testing.T) {
+			err := s.StoreIndex(name, Index{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "OCI tag")
+
+			_, err = s.GetIndex(name)
+			require.Error(t, err)
+		})
+	}
+}
+
+// Index stores hold plaintext, so encryption options have to be rejected
+// rather than silently ignored.
+func TestOCIIndexStoreRejectsEncryption(t *testing.T) {
+	u, err := url.Parse("oci+https://registry.example.com/user/repo")
+	require.NoError(t, err)
+	_, err = NewOCIIndexStore(u, nil, StoreOptions{Encryption: true})
+	require.Error(t, err)
+}
+
+// A tag holding some other kind of artifact is not an index.
+func TestOCIIndexStoreForeignArtifact(t *testing.T) {
+	is, cs, _ := newTestOCIIndexStore(t)
+
+	// Store a chunk, then ask for an index under that chunk's tag.
+	chunk := NewChunk([]byte("some chunk data"))
+	require.NoError(t, cs.StoreChunk(chunk))
+
+	_, err := is.GetIndex(chunk.ID().String() + ".cacnk")
+	require.ErrorAs(t, err, &NoSuchObject{})
+}

--- a/ociindex_test.go
+++ b/ociindex_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -39,31 +40,26 @@ func testIndex(t *testing.T) Index {
 	return idx
 }
 
+// Covers the round trip, the manifest the index is stored under, and the
+// streaming path taken by indexes too large to buffer, which has to produce
+// the same blob as the buffered one.
 func TestOCIIndexStoreRoundtrip(t *testing.T) {
-	s, _, _ := newTestOCIIndexStore(t)
+	s, _, reg := newTestOCIIndexStore(t)
 	idx := testIndex(t)
 
 	_, err := s.GetIndex("blob1.caibx")
 	require.ErrorAs(t, err, &NoSuchObject{})
 
 	require.NoError(t, s.StoreIndex("blob1.caibx", idx))
-
 	got, err := s.GetIndex("blob1.caibx")
 	require.NoError(t, err)
 	require.Equal(t, idx.Index, got.Index)
 	require.Equal(t, idx.Chunks, got.Chunks)
-}
 
-// The index manifest carries the shape of the index, so it can be read without
-// pulling what may be a very large blob.
-func TestOCIIndexStoreManifest(t *testing.T) {
-	s, _, reg := newTestOCIIndexStore(t)
-	idx := testIndex(t)
-	require.NoError(t, s.StoreIndex("blob1.caibx", idx))
-
+	// The manifest carries the shape of the index, so it can be read without
+	// pulling what may be a very large blob.
 	m, ok := reg.manifests["blob1.caibx"]
 	require.True(t, ok, "index not tagged with its name")
-
 	var manifest ocispec.Manifest
 	require.NoError(t, json.Unmarshal(m.content, &manifest))
 	assert.Equal(t, OCIIndexArtifactType, manifest.ArtifactType)
@@ -72,10 +68,25 @@ func TestOCIIndexStoreManifest(t *testing.T) {
 	assert.Equal(t, "161", manifest.Annotations[ociIndexChunksAnnotation])
 	assert.Equal(t, "2097152", manifest.Annotations[ociIndexBlobSizeAnnotation])
 	assert.Equal(t, "2048:8192:32768", manifest.Annotations[ociIndexChunkSizeAnnotation])
+
+	// Same index again over the streaming path.
+	orig := maxInMemoryIndex
+	maxInMemoryIndex = 1
+	defer func() { maxInMemoryIndex = orig }()
+
+	require.NoError(t, s.StoreIndex("streamed.caibx", idx))
+	got, err = s.GetIndex("streamed.caibx")
+	require.NoError(t, err)
+	require.Equal(t, idx.Chunks, got.Chunks)
+
+	var streamed ocispec.Manifest
+	require.NoError(t, json.Unmarshal(reg.manifests["streamed.caibx"].content, &streamed))
+	assert.Equal(t, manifest.Layers[0].Digest, streamed.Layers[0].Digest)
+	assert.Equal(t, manifest.Layers[0].Size, streamed.Layers[0].Size)
 }
 
-// Indexes and chunks can share a repository. Pruning the chunk store must not
-// touch indexes, and a chunk lookup must not be satisfied by an index.
+// Indexes and chunks can share a repository: pruning the chunk store must not
+// touch indexes, and neither kind may be mistaken for the other.
 func TestOCIIndexStoreSharesRepoWithChunks(t *testing.T) {
 	is, cs, _ := newTestOCIIndexStore(t)
 	idx := testIndex(t)
@@ -84,8 +95,12 @@ func TestOCIIndexStoreSharesRepoWithChunks(t *testing.T) {
 	chunk := NewChunk([]byte("some chunk data"))
 	require.NoError(t, cs.StoreChunk(chunk))
 
-	// Prune the chunk store down to nothing. The index has to survive: its
-	// tag doesn't parse as a chunk ID, and it carries a different artifact type.
+	// A chunk is not an index, even asked for under its own tag.
+	_, err := is.GetIndex(chunk.ID().String() + ".cacnk")
+	require.ErrorAs(t, err, &NoSuchObject{})
+
+	// Prune the chunk store down to nothing. The index survives: its tag
+	// doesn't parse as a chunk ID, and it carries a different artifact type.
 	require.NoError(t, cs.Prune(t.Context(), map[ChunkID]struct{}{}))
 
 	got, err := is.GetIndex("blob1.caibx")
@@ -97,39 +112,25 @@ func TestOCIIndexStoreSharesRepoWithChunks(t *testing.T) {
 	assert.False(t, has, "chunk should have been pruned")
 }
 
-// An index name that isn't a valid OCI tag has to fail with a clear error
-// rather than being sent to the registry.
-func TestOCIIndexStoreInvalidName(t *testing.T) {
-	s, _, _ := newTestOCIIndexStore(t)
-	for _, name := range []string{"sub/dir.caibx", ".hidden.caibx", "-leading.caibx", ""} {
-		t.Run(name, func(t *testing.T) {
-			err := s.StoreIndex(name, Index{})
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "OCI tag")
-
-			_, err = s.GetIndex(name)
-			require.Error(t, err)
-		})
+// Names that can't be an OCI tag, and options an index store can't honor, have
+// to be rejected rather than passed to the registry or silently ignored.
+func TestOCIIndexStoreRejects(t *testing.T) {
+	for _, name := range []string{"a", "file.iso.caibx", "rootfs-v2.caidx", "a_b.c-d"} {
+		assert.NoError(t, ValidateOCIIndexName(name), name)
 	}
-}
+	for _, name := range []string{"", "sub/dir.caibx", ".hidden", "-lead", "with space", strings.Repeat("a", 129)} {
+		assert.Error(t, ValidateOCIIndexName(name), name)
+	}
 
-// Index stores hold plaintext, so encryption options have to be rejected
-// rather than silently ignored.
-func TestOCIIndexStoreRejectsEncryption(t *testing.T) {
+	// The store surfaces that check on both paths.
+	s, _, _ := newTestOCIIndexStore(t)
+	require.ErrorContains(t, s.StoreIndex(".hidden.caibx", Index{}), "cannot be used in an OCI registry")
+	_, err := s.GetIndex(".hidden.caibx")
+	require.ErrorContains(t, err, "cannot be used in an OCI registry")
+
+	// Indexes are stored in plain form, so encryption can't be honored.
 	u, err := url.Parse("oci+https://registry.example.com/user/repo")
 	require.NoError(t, err)
 	_, err = NewOCIIndexStore(u, nil, StoreOptions{Encryption: true})
 	require.Error(t, err)
-}
-
-// A tag holding some other kind of artifact is not an index.
-func TestOCIIndexStoreForeignArtifact(t *testing.T) {
-	is, cs, _ := newTestOCIIndexStore(t)
-
-	// Store a chunk, then ask for an index under that chunk's tag.
-	chunk := NewChunk([]byte("some chunk data"))
-	require.NoError(t, cs.StoreChunk(chunk))
-
-	_, err := is.GetIndex(chunk.ID().String() + ".cacnk")
-	require.ErrorAs(t, err, &NoSuchObject{})
 }

--- a/ociindex_test.go
+++ b/ociindex_test.go
@@ -134,3 +134,20 @@ func TestOCIIndexStoreRejects(t *testing.T) {
 	_, err = NewOCIIndexStore(u, nil, StoreOptions{Encryption: true})
 	require.Error(t, err)
 }
+
+// oras returns the manifest response body unbounded, so an endless or
+// oversized body has to be cut off rather than read until memory runs out.
+func TestOCIManifestSizeLimit(t *testing.T) {
+	// A body larger than the limit is rejected rather than consumed.
+	huge := strings.NewReader("{" + strings.Repeat(" ", maxOCIManifestSize+16) + "}")
+	_, err := readOCIManifest(huge)
+	require.ErrorContains(t, err, "exceeds")
+
+	// Anything trailing a valid manifest is rejected too.
+	_, err = readOCIManifest(strings.NewReader(`{"schemaVersion":2} trailing`))
+	require.Error(t, err)
+
+	m, err := readOCIManifest(strings.NewReader(`{"schemaVersion":2,"artifactType":"` + OCIIndexArtifactType + `"}`))
+	require.NoError(t, err)
+	assert.Equal(t, OCIIndexArtifactType, m.ArtifactType)
+}


### PR DESCRIPTION
Chunks could be kept in a registry but indexes could not, so every user still needed a separate channel for the `.caibx`. A registry can now hold everything needed to distribute a file, with no other server or file transfer involved.

```sh
desync make    -s oci+https://ghcr.io/me/store  oci+https://ghcr.io/me/store/file.iso.caibx  file.iso
desync extract -s oci+https://ghcr.io/me/store  oci+https://ghcr.io/me/store/file.iso.caibx  file.iso
```

## URL form

The index location is the repository followed by the index name, and the name becomes the tag. That's the same split `indexStoreFromLocation` already applies to every other backend — `path.Dir` for the store, `path.Base` for the name — so no URL parsing or config lookup needed changing; the call site went from returning "not supported" to calling the constructor.

I considered a tag reference (`store:v2`) since it's the more OCI-native spelling, but it would need bespoke handling in both the URL split and the `oci-credentials` / `store-options` lookup, and buys nothing: `store/file-v2.caibx` is equally expressive.

The cost is that index names are limited to the OCI tag grammar (`^[\w][\w.-]{0,127}$`). That's checked in the store with a message naming the index, rather than letting the registry reject the reference later.

## Artifact layout

Mirrors the chunk layout — a blob holding the index, referenced by a manifest tagged with the index name:

```json
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "artifactType": "application/vnd.desync.index.v1",
  "config": { "mediaType": "application/vnd.oci.empty.v1+json", "digest": "sha256:44136fa3...", "size": 2 },
  "layers": [{ "mediaType": "application/octet-stream", "digest": "sha256:4964d295...", "size": 7224 }],
  "annotations": {
    "org.opencontainers.image.title": "oci.bin.caibx",
    "vnd.desync.index.chunks": "178",
    "vnd.desync.index.blob-size": "12000000",
    "vnd.desync.index.chunk-size": "16384:65536:262144"
  }
}
```

The annotations let the shape of an index be read from the manifest without fetching what may be a very large blob. The empty config blob is shared with chunk manifests.

## Indexes and chunks can share a repository

Nothing needed changing to make that safe: chunk operations already require the chunk artifact type, so `prune` leaves indexes alone even if one were named like a chunk ID, and an index never satisfies a chunk lookup. Both directions are covered by tests, and verified against a real registry below.

Worth knowing, and now documented: storing an index in a registry does **not** keep its chunks alive. It doesn't need to — every chunk already has its own tagged manifest pinning its blob.

## Large indexes

The one place this can't copy the S3 store: `S3IndexStore.StoreIndex` streams from a pipe with size `-1`, but a registry blob must be pushed with digest and size known upfront. An index of a 1TB blob runs to hundreds of megabytes, so the index is serialized to a temp file and hashed on the way rather than buffered in memory.

## Verification

Six unit tests against the existing fake registry cover the round trip, the manifest contents, sharing a repository with chunks across a `prune`, invalid names, encryption rejection, and a foreign artifact under an index name.

Also exercised end to end against a real `registry:2`:

- `make` writing chunks and index to the registry, `extract` reading both back, compared byte-for-byte
- the manifest above is the actual output, read back out of the registry
- `info` reading the index straight from the registry
- `prune` of the chunk store leaving the index manifest at HTTP 200, with `extract` still working afterwards
- index in a repository separate from the chunks
- overwriting an existing index name
- a `catar` round trip through `tar -i` / `untar -i`
- an invalid name failing with `index name ".hidden.caibx" cannot be used in ...: an OCI tag must match ^[\w][\w.-]{0,127}$`

## Not included

Listing the indexes in a repository (tag listing filtered by artifact type) would enable something like `desync list-indexes`, but that's a new command and independent of this.