### PR TITLE
Gate CI on golangci-lint and govulncheck

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -61,6 +61,41 @@ jobs:
           test -z "$(gofmt -l .)" || { echo "Files need gofmt:"; gofmt -l .; exit 1; }
           go mod tidy -diff
 
+  # Separate from the build matrix so lint failures and test failures are
+  # reported side by side rather than one hiding the other.
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      # Runs errcheck, govet, ineffassign, staticcheck and unused; see
+      # .golangci.yml for what is enabled and why.
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.12
+
+  # govulncheck reports only vulnerabilities the code actually reaches, so a
+  # finding here is worth acting on rather than triaging away. It runs on the
+  # current stable toolchain rather than the go.mod version: most findings are
+  # in the standard library, and the fix for those is a Go upgrade, which is
+  # exactly what this should be telling us.
+  vulncheck:
+    name: Vulnerabilities
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
   # FreeBSD has no GitHub-hosted runner, so the tests run in a VM on the Linux
   # runner. Booting it costs a few minutes, hence the separate job.
   freebsd:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,59 @@
+version: "2"
+
+# Report every finding. The defaults cap output at 50 per linter and 3 per
+# distinct message, which silently hides the rest of a repeated problem.
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+linters:
+  # errcheck, govet, ineffassign, staticcheck and unused.
+  default: standard
+
+  settings:
+    errcheck:
+      # Writes to a console stream or to an http.ResponseWriter have nowhere
+      # to report a failure to. Excluding them keeps the linter pointed at
+      # unchecked errors a caller could actually act on.
+      exclude-functions:
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln
+        - (net/http.ResponseWriter).Write
+
+    staticcheck:
+      # The QF ("quickfix") checks propose refactorings rather than report
+      # defects: dropping an embedded type from a selector that names it for
+      # clarity, applying De Morgan's law to a condition that reads better as
+      # written. Style is not what this gate is for.
+      checks:
+        - all
+        - -QF1001
+        - -QF1006
+        - -QF1008
+        # golangci-lint leaves these off by default: naming and comment-style
+        # conventions this codebase has never followed. Turning them on would
+        # mean renaming exported identifiers for no benefit.
+        - -ST1000
+        - -ST1003
+        - -ST1016
+        - -ST1020
+        - -ST1021
+        - -ST1022
+        - -ST1023
+
+  exclusions:
+    rules:
+      # A deferred Close has nowhere to report to, the function it defers in
+      # has already decided what to return. A Close called outright is a
+      # different matter: on a writer it is where the write actually fails,
+      # so those stay flagged.
+      - linters: [errcheck]
+        source: '^\s*defer .*[Cc]lose\(\)'
+
+      # The point of these two assertions is what fmt does with a ChunkID
+      # value versus a pointer, given String() has a pointer receiver. Calling
+      # String() directly, as the check suggests, would test nothing.
+      - path: types_test\.go
+        text: "S1025"
+        linters: [staticcheck]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,8 +10,9 @@ repos:
     rev: master
     hooks:
       - id: go-fmt
-      #- id: go-vet
+      - id: go-vet
       #- id: go-imports
+      # golangci-lint needs the binary on PATH; CI enforces it either way.
       #- id: golangci-lint
       #- id: go-critic
       #- id: go-unit-tests

--- a/assemble.go
+++ b/assemble.go
@@ -118,7 +118,9 @@ func AssembleFile(ctx context.Context, name string, idx Index, s Store, seeds []
 		if err != nil {
 			return stats, err
 		}
-		f.Close()
+		if err := f.Close(); err != nil {
+			return stats, err
+		}
 		isBlank = true
 	case err != nil: // Some other error => bail
 		return stats, err

--- a/cache.go
+++ b/cache.go
@@ -1,6 +1,7 @@
 package desync
 
 import (
+	stderrors "errors"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -58,8 +59,7 @@ func (c Cache) String() string {
 
 // Close the underlying writable chunk store
 func (c Cache) Close() error {
-	c.l.Close()
-	return c.s.Close()
+	return stderrors.Join(c.l.Close(), c.s.Close())
 }
 
 // RepairableCache is a cache whose GetChunk() function will return ChunkMissing error instead of ChunkInvalid

--- a/cmd/desync/cache_test.go
+++ b/cmd/desync/cache_test.go
@@ -29,7 +29,8 @@ func TestCacheCommand(t *testing.T) {
 
 			// Redirect the command's output to turn off the progressbar and run it
 			stderr = io.Discard
-			cmd.SetOutput(io.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 			_, err := cmd.ExecuteC()
 			require.NoError(t, err)
 

--- a/cmd/desync/cat_test.go
+++ b/cmd/desync/cat_test.go
@@ -34,7 +34,8 @@ func TestCatCommand(t *testing.T) {
 
 			// Redirect the command's output
 			stdout = b
-			cmd.SetOutput(io.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 			_, err := cmd.ExecuteC()
 			require.NoError(t, err)
 

--- a/cmd/desync/chop_test.go
+++ b/cmd/desync/chop_test.go
@@ -30,7 +30,8 @@ func TestChopCommand(t *testing.T) {
 
 		// Redirect the command's output to turn off the progressbar and run it
 		stderr = io.Discard
-		cmd.SetOutput(io.Discard)
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
 		_, err := cmd.ExecuteC()
 		require.NoError(t, err)
 
@@ -53,7 +54,8 @@ func TestChopErrors(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			cmd := newChopCommand(context.Background())
-			cmd.SetOutput(io.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 			cmd.SetArgs(test.args)
 			_, err := cmd.ExecuteC()
 			require.Error(t, err)

--- a/cmd/desync/chunkserver_test.go
+++ b/cmd/desync/chunkserver_test.go
@@ -29,27 +29,29 @@ func TestChunkServerReadCommand(t *testing.T) {
 	extractCmd := newExtractCommand(context.Background())
 	extractCmd.SetArgs([]string{"-s", store, "testdata/blob1.caibx", filepath.Join(outdir, "blob")})
 	stdout = io.Discard
-	extractCmd.SetOutput(io.Discard)
+	extractCmd.SetOut(io.Discard)
+	extractCmd.SetErr(io.Discard)
 	_, err := extractCmd.ExecuteC()
 	require.NoError(t, err)
 
 	// The server should not be serving up arbitrary files from disk. Expect a 400 error
 	resp, err := http.Get(store + "somefile")
 	require.NoError(t, err)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 	// Asking for a chunk that doesn't exist should return 404
 	resp, err = http.Get(store + "0000/0000000000000000000000000000000000000000000000000000000000000000.cacnk")
 	require.NoError(t, err)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 
 	// This server shouldn't allow writing. Confirm by trying to chunk a file with
 	// the "chop" command and storing the chunks there.
 	chopCmd := newChopCommand(context.Background())
 	chopCmd.SetArgs([]string{"-s", store, "testdata/blob2.caibx", "testdata/blob2"})
-	chopCmd.SetOutput(io.Discard)
+	chopCmd.SetOut(io.Discard)
+	chopCmd.SetErr(io.Discard)
 	_, err = chopCmd.ExecuteC()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "writing to upstream")
@@ -66,7 +68,8 @@ func TestChunkServerWriteCommand(t *testing.T) {
 	// Run a "chop" command to confirm the chunk server can be used to write chunks
 	chopCmd := newChopCommand(context.Background())
 	chopCmd.SetArgs([]string{"-s", store, "testdata/blob1.caibx", "testdata/blob1"})
-	chopCmd.SetOutput(io.Discard)
+	chopCmd.SetOut(io.Discard)
+	chopCmd.SetErr(io.Discard)
 	_, err := chopCmd.ExecuteC()
 	require.NoError(t, err)
 
@@ -74,7 +77,7 @@ func TestChunkServerWriteCommand(t *testing.T) {
 	req, _ := http.NewRequest("PUT", store+"somefile", strings.NewReader("invalid"))
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 func TestChunkServerVerifiedTLS(t *testing.T) {
@@ -89,7 +92,8 @@ func TestChunkServerVerifiedTLS(t *testing.T) {
 	// Run the "extract" command to confirm the TLS chunk server can be used
 	extractCmd := newExtractCommand(context.Background())
 	extractCmd.SetArgs([]string{"--ca-cert", "testdata/ca.crt", "-s", store, "testdata/blob1.caibx", filepath.Join(outdir, "blob1")})
-	extractCmd.SetOutput(io.Discard)
+	extractCmd.SetOut(io.Discard)
+	extractCmd.SetErr(io.Discard)
 	_, err := extractCmd.ExecuteC()
 	require.NoError(t, err)
 }
@@ -115,9 +119,11 @@ func TestChunkServerInsecureTLS(t *testing.T) {
 
 	// Run the "extract" command without accepting any cert. Should fail.
 	extractCmd = newExtractCommand(context.Background())
-	extractCmd.SetOutput(io.Discard)
+	extractCmd.SetOut(io.Discard)
+	extractCmd.SetErr(io.Discard)
 	extractCmd.SetArgs([]string{"-s", store, "testdata/blob1.caibx", filepath.Join(outdir, "blob1")})
-	extractCmd.SetOutput(io.Discard)
+	extractCmd.SetOut(io.Discard)
+	extractCmd.SetErr(io.Discard)
 	_, err = extractCmd.ExecuteC()
 	require.Error(t, err)
 
@@ -156,7 +162,8 @@ func TestChunkServerMutualTLS(t *testing.T) {
 	extractCmd.SetArgs([]string{
 		"--ca-cert", "testdata/ca.crt",
 		"-s", store, "testdata/blob1.caibx", filepath.Join(outdir, "blob1")})
-	extractCmd.SetOutput(io.Discard)
+	extractCmd.SetOut(io.Discard)
+	extractCmd.SetErr(io.Discard)
 	_, err = extractCmd.ExecuteC()
 	require.Error(t, err)
 }
@@ -172,7 +179,7 @@ func freeLocalAddr(t *testing.T) string {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	addr := l.Addr().String()
-	l.Close()
+	_ = l.Close()
 	return addr
 }
 
@@ -233,7 +240,8 @@ func TestChunkServerEncryption(t *testing.T) {
 	// store them un-encrypted in its local store.
 	chopCmd := newChopCommand(context.Background())
 	chopCmd.SetArgs([]string{"-s", store, "testdata/blob1.caibx", "testdata/blob1"})
-	chopCmd.SetOutput(io.Discard)
+	chopCmd.SetOut(io.Discard)
+	chopCmd.SetErr(io.Discard)
 	_, err := chopCmd.ExecuteC()
 	require.NoError(t, err)
 
@@ -241,7 +249,8 @@ func TestChunkServerEncryption(t *testing.T) {
 	extractFile := filepath.Join(outdir, "blob1")
 	extractCmd := newExtractCommand(context.Background())
 	extractCmd.SetArgs([]string{"-s", store, "testdata/blob1.caibx", extractFile})
-	extractCmd.SetOutput(io.Discard)
+	extractCmd.SetOut(io.Discard)
+	extractCmd.SetErr(io.Discard)
 	_, err = extractCmd.ExecuteC()
 	require.NoError(t, err)
 
@@ -272,7 +281,8 @@ func TestChunkServerEnvKeyDoesNotEnableEncryption(t *testing.T) {
 	// A plain (compressed, unencrypted) client must be able to write chunks
 	chopCmd := newChopCommand(context.Background())
 	chopCmd.SetArgs([]string{"-s", store, "testdata/blob1.caibx", "testdata/blob1"})
-	chopCmd.SetOutput(io.Discard)
+	chopCmd.SetOut(io.Discard)
+	chopCmd.SetErr(io.Discard)
 	_, err := chopCmd.ExecuteC()
 	require.NoError(t, err)
 
@@ -296,7 +306,8 @@ func TestChunkServerEncryptionMissingKey(t *testing.T) {
 	} {
 		cmd := newChunkServerCommand(context.Background())
 		cmd.SetArgs(append(args, "-s", t.TempDir(), "-l", "127.0.0.1:0"))
-		cmd.SetOutput(io.Discard)
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
 		_, err := cmd.ExecuteC()
 		require.ErrorContains(t, err, "no encryption key configured")
 	}

--- a/cmd/desync/credentials_test.go
+++ b/cmd/desync/credentials_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var now = time.Now
@@ -22,7 +23,8 @@ func TestNewRefreshableSharedCredentials(t *testing.T) {
 
 	assert.True(t, c.IsExpired(), "Expect creds to be expired before retrieve")
 
-	_, err := c.Get()
+	// The provider ignores the credential context, so nil is fine here.
+	_, err := c.GetWithContext(nil)
 	assert.Nil(t, err, "Expect no error")
 
 	assert.False(t, c.IsExpired(), "Expect creds to not be expired after retrieve")
@@ -62,7 +64,7 @@ func TestRefreshableSharedCredentialsProviderIsExpired(t *testing.T) {
 func TestRefreshableSharedCredentialsProviderWithAWS_SHARED_CREDENTIALS_FILE(t *testing.T) {
 	defer restoreEnv(os.Environ())
 	os.Clearenv()
-	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", "testdata/example.ini")
+	require.NoError(t, os.Setenv("AWS_SHARED_CREDENTIALS_FILE", "testdata/example.ini"))
 
 	p := RefreshableSharedCredentialsProvider{exp: now().Add(time.Minute), now: now}
 	creds, err := p.Retrieve()
@@ -80,7 +82,7 @@ func TestRefreshableSharedCredentialsProviderWithAWS_SHARED_CREDENTIALS_FILEAbsP
 
 	wd, err := os.Getwd()
 	assert.NoError(t, err)
-	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(wd, "testdata/example.ini"))
+	require.NoError(t, os.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(wd, "testdata/example.ini")))
 	p := RefreshableSharedCredentialsProvider{exp: now().Add(time.Minute), now: now}
 	creds, err := p.Retrieve()
 	assert.Nil(t, err, "Expect no error")
@@ -93,7 +95,7 @@ func TestRefreshableSharedCredentialsProviderWithAWS_SHARED_CREDENTIALS_FILEAbsP
 func TestRefreshableSharedCredentialsProviderWithAWS_PROFILE(t *testing.T) {
 	defer restoreEnv(os.Environ())
 	os.Clearenv()
-	os.Setenv("AWS_PROFILE", "no_token")
+	require.NoError(t, os.Setenv("AWS_PROFILE", "no_token"))
 
 	p := RefreshableSharedCredentialsProvider{Filename: "testdata/example.ini", Profile: "", exp: now().Add(time.Minute), now: now}
 	creds, err := p.Retrieve()
@@ -133,8 +135,8 @@ func TestRefreshableSharedCredentialsProviderColonInCredFile(t *testing.T) {
 func TestRefreshableSharedCredentialsProvider_DefaultFilename(t *testing.T) {
 	defer restoreEnv(os.Environ())
 	os.Clearenv()
-	os.Setenv("USERPROFILE", "profile_dir")
-	os.Setenv("HOME", "home_dir")
+	require.NoError(t, os.Setenv("USERPROFILE", "profile_dir"))
+	require.NoError(t, os.Setenv("HOME", "home_dir"))
 
 	// default filename and profile
 	p := RefreshableSharedCredentialsProvider{exp: now().Add(time.Minute), now: now}
@@ -154,6 +156,6 @@ func TestRefreshableSharedCredentialsProvider_DefaultFilename(t *testing.T) {
 func restoreEnv(env []string) {
 	for _, e := range env {
 		kv := strings.SplitN(e, "=", 2)
-		os.Setenv(kv[0], kv[1])
+		_ = os.Setenv(kv[0], kv[1])
 	}
 }

--- a/cmd/desync/extract.go
+++ b/cmd/desync/extract.go
@@ -155,8 +155,9 @@ func writeWithTmpFile(ctx context.Context, name string, idx desync.Index, s desy
 	if err != nil {
 		return stats, err
 	}
-	tmp.Close()
-	defer os.Remove(tmp.Name())
+	// Reopened by name below, so nothing is lost by discarding these.
+	_ = tmp.Close()
+	defer func() { _ = os.Remove(tmp.Name()) }()
 
 	// Build the blob from the chunks, writing everything into the tempfile
 	if stats, err = writeInplace(ctx, tmp.Name(), idx, s, seeds, assembleOpt); err != nil {

--- a/cmd/desync/extract_test.go
+++ b/cmd/desync/extract_test.go
@@ -89,7 +89,8 @@ func TestExtractCommand(t *testing.T) {
 
 			// Redirect the command's output and run it
 			stderr = io.Discard
-			cmd.SetOutput(io.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 			_, err := cmd.ExecuteC()
 			require.NoError(t, err)
 
@@ -117,7 +118,8 @@ func TestExtractWithFailover(t *testing.T) {
 
 	// Redirect the command's output and run it
 	stderr = io.Discard
-	cmd.SetOutput(io.Discard)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 	_, err := cmd.ExecuteC()
 	require.NoError(t, err)
 }
@@ -152,7 +154,8 @@ func TestExtractWithInvalidSeeds(t *testing.T) {
 
 			// Redirect the command's output and run it
 			stderr = io.Discard
-			cmd.SetOutput(io.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 			_, err := cmd.ExecuteC()
 			require.Error(t, err)
 		})

--- a/cmd/desync/indexserver_test.go
+++ b/cmd/desync/indexserver_test.go
@@ -23,7 +23,8 @@ func TestIndexServerReadCommand(t *testing.T) {
 	listCmd := newListCommand(context.Background())
 	listCmd.SetArgs([]string{fmt.Sprintf("http://%s/blob1.caibx", addr)})
 	stdout = io.Discard
-	listCmd.SetOutput(io.Discard)
+	listCmd.SetOut(io.Discard)
+	listCmd.SetErr(io.Discard)
 	_, err := listCmd.ExecuteC()
 	require.NoError(t, err)
 
@@ -32,14 +33,15 @@ func TestIndexServerReadCommand(t *testing.T) {
 	// the server.
 	resp, err := http.Get(fmt.Sprintf("http://%s/blob1", addr))
 	require.NoError(t, err)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 	// This server shouldn't allow writing. Confirm by trying to chunk a file with
 	// the "make" command and storing a new index on the index server.
 	makeCmd := newMakeCommand(context.Background())
 	makeCmd.SetArgs([]string{fmt.Sprintf("http://%s/new.caibx", addr), "testdata/blob1"})
-	makeCmd.SetOutput(io.Discard)
+	makeCmd.SetOut(io.Discard)
+	makeCmd.SetErr(io.Discard)
 	_, err = makeCmd.ExecuteC()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "writing to upstream")
@@ -57,7 +59,8 @@ func TestIndexServerWriteCommand(t *testing.T) {
 	// the "make" command and storing a new index on the index server.
 	makeCmd := newMakeCommand(context.Background())
 	makeCmd.SetArgs([]string{fmt.Sprintf("http://%s/new.caibx", addr), "testdata/blob1"})
-	makeCmd.SetOutput(io.Discard)
+	makeCmd.SetOut(io.Discard)
+	makeCmd.SetErr(io.Discard)
 	_, err := makeCmd.ExecuteC()
 	require.NoError(t, err)
 
@@ -65,7 +68,7 @@ func TestIndexServerWriteCommand(t *testing.T) {
 	req, _ := http.NewRequest("PUT", fmt.Sprintf("http://%s/invalid.caibx", addr), strings.NewReader("invalid"))
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	require.Equal(t, http.StatusUnsupportedMediaType, resp.StatusCode)
 }
 
@@ -95,7 +98,7 @@ func TestIndexServerPathTraversal(t *testing.T) {
 	req, _ := http.NewRequest("PUT", traversalURL, strings.NewReader("not-a-real-index"))
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	require.NoFileExists(t, target)
 
@@ -103,13 +106,13 @@ func TestIndexServerPathTraversal(t *testing.T) {
 	// information (no 404-vs-400 oracle).
 	resp, err = http.Get(traversalURL)
 	require.NoError(t, err)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 	req, _ = http.NewRequest("HEAD", traversalURL, nil)
 	resp, err = http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
@@ -125,14 +128,14 @@ func TestIndexServerHead(t *testing.T) {
 	req, _ := http.NewRequest("HEAD", fmt.Sprintf("http://%s/blob1.caibx", addr), nil)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Missing index -> 404 Not Found
 	req, _ = http.NewRequest("HEAD", fmt.Sprintf("http://%s/does-not-exist.caibx", addr), nil)
 	resp, err = http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
 

--- a/cmd/desync/info_test.go
+++ b/cmd/desync/info_test.go
@@ -113,7 +113,8 @@ func TestInfoCommand(t *testing.T) {
 
 			// Redirect the command's output
 			stdout = b
-			cmd.SetOutput(io.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 			_, err = cmd.ExecuteC()
 			require.NoError(t, err)
 

--- a/cmd/desync/inspectchunks_test.go
+++ b/cmd/desync/inspectchunks_test.go
@@ -44,7 +44,8 @@ func TestInspectChunksCommand(t *testing.T) {
 
 			// Redirect the command's output
 			stdout = b
-			cmd.SetOutput(io.Discard)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
 			_, err = cmd.ExecuteC()
 			require.NoError(t, err)
 

--- a/cmd/desync/list_test.go
+++ b/cmd/desync/list_test.go
@@ -18,7 +18,8 @@ func TestListCommand(t *testing.T) {
 
 	// Redirect the command's output
 	stdout = b
-	cmd.SetOutput(io.Discard)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
 	_, err := cmd.ExecuteC()
 	require.NoError(t, err)
 

--- a/cmd/desync/make.go
+++ b/cmd/desync/make.go
@@ -86,7 +86,7 @@ func runMake(ctx context.Context, opt makeOptions, args []string) error {
 		}
 	}
 	if opt.printStats {
-		printJSON(stderr, stats) // write to stderr since stdout could be used for index data
+		_ = printJSON(stderr, stats) // write to stderr since stdout could be used for index data
 	}
 	return storeCaibxFile(index, indexFile, opt.cmdStoreOptions)
 }

--- a/cmd/desync/mtree.go
+++ b/cmd/desync/mtree.go
@@ -79,7 +79,7 @@ func runMtree(ctx context.Context, opt mtreeOptions, args []string) error {
 		var tarErr error
 		go func() {
 			tarErr = desync.Tar(ctx, w, inFS)
-			w.Close()
+			w.CloseWithError(tarErr)
 		}()
 		untarErr := desync.UnTar(ctx, r, mtreeFS)
 

--- a/cmd/desync/tar.go
+++ b/cmd/desync/tar.go
@@ -153,7 +153,7 @@ func runTar(ctx context.Context, opt tarOptions, args []string) error {
 	var tarErr error
 	go func() {
 		tarErr = desync.Tar(ctx, w, fs)
-		w.Close()
+		w.CloseWithError(tarErr)
 	}()
 
 	// Read from the pipe, split the stream and store the chunks. This should

--- a/cmd/desync/version_test.go
+++ b/cmd/desync/version_test.go
@@ -20,7 +20,8 @@ func TestVersionCommand(t *testing.T) {
 		cmd.SetArgs(args)
 		b := new(bytes.Buffer)
 		stdout = b
-		cmd.SetOutput(io.Discard)
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
 		_, err := cmd.ExecuteC()
 		require.NoError(t, err)
 		return b.String()

--- a/dedupqueue_test.go
+++ b/dedupqueue_test.go
@@ -63,7 +63,7 @@ func TestDedupQueueParallel(t *testing.T) {
 		for range 10 {
 			wg.Go(func() {
 				<-start
-				q.GetChunk(ChunkID{0})
+				_, _ = q.GetChunk(ChunkID{0})
 			})
 		}
 

--- a/format.go
+++ b/format.go
@@ -147,8 +147,11 @@ func (d *FormatDecoder) Next() (any, error) {
 	// If we previously returned a reader, make sure we advance all the way in
 	// case the caller didn't read it all.
 	if d.advance != nil {
-		io.Copy(io.Discard, d.advance)
+		_, err := io.Copy(io.Discard, d.advance)
 		d.advance = nil
+		if err != nil {
+			return nil, err
+		}
 	}
 	hdr, err := d.r.ReadHeader()
 	if err != nil {

--- a/gcsindex.go
+++ b/gcsindex.go
@@ -83,7 +83,7 @@ func (s GCIndexStore) StoreIndex(name string, idx Index) error {
 
 	if err != nil {
 		log.WithError(err).Error("Error when copying data from local filesystem to object in GCS bucket")
-		w.Close()
+		_ = w.Close()
 		return errors.Wrap(err, path.Base(s.Location))
 	}
 

--- a/ioctl_linux.go
+++ b/ioctl_linux.go
@@ -27,13 +27,13 @@ func CanClone(dstFile, srcFile string) bool {
 	if err != nil {
 		return false
 	}
-	defer os.Remove(dst.Name())
+	defer func() { _ = os.Remove(dst.Name()) }()
 	defer dst.Close()
 	src, err := os.CreateTemp(filepath.Dir(srcFile), ".tmp")
 	if err != nil {
 		return false
 	}
-	defer os.Remove(src.Name())
+	defer func() { _ = os.Remove(src.Name()) }()
 	defer src.Close()
 	err = CloneRange(dst, src, 0, 0, 0)
 	return err == nil
@@ -50,10 +50,10 @@ func CloneRange(dst, src *os.File, srcOffset, srcLength, dstOffset uint64) error
 	//     __u64 dest_offset;
 	// };
 	arg := new(bytes.Buffer)
-	binary.Write(arg, binary.LittleEndian, uint64(src.Fd()))
-	binary.Write(arg, binary.LittleEndian, srcOffset)
-	binary.Write(arg, binary.LittleEndian, srcLength)
-	binary.Write(arg, binary.LittleEndian, dstOffset)
+	_ = binary.Write(arg, binary.LittleEndian, uint64(src.Fd()))
+	_ = binary.Write(arg, binary.LittleEndian, srcOffset)
+	_ = binary.Write(arg, binary.LittleEndian, srcLength)
+	_ = binary.Write(arg, binary.LittleEndian, dstOffset)
 	err := ioctl(dst.Fd(), fiCloneRange, uintptr(unsafe.Pointer(&arg.Bytes()[0])))
 	return errors.Wrapf(err, "failure cloning blocks from %s to %s", src.Name(), dst.Name())
 }

--- a/local.go
+++ b/local.go
@@ -89,11 +89,16 @@ func (s LocalStore) StoreChunk(chunk *Chunk) error {
 		return err
 	}
 	if _, err = tmp.Write(b); err != nil {
-		tmp.Close()
-		os.Remove(tmp.Name()) // clean up
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name()) // clean up
 		return err
 	}
-	tmp.Close() // Windows can't rename open files, close explicitly
+	// Windows can't rename open files, close explicitly. A failure here means
+	// the chunk wasn't flushed, so it must not be renamed into place.
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmp.Name())
+		return err
+	}
 	return os.Rename(tmp.Name(), p)
 }
 

--- a/localfs_dirmeta_test.go
+++ b/localfs_dirmeta_test.go
@@ -19,9 +19,9 @@ import (
 func makeWritableOnCleanup(t *testing.T, root string) {
 	t.Helper()
 	t.Cleanup(func() {
-		filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 			if err == nil && d.IsDir() {
-				os.Chmod(path, 0755)
+				_ = os.Chmod(path, 0755)
 			}
 			return nil
 		})

--- a/make.go
+++ b/make.go
@@ -59,7 +59,7 @@ func IndexFromFile(ctx context.Context,
 			index.Index.FeatureFlags |= t.FeatureFlags
 		}
 	}
-	f.Close()
+	_ = f.Close()
 
 	size, err := GetFileSize(name)
 	if err != nil {

--- a/mount-index.go
+++ b/mount-index.go
@@ -132,7 +132,9 @@ func MountIndex(ctx context.Context, idx Index, ifs MountFS, path string, s Stor
 		if err := ifs.Close(); err != nil {
 			fmt.Fprintln(os.Stderr, "error during unmount:", err)
 		}
-		server.Unmount()
+		if err := server.Unmount(); err != nil {
+			fmt.Fprintln(os.Stderr, "error during unmount:", err)
+		}
 	}()
 	server.Wait()
 	return nil

--- a/nullseed.go
+++ b/nullseed.go
@@ -36,7 +36,7 @@ func newNullChunkSeed(dstFile string, blocksize uint64, max uint64) (*nullChunkS
 
 func (s *nullChunkSeed) close() error {
 	if s.blockfile != nil {
-		s.blockfile.Close()
+		_ = s.blockfile.Close()
 		return os.Remove(s.blockfile.Name())
 	}
 	return nil

--- a/oci.go
+++ b/oci.go
@@ -116,7 +116,9 @@ func newOCIRepository(u *url.URL, creds auth.CredentialFunc, opt StoreOptions, l
 	// referrers indexing oras-go falls back to on registries without referrers
 	// support can never have anything to do. Declaring the capability stops it
 	// from fetching every manifest ahead of a delete just to look for a subject.
-	repo.SetReferrersCapability(true)
+	if err := repo.SetReferrersCapability(true); err != nil {
+		return nil, err
+	}
 	repo.TagListPageSize = ociTagListPageSize
 
 	tlsConfig, err := opt.tlsClientConfig()

--- a/oci_test.go
+++ b/oci_test.go
@@ -502,7 +502,7 @@ func TestOCIStoreRetry(t *testing.T) {
 		if dropped.CompareAndSwap(false, true) {
 			conn, _, err := w.(http.Hijacker).Hijack()
 			if err == nil {
-				conn.Close()
+				_ = conn.Close()
 			}
 			return
 		}
@@ -550,7 +550,7 @@ func TestOCIIdleTimeout(t *testing.T) {
 	resp, err := client.Get(srv.URL + "/slow")
 	require.NoError(t, err)
 	b, err := io.ReadAll(resp.Body)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	require.NoError(t, err)
 	require.Equal(t, "xxxx", string(b))
 
@@ -558,6 +558,6 @@ func TestOCIIdleTimeout(t *testing.T) {
 	resp, err = client.Get(srv.URL + "/stall")
 	require.NoError(t, err)
 	_, err = io.ReadAll(resp.Body)
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	require.Error(t, err)
 }

--- a/ociindex.go
+++ b/ociindex.go
@@ -110,7 +110,7 @@ func (s OCIIndexStore) GetIndexReader(name string) (io.ReadCloser, error) {
 		return nil, err
 	}
 	manifest, err := readOCIManifest(r)
-	r.Close()
+	_ = r.Close()
 	if err != nil {
 		return nil, fmt.Errorf("invalid manifest for index %s in %s: %w", name, s, err)
 	}
@@ -191,7 +191,7 @@ func (s OCIIndexStore) StoreIndex(name string, idx Index) error {
 		}()
 		err := s.repo.Blobs().Push(ctx, blobDesc, pr)
 		// Unblocks the writer if the push stopped reading early.
-		pr.Close()
+		_ = pr.Close()
 		if err != nil {
 			return err
 		}

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -85,10 +85,10 @@ func TestProtocol(t *testing.T) {
 
 	<-gCtx.Done()
 	// unblock client/server in case of an error
-	r1.Close()
-	r2.Close()
-	w1.Close()
-	w2.Close()
+	_ = r1.Close()
+	_ = r2.Close()
+	_ = w1.Close()
+	_ = w2.Close()
 
 	require.NoError(t, g.Wait())
 }

--- a/protocolserver_test.go
+++ b/protocolserver_test.go
@@ -19,11 +19,11 @@ func TestProtocolServer(t *testing.T) {
 	chunkIn := NewChunk(uncompressed)
 	id := chunkIn.ID()
 	store := &TestStore{}
-	store.StoreChunk(chunkIn)
+	require.NoError(t, store.StoreChunk(chunkIn))
 
 	ps := NewProtocolServer(r2, w1, store)
 
-	go ps.Serve(context.Background())
+	go func() { _ = ps.Serve(context.Background()) }()
 
 	// Client
 	flags, err := server.Initialize(CaProtocolPullChunks)

--- a/remotehttp_test.go
+++ b/remotehttp_test.go
@@ -37,7 +37,7 @@ func TestHTTPStoreURL(t *testing.T) {
 			u.Path = test.storePath
 			s, err := NewRemoteHTTPStore(u, StoreOptions{})
 			require.NoError(t, err)
-			s.GetChunk(chunkID)
+			_, _ = s.GetChunk(chunkID)
 			require.Equal(t, test.serverPath, requestURI)
 		})
 	}
@@ -59,20 +59,20 @@ func TestHasChunk(t *testing.T) {
 			w.WriteHeader(http.StatusForbidden)
 		case "/0000/0000000500000000000000000000000000000000000000000000000000000000.cacnk":
 			w.WriteHeader(http.StatusBadGateway)
-			io.WriteString(w, "Bad Gateway")
+			_, _ = io.WriteString(w, "Bad Gateway")
 		case "/0000/0000000600000000000000000000000000000000000000000000000000000000.cacnk":
 			if attemptCount >= 2 {
 				w.WriteHeader(http.StatusOK)
 			} else {
 				w.WriteHeader(http.StatusBadGateway)
-				io.WriteString(w, "Bad Gateway")
+				_, _ = io.WriteString(w, "Bad Gateway")
 			}
 		case "/0000/0000000700000000000000000000000000000000000000000000000000000000.cacnk":
 			if attemptCount >= 3 {
 				w.WriteHeader(http.StatusNotFound)
 			} else {
 				w.WriteHeader(http.StatusBadGateway)
-				io.WriteString(w, "Bad Gateway")
+				_, _ = io.WriteString(w, "Bad Gateway")
 			}
 		default:
 			w.WriteHeader(http.StatusBadRequest)
@@ -129,35 +129,35 @@ func TestGetChunk(t *testing.T) {
 		switch r.URL.String() {
 		case "/3bc8/3bc8e3230df5515b1b40e938e49ebc765c6157d4cf4e2b9d5f9c272571365395":
 			w.WriteHeader(http.StatusOK)
-			io.WriteString(w, "Chunk Content String 1")
+			_, _ = io.WriteString(w, "Chunk Content String 1")
 		case "/0000/0000000100000000000000000000000000000000000000000000000000000000":
 			w.WriteHeader(http.StatusOK)
-			io.WriteString(w, "Chunk Content With hash mismatch")
+			_, _ = io.WriteString(w, "Chunk Content With hash mismatch")
 		case "/0000/0000000200000000000000000000000000000000000000000000000000000000":
 			w.WriteHeader(http.StatusNotFound)
 		case "/0000/0000000300000000000000000000000000000000000000000000000000000000":
 			w.WriteHeader(http.StatusBadRequest)
-			io.WriteString(w, "BadRequest")
+			_, _ = io.WriteString(w, "BadRequest")
 		case "/0000/0000000400000000000000000000000000000000000000000000000000000000":
 			w.WriteHeader(http.StatusForbidden)
-			io.WriteString(w, "Forbidden")
+			_, _ = io.WriteString(w, "Forbidden")
 		case "/0000/0000000500000000000000000000000000000000000000000000000000000000":
 			w.WriteHeader(http.StatusBadGateway)
-			io.WriteString(w, "Bad Gateway")
+			_, _ = io.WriteString(w, "Bad Gateway")
 		case "/65a1/65a128d0658c4cf0941771c7090fea6d9c6f981810659c24c91ba23edd71574b":
 			if attemptCount >= 2 {
 				w.WriteHeader(http.StatusOK)
-				io.WriteString(w, "Chunk Content String 6")
+				_, _ = io.WriteString(w, "Chunk Content String 6")
 			} else {
 				w.WriteHeader(http.StatusBadGateway)
-				io.WriteString(w, "Bad Gateway")
+				_, _ = io.WriteString(w, "Bad Gateway")
 			}
 		case "/0000/0000000700000000000000000000000000000000000000000000000000000000":
 			if attemptCount >= 3 {
 				w.WriteHeader(http.StatusNotFound)
 			} else {
 				w.WriteHeader(http.StatusBadGateway)
-				io.WriteString(w, "Bad Gateway")
+				_, _ = io.WriteString(w, "Bad Gateway")
 			}
 		default:
 			w.WriteHeader(http.StatusBadRequest)
@@ -225,7 +225,7 @@ func TestPutChunk(t *testing.T) {
 			content, err := io.ReadAll(r.Body)
 			if err != nil {
 				w.WriteHeader(http.StatusBadRequest)
-				io.WriteString(w, err.Error())
+				_, _ = io.WriteString(w, err.Error())
 			} else {
 				writtenContent = content
 				w.WriteHeader(http.StatusOK)
@@ -234,33 +234,33 @@ func TestPutChunk(t *testing.T) {
 			content, err := io.ReadAll(r.Body)
 			if err != nil {
 				w.WriteHeader(http.StatusBadRequest)
-				io.WriteString(w, err.Error())
+				_, _ = io.WriteString(w, err.Error())
 			} else {
 				writtenContent = content
 				w.WriteHeader(http.StatusCreated)
 			}
 		case "/0000/0000000300000000000000000000000000000000000000000000000000000000":
 			w.WriteHeader(http.StatusBadRequest)
-			io.WriteString(w, "BadRequest")
+			_, _ = io.WriteString(w, "BadRequest")
 		case "/0000/0000000400000000000000000000000000000000000000000000000000000000":
 			w.WriteHeader(http.StatusForbidden)
-			io.WriteString(w, "Forbidden")
+			_, _ = io.WriteString(w, "Forbidden")
 		case "/0000/0000000500000000000000000000000000000000000000000000000000000000":
 			w.WriteHeader(http.StatusBadGateway)
-			io.WriteString(w, "Bad Gateway")
+			_, _ = io.WriteString(w, "Bad Gateway")
 		case "/65a1/65a128d0658c4cf0941771c7090fea6d9c6f981810659c24c91ba23edd71574b":
 			if attemptCount >= 2 {
 				content, err := io.ReadAll(r.Body)
 				if err != nil {
 					w.WriteHeader(http.StatusBadRequest)
-					io.WriteString(w, err.Error())
+					_, _ = io.WriteString(w, err.Error())
 				} else {
 					writtenContent = content
 					w.WriteHeader(http.StatusOK)
 				}
 			} else {
 				w.WriteHeader(http.StatusBadGateway)
-				io.WriteString(w, "Bad Gateway")
+				_, _ = io.WriteString(w, "Bad Gateway")
 			}
 		default:
 			w.WriteHeader(http.StatusBadRequest)
@@ -322,7 +322,7 @@ func TestPutChunk(t *testing.T) {
 func TestRetryExhaustedError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		io.WriteString(w, "service down for maintenance")
+		_, _ = io.WriteString(w, "service down for maintenance")
 	}))
 	defer ts.Close()
 	u, _ := url.Parse(ts.URL)
@@ -353,7 +353,7 @@ func TestRemoteHTTPPutEncrypted(t *testing.T) {
 
 	// Setup a dummy server that records the request body (raw chunk data)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		io.Copy(body, r.Body)
+		_, _ = io.Copy(body, r.Body)
 	}))
 	defer ts.Close()
 	u, _ := url.Parse(ts.URL)

--- a/remotehttpindex.go
+++ b/remotehttpindex.go
@@ -51,8 +51,8 @@ func (r *RemoteHTTPIndex) StoreIndex(name string, idx Index) error {
 
 		rdr, w := io.Pipe()
 		go func() {
-			defer w.Close()
-			idx.WriteTo(w)
+			_, err := idx.WriteTo(w)
+			w.CloseWithError(err)
 		}()
 		return rdr
 	}

--- a/s3.go
+++ b/s3.go
@@ -131,7 +131,7 @@ retry:
 			}
 		}
 		if attempt <= s.opt.ErrorRetry {
-			obj.Close()
+			_ = obj.Close()
 			cancel()
 			time.Sleep(time.Duration(attempt) * s.opt.ErrorRetryBaseInterval)
 			goto retry
@@ -151,7 +151,7 @@ retry:
 				"object":  name,
 				"attempt": attempt,
 			}).WithError(err).Info("chunk failed validation, retrying")
-			obj.Close()
+			_ = obj.Close()
 			cancel()
 			time.Sleep(time.Duration(attempt) * s.opt.ErrorRetryBaseInterval)
 			goto retry

--- a/s3_test.go
+++ b/s3_test.go
@@ -69,10 +69,10 @@ func sendObject(conn *net.TCPConn, request *http.Request, filePath string, mode 
 	if err != nil {
 		if os.IsNotExist(err) {
 			resp := response(request, http.Header{}, 404, "")
-			resp.Write(conn)
+			_ = resp.Write(conn)
 		} else {
 			resp := response(request, http.Header{}, 500, err.Error())
-			resp.Write(conn)
+			_ = resp.Write(conn)
 		}
 		return nil
 	}
@@ -81,7 +81,7 @@ func sendObject(conn *net.TCPConn, request *http.Request, filePath string, mode 
 	stat, err := file.Stat()
 	if err != nil {
 		resp := response(request, http.Header{}, 500, err.Error())
-		resp.Write(conn)
+		_ = resp.Write(conn)
 		return nil
 	}
 	headers := http.Header{}
@@ -140,7 +140,7 @@ func sendObject(conn *net.TCPConn, request *http.Request, filePath string, mode 
 			Body:       file,
 			Header:     headers,
 		}
-		resp.Write(conn)
+		_ = resp.Write(conn)
 	}
 	return nil
 }
@@ -165,7 +165,7 @@ func handleGetObjectRequest(conn *net.TCPConn, bucket, store string, errorMode s
 		(*errorTimes)++
 	} else {
 		resp := response(request, http.Header{}, 400, "")
-		resp.Write(conn)
+		_ = resp.Write(conn)
 	}
 	return err
 }

--- a/s3index.go
+++ b/s3index.go
@@ -76,8 +76,8 @@ func (s S3IndexStore) StoreIndex(name string, idx Index) error {
 	r, w := io.Pipe()
 
 	go func() {
-		defer w.Close()
-		idx.WriteTo(w)
+		_, err := idx.WriteTo(w)
+		w.CloseWithError(err)
 	}()
 
 	ctx, cancel := s.opt.contextWithTimeout(context.Background())

--- a/sftp.go
+++ b/sftp.go
@@ -107,7 +107,7 @@ retry:
 		// errors since that could be racy and fail if another goroutine does the
 		// same.
 		if errCount < 1 {
-			s.client.Mkdir(d)
+			_ = s.client.Mkdir(d)
 			errCount++
 			goto retry
 		}
@@ -115,7 +115,7 @@ retry:
 	}
 
 	if _, err := io.Copy(f, r); err != nil {
-		s.client.Remove(tmpfile)
+		_ = s.client.Remove(tmpfile)
 		return errors.Wrap(err, "sftp:copying chunk data to "+tmpfile)
 	}
 	if err = f.Close(); err != nil {

--- a/sftpindex.go
+++ b/sftpindex.go
@@ -55,8 +55,8 @@ func (s *SFTPIndexStore) StoreIndex(name string, idx Index) error {
 	r, w := io.Pipe()
 
 	go func() {
-		defer w.Close()
-		idx.WriteTo(w)
+		_, err := idx.WriteTo(w)
+		w.CloseWithError(err)
 	}()
 	return s.StoreObject(s.pathFromName(name), r)
 }

--- a/swapstore.go
+++ b/swapstore.go
@@ -72,7 +72,7 @@ func (s *SwapStore) Swap(new Store) error {
 	if oldWritable && !newWritable {
 		return errors.New("a writable store can only be updated with another writable one")
 	}
-	s.s.Close() // Close the old store
+	_ = s.s.Close() // Close the old store, the swap goes ahead regardless
 	s.s = new
 	return nil
 }

--- a/tar_test.go
+++ b/tar_test.go
@@ -32,7 +32,7 @@ func TestTar(t *testing.T) {
 		"dir1/sub11/f12",
 	}
 	for i, name := range files {
-		os.WriteFile(filepath.Join(base, name), fmt.Appendf(nil, "filecontent%d", i), 0644)
+		require.NoError(t, os.WriteFile(filepath.Join(base, name), fmt.Appendf(nil, "filecontent%d", i), 0644))
 	}
 
 	require.NoError(t, os.Symlink("dir1", filepath.Join(base, "symlink")))

--- a/tarfs_test.go
+++ b/tarfs_test.go
@@ -33,7 +33,7 @@ func TestGnuTarWrite(t *testing.T) {
 	if err := UnTar(context.Background(), r, fs); err != nil {
 		t.Fatal(err)
 	}
-	fs.Close()
+	_ = fs.Close()
 
 	// Compare to expected
 	if !bytes.Equal(b.Bytes(), exp) {

--- a/writededupqueue_test.go
+++ b/writededupqueue_test.go
@@ -31,7 +31,7 @@ func TestWriteDedupQueueParallelReadWrite(t *testing.T) {
 		done := make(chan struct{})
 		go func() {
 			defer close(done)
-			q.GetChunk(c.ID())
+			_, _ = q.GetChunk(c.ID())
 		}()
 		<-sleeping
 


### PR DESCRIPTION
Adds a lint gate to CI and fixes what it found.

## CI

Two new jobs, both separate from the build matrix so a lint failure and a test failure are reported side by side:

- **golangci-lint** — the standard set: errcheck, govet, ineffassign, staticcheck, unused.
- **govulncheck** — reports only vulnerabilities the code actually reaches, so a finding is worth acting on rather than triaging away. It runs against the current stable toolchain rather than the go.mod version, since most findings are in the standard library and the fix for those is a Go upgrade.

`.golangci.yml` turns off two categories, both style rather than defects:

- staticcheck's `QF` refactoring suggestions — dropping an embedded type from a selector that names it for clarity, applying De Morgan's law to a condition that reads better as written.
- errcheck on a *deferred* `Close`, which has nowhere to report to. A `Close` called outright stays flagged, and that is where the real bugs turned out to be.

The default caps on reported issues are lifted; at three per distinct message they hid most of what was there.

The `go-vet` pre-commit hook is enabled too, since it needs no tooling beyond the toolchain. `golangci-lint` stays commented out there because it needs the binary on PATH, and CI enforces it either way.

## What it found

Most of the 72 findings were an intentional discard that just wasn't written as one. Four were worth changing:

- **`LocalStore.StoreChunk` renamed the temp file into place without checking that closing it succeeded.** A close failure means the chunk was never flushed, so the store would publish a chunk it had not written.
- **The RemoteHTTP, S3 and SFTP index stores closed the pipe write end with a plain `Close`.** A failing `WriteTo` therefore ended the stream cleanly and the store uploaded a short index as if it were whole. They now close with the error, as the OCI index store already did. Same pattern in `tar` and `mtree`.
- **`Cache.Close` returned only the upstream store's error**, discarding the cache store's.
- **`FormatDecoder.Next` ignored the error from advancing past an unread element**, leaving the stream misaligned so the next read reported a bogus header instead of the real failure.

Deprecated calls in tests were replaced: cobra's `SetOutput` with `SetOut`/`SetErr`, minio's `Credentials.Get` with `GetWithContext`.

`golangci-lint run ./...` reports 0 issues, and the suite passes under `-race`.