### PR TITLE
Support NetBSD, OpenBSD and DragonFly

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -43,12 +43,18 @@ jobs:
       - run: go test ./...
       - run: go build -o cmd/desync/ ./cmd/desync
 
-      # Fast signal for the FreeBSD build. The freebsd job below runs the
-      # actual tests, but it has to boot a VM first, so a broken build is
-      # reported here within seconds instead of minutes.
-      - name: Cross-compile FreeBSD
+      # Fast signal for the BSD builds. The VM jobs below run the actual
+      # tests, but they have to boot a VM first, so a broken build is
+      # reported here within seconds instead of minutes. Covers every BSD
+      # release artifact target; dragonfly is amd64-only in Go.
+      - name: Cross-compile BSDs
         if: runner.os == 'Linux'
-        run: GOOS=freebsd GOARCH=amd64 go build -o /dev/null ./cmd/desync
+        run: |
+          for target in freebsd/amd64 freebsd/arm64 netbsd/amd64 netbsd/arm64 \
+                        openbsd/amd64 openbsd/arm64 dragonfly/amd64; do
+            echo "==> $target"
+            GOOS=${target%/*} GOARCH=${target#*/} go build -o /dev/null ./cmd/desync
+          done
 
       - name: Race detector
         if: runner.os == 'Linux'
@@ -123,8 +129,15 @@ jobs:
           go-version: stable
       - run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
 
-  # FreeBSD has no GitHub-hosted runner, so the tests run in a VM on the Linux
-  # runner. Booting it costs a few minutes, hence the separate job.
+  # None of the BSDs have a GitHub-hosted runner, so their tests run in a VM on
+  # the Linux runner. Booting one costs a few minutes, hence the separate jobs
+  # rather than steps in the matrix above. They can't be a matrix either: the
+  # VM image is chosen by which action is named in `uses`, and that field
+  # doesn't accept expressions.
+  #
+  # `go version` is echoed because the toolchain comes from each system's own
+  # package repo. Those lag, and go.mod sets a minimum, so "the package is too
+  # old" is the failure mode worth being able to read straight off the log.
   freebsd:
     name: Validate on FreeBSD
     runs-on: ubuntu-latest
@@ -140,5 +153,63 @@ jobs:
           prepare: |
             pkg install -y go
           run: |
+            go version
+            go test ./...
+            go build -o cmd/desync/ ./cmd/desync
+
+  netbsd:
+    name: Validate on NetBSD
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Test in NetBSD VM
+        uses: vmactions/netbsd-vm@v1
+        with:
+          usesh: true
+          copyback: false
+          prepare: |
+            /usr/sbin/pkg_add go
+          run: |
+            go version
+            go test ./...
+            go build -o cmd/desync/ ./cmd/desync
+
+  openbsd:
+    name: Validate on OpenBSD
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Test in OpenBSD VM
+        uses: vmactions/openbsd-vm@v1
+        with:
+          usesh: true
+          copyback: false
+          prepare: |
+            pkg_add -I go
+          run: |
+            go version
+            go test ./...
+            go build -o cmd/desync/ ./cmd/desync
+
+  dragonfly:
+    name: Validate on DragonFly BSD
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Test in DragonFly BSD VM
+        uses: vmactions/dragonflybsd-vm@v1
+        with:
+          usesh: true
+          copyback: false
+          prepare: |
+            pkg install -y go
+          run: |
+            go version
             go test ./...
             go build -o cmd/desync/ ./cmd/desync

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -172,6 +172,10 @@ jobs:
           prepare: |
             /usr/sbin/pkg_add go
           run: |
+            # pkgsrc installs under /usr/pkg, which isn't on the default PATH
+            # the way FreeBSD's /usr/local/bin is.
+            PATH=/usr/pkg/bin:/usr/pkg/sbin:$PATH
+            export PATH
             go version
             go test ./...
             go build -o cmd/desync/ ./cmd/desync

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -138,6 +138,10 @@ jobs:
   # `go version` is echoed because the toolchain comes from each system's own
   # package repo. Those lag, and go.mod sets a minimum, so "the package is too
   # old" is the failure mode worth being able to read straight off the log.
+  #
+  # -buildvcs=false because git exits 128 on the rsynced-in tree, which would
+  # otherwise fail the build over version stamping rather than anything about
+  # the code. Release builds stamp via goreleaser's ldflags regardless.
   freebsd:
     name: Validate on FreeBSD
     runs-on: ubuntu-latest
@@ -155,7 +159,7 @@ jobs:
           run: |
             go version
             go test ./...
-            go build -o cmd/desync/ ./cmd/desync
+            go build -buildvcs=false -o cmd/desync/ ./cmd/desync
 
   netbsd:
     name: Validate on NetBSD
@@ -172,13 +176,16 @@ jobs:
           prepare: |
             /usr/sbin/pkg_add go
           run: |
-            # pkgsrc installs under /usr/pkg, which isn't on the default PATH
-            # the way FreeBSD's /usr/local/bin is.
-            PATH=/usr/pkg/bin:/usr/pkg/sbin:$PATH
+            # pkgsrc has no unversioned `go`: the meta-package installs no
+            # files of its own, and the versioned one it depends on lands as
+            # /usr/pkg/bin/go126 plus /usr/pkg/go126/bin/go. Glob for it rather
+            # than hard-coding a version that pkgsrc will bump. Only the one
+            # the meta-package pulled in is installed, so this matches once.
+            PATH=$(ls -d /usr/pkg/go[0-9]*/bin 2>/dev/null | tail -1):/usr/pkg/bin:$PATH
             export PATH
             go version
             go test ./...
-            go build -o cmd/desync/ ./cmd/desync
+            go build -buildvcs=false -o cmd/desync/ ./cmd/desync
 
   openbsd:
     name: Validate on OpenBSD
@@ -197,7 +204,7 @@ jobs:
           run: |
             go version
             go test ./...
-            go build -o cmd/desync/ ./cmd/desync
+            go build -buildvcs=false -o cmd/desync/ ./cmd/desync
 
   dragonfly:
     name: Validate on DragonFly BSD
@@ -216,4 +223,4 @@ jobs:
           run: |
             go version
             go test ./...
-            go build -o cmd/desync/ ./cmd/desync
+            go build -buildvcs=false -o cmd/desync/ ./cmd/desync

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,13 +21,19 @@ builds:
       - darwin
       - windows
       - freebsd
+      # The remaining BSDs build and pass their test suites, but can't FUSE
+      # mount: go-fuse supports linux, darwin and freebsd only. Every other
+      # command works.
+      - netbsd
+      - openbsd
+      - dragonfly
     goarch:
       - amd64
       - arm64
       # 32-bit ARM and RISC-V for the embedded/appliance case, which is where
       # image updates tend to land. Linux only: the other platforms either
-      # don't support these architectures at all, or (freebsd/arm) are too
-      # niche to be worth an artifact nobody exercises.
+      # don't support these architectures at all, or (the BSDs) are too niche
+      # to be worth an artifact nobody exercises.
       - arm
       - riscv64
     # Both ARM variants: v6 runs anywhere 32-bit ARM does, v7 is faster on
@@ -35,9 +41,18 @@ builds:
     goarm:
       - "6"
       - "7"
+    # Combinations Go has no port for at all (dragonfly is amd64-only, for
+    # instance) are dropped by goreleaser on its own; these are the ones that
+    # would otherwise build and ship.
     ignore:
       - goos: freebsd
         goarch: arm
+      - goos: netbsd
+        goarch: arm
+      - goos: openbsd
+        goarch: arm
+      - goos: openbsd
+        goarch: riscv64
 
 archives:
   # Declaring files at all replaces goreleaser's default list, so the license

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ desync extract -s http://server/store -c /tmp/cache index.caibx /path/to/largefi
 | macOS | Supported | Minor incompatibilities possible when exchanging catar files with Linux (filemodes) |
 | Windows | Partial | Subset of commands. No `mount-index`. Device entries unsupported in tar; `--no-same-owner` and `--no-same-permissions` ignored in `untar`. |
 | FreeBSD | Supported | Tested in CI in a VM and release binaries are published, but it sees far less real-world use than Linux. |
-| NetBSD | Supported | No `mount-index`. Tested in CI in a VM and release binaries are published, but it sees far less real-world use than Linux. |
+| NetBSD | Supported | No `mount-index`. Extended attributes work only on filesystems that implement them, and are skipped elsewhere. Tested in CI in a VM and release binaries are published, but it sees far less real-world use than Linux. |
 | OpenBSD | Supported | No `mount-index`, and extended attributes are silently dropped by `tar` and `untar`. Otherwise as NetBSD. |
 | DragonFly | Supported | No `mount-index`. Extended attributes are silently dropped by `tar` and `untar`, and device entries don't round-trip: `mknod` reports success but the node reads back with no device number. Otherwise as NetBSD. |
 

--- a/README.md
+++ b/README.md
@@ -118,9 +118,11 @@ desync extract -s http://server/store -c /tmp/cache index.caibx /path/to/largefi
 | --- | --- | --- |
 | Linux | Full support | All features including FUSE, reflinks (Btrfs/XFS) |
 | macOS | Supported | Minor incompatibilities possible when exchanging catar files with Linux (filemodes) |
-| Windows | Partial | Subset of commands. Device entries unsupported in tar; `--no-same-owner` and `--no-same-permissions` ignored in `untar`. |
+| Windows | Partial | Subset of commands. No `mount-index`. Device entries unsupported in tar; `--no-same-owner` and `--no-same-permissions` ignored in `untar`. |
 | FreeBSD | Supported | Tested in CI in a VM and release binaries are published, but it sees far less real-world use than Linux. |
-| Other BSD | Unsupported | NetBSD, OpenBSD and DragonFly are not supported by the FUSE library desync uses. |
+| NetBSD | Supported | No `mount-index`. Tested in CI in a VM and release binaries are published, but it sees far less real-world use than Linux. |
+| OpenBSD | Supported | No `mount-index`, and extended attributes are silently dropped by `tar` and `untar`. Otherwise as NetBSD. |
+| DragonFly | Supported | No `mount-index`, and extended attributes are silently dropped by `tar` and `untar`. Otherwise as NetBSD. |
 
 ## Design Philosophy
 
@@ -130,6 +132,7 @@ desync extract -s http://server/store -c /tmp/cache index.caibx /path/to/largefi
 - **Compression** — only zstd compression and uncompressed stores are supported.
 - **Serving casync clients** — desync can stand in for the casync binary on SSH servers for read-only chunk serving. Set `CASYNC_REMOTE_PATH=desync` on the client.
 - **catar limitations** — SELinux and ACLs in existing catar files are ignored and won't be present in newly created catars. FCAPs are supported only as a verbatim copy of the `security.capability` XAttr.
+- **FUSE mounting** — `mount-index` needs the FUSE bindings, which cover Linux, macOS and FreeBSD. Elsewhere the command exists but reports that it's unavailable.
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ desync extract -s http://server/store -c /tmp/cache index.caibx /path/to/largefi
 | FreeBSD | Supported | Tested in CI in a VM and release binaries are published, but it sees far less real-world use than Linux. |
 | NetBSD | Supported | No `mount-index`. Tested in CI in a VM and release binaries are published, but it sees far less real-world use than Linux. |
 | OpenBSD | Supported | No `mount-index`, and extended attributes are silently dropped by `tar` and `untar`. Otherwise as NetBSD. |
-| DragonFly | Supported | No `mount-index`, and extended attributes are silently dropped by `tar` and `untar`. Otherwise as NetBSD. |
+| DragonFly | Supported | No `mount-index`. Extended attributes are silently dropped by `tar` and `untar`, and device entries don't round-trip: `mknod` reports success but the node reads back with no device number. Otherwise as NetBSD. |
 
 ## Design Philosophy
 

--- a/cmd/desync/mount-index.go
+++ b/cmd/desync/mount-index.go
@@ -1,5 +1,4 @@
-//go:build !windows
-// +build !windows
+//go:build !windows && !netbsd && !openbsd && !dragonfly
 
 package main
 

--- a/cmd/desync/mount-index_nofuse.go
+++ b/cmd/desync/mount-index_nofuse.go
@@ -1,3 +1,5 @@
+//go:build windows || netbsd || openbsd || dragonfly
+
 package main
 
 import (
@@ -7,8 +9,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// newMountIndexCommand is a placeholder on platforms desync can't FUSE mount
+// on. The command is registered (hidden) rather than omitted so that invoking
+// it reports why it's unavailable instead of "unknown command".
 func newMountIndexCommand(ctx context.Context) *cobra.Command {
 	return &cobra.Command{
+		Use:    "mount-index <index> <mountpoint>",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("command not available on this platform")

--- a/localfs_mkdev_test.go
+++ b/localfs_mkdev_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,6 +63,14 @@ func TestMkdevOutOfRange(t *testing.T) {
 func TestCreateDeviceRoundTrip(t *testing.T) {
 	if os.Geteuid() != 0 {
 		t.Skip("creating device nodes requires root")
+	}
+	// On DragonFly mknod reports success but the node reads back with an Rdev
+	// of NODEV (0xffffffff) for every pair tried here, 0:0 included, so the
+	// major/minor can't survive the trip through the kernel. TestMkdev above
+	// still passes there, which places the problem in mknod rather than in
+	// desync's encoding.
+	if runtime.GOOS == "dragonfly" {
+		t.Skip("dragonfly does not preserve device numbers through mknod")
 	}
 	for _, tc := range devTestCases {
 		dir := t.TempDir()

--- a/localfs_mknod_mknodat.go
+++ b/localfs_mknod_mknodat.go
@@ -1,4 +1,4 @@
-//go:build linux || netbsd || openbsd || dragonfly
+//go:build linux || openbsd || dragonfly
 
 package desync
 
@@ -15,10 +15,11 @@ import (
 // that directory fd with a base name that has no path separators, so it
 // cannot escape Root.
 //
-// This covers every platform whose mknodat(2) wrapper takes the device number
-// as an int. FreeBSD has mknodat too but types it as uint64, so it needs its
-// own copy; Darwin has no mknodat at all and falls back to a resolve-then-
-// mknod dance.
+// This covers the platforms whose mknodat(2) both takes the device number as
+// an int and actually carries it through. FreeBSD has mknodat too but types
+// the argument uint64, so it needs its own copy. Darwin has no mknodat at all,
+// and NetBSD's drops the device number, so both go through plain mknod
+// instead.
 func (fs *LocalFS) createDeviceNode(r *os.Root, n NodeDevice) error {
 	dev, err := mkdev(n.Major, n.Minor)
 	if err != nil {

--- a/localfs_mknod_mknodat.go
+++ b/localfs_mknod_mknodat.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux || netbsd || openbsd || dragonfly
 
 package desync
 
@@ -14,6 +14,11 @@ import (
 // traverse any symlink escaping the root) and the node is created relative to
 // that directory fd with a base name that has no path separators, so it
 // cannot escape Root.
+//
+// This covers every platform whose mknodat(2) wrapper takes the device number
+// as an int. FreeBSD has mknodat too but types it as uint64, so it needs its
+// own copy; Darwin has no mknodat at all and falls back to a resolve-then-
+// mknod dance.
 func (fs *LocalFS) createDeviceNode(r *os.Root, n NodeDevice) error {
 	dev, err := mkdev(n.Major, n.Minor)
 	if err != nil {

--- a/localfs_mknod_other.go
+++ b/localfs_mknod_other.go
@@ -1,4 +1,4 @@
-//go:build !linux && !freebsd && !windows
+//go:build !linux && !freebsd && !windows && !netbsd && !openbsd && !dragonfly
 
 package desync
 
@@ -11,12 +11,12 @@ import (
 )
 
 // createDeviceNode creates a device node confined to the extraction root.
-// Darwin (and other non-Linux Unix) has no mknodat(2), so the parent
-// directory is first resolved through the os.Root handle - which refuses to
-// traverse any symlink that escapes the root - to validate confinement, and
-// the node is then created on the corresponding real path. Extraction is
-// single-threaded, so there is no concurrent attacker able to swap a
-// component between this check and the mknod call.
+// Darwin has no mknodat(2), so the parent directory is first resolved through
+// the os.Root handle - which refuses to traverse any symlink that escapes the
+// root - to validate confinement, and the node is then created on the
+// corresponding real path. Extraction is single-threaded, so there is no
+// concurrent attacker able to swap a component between this check and the
+// mknod call.
 func (fs *LocalFS) createDeviceNode(r *os.Root, n NodeDevice) error {
 	dev, err := mkdev(n.Major, n.Minor)
 	if err != nil {

--- a/localfs_mknod_other.go
+++ b/localfs_mknod_other.go
@@ -1,4 +1,4 @@
-//go:build !linux && !freebsd && !windows && !netbsd && !openbsd && !dragonfly
+//go:build !linux && !freebsd && !windows && !openbsd && !dragonfly
 
 package desync
 
@@ -11,12 +11,15 @@ import (
 )
 
 // createDeviceNode creates a device node confined to the extraction root.
-// Darwin has no mknodat(2), so the parent directory is first resolved through
-// the os.Root handle - which refuses to traverse any symlink that escapes the
-// root - to validate confinement, and the node is then created on the
-// corresponding real path. Extraction is single-threaded, so there is no
-// concurrent attacker able to swap a component between this check and the
-// mknod call.
+// Darwin has no mknodat(2) to use, and NetBSD's takes a uint32_t where every
+// other BSD takes a dev_t and loses the device number as a result - nodes come
+// back with an rdev of 0 - while its plain mknod(2) is the versioned
+// __mknod50, which carries the full dev_t. So both create the node with mknod
+// instead: the parent directory is first resolved through the os.Root handle -
+// which refuses to traverse any symlink that escapes the root - to validate
+// confinement, and the node is then created on the corresponding real path.
+// Extraction is single-threaded, so there is no concurrent attacker able to
+// swap a component between this check and the mknod call.
 func (fs *LocalFS) createDeviceNode(r *os.Root, n NodeDevice) error {
 	dev, err := mkdev(n.Major, n.Minor)
 	if err != nil {

--- a/localfs_other.go
+++ b/localfs_other.go
@@ -4,6 +4,7 @@
 package desync
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -205,6 +206,19 @@ func mkdev(major, minor uint64) (uint64, error) {
 	return unix.Mkdev(uint32(major), uint32(minor)), nil
 }
 
+// xattrUnsupported reports whether an extended attribute call failed because
+// the filesystem has no support for them, rather than for a real reason. Where
+// that support is per-filesystem rather than per-system - NetBSD has none on
+// tmpfs, and the same is true of vfat on Linux - a tree walk would otherwise
+// fail on its first entry, so a store with no xattrs to read is treated as a
+// store with none rather than as an error.
+//
+// ENOTSUP and EOPNOTSUPP are the same value on Linux but not on the BSDs, so
+// both are tested.
+func xattrUnsupported(err error) bool {
+	return errors.Is(err, unix.EOPNOTSUPP) || errors.Is(err, unix.ENOTSUP)
+}
+
 // Next returns the next filesystem entry or io.EOF when done. The caller is responsible
 // for closing the returned File object.
 func (fs *LocalFS) Next() (*File, error) {
@@ -240,7 +254,7 @@ func (fs *LocalFS) Next() (*File, error) {
 	// Extract the Xattrs if any
 	xa := make(map[string]string)
 	keys, err := xattr.LList(entry.path)
-	if err != nil {
+	if err != nil && !xattrUnsupported(err) {
 		return nil, err
 	}
 	for _, key := range keys {

--- a/localfs_xattr_test.go
+++ b/localfs_xattr_test.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package desync
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/pkg/xattr"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
+)
+
+// TestXattrUnsupported checks that only a filesystem's lack of extended
+// attribute support is waved through, and that a real failure to read them
+// still surfaces. Walking a tree on NetBSD's tmpfs used to fail on the first
+// entry because the two were not told apart.
+func TestXattrUnsupported(t *testing.T) {
+	listErr := func(err error) error {
+		return &xattr.Error{Op: "xattr.list", Path: "/tmp/x", Err: err}
+	}
+
+	assert.True(t, xattrUnsupported(listErr(unix.EOPNOTSUPP)))
+	assert.True(t, xattrUnsupported(listErr(unix.ENOTSUP)))
+
+	assert.False(t, xattrUnsupported(listErr(unix.EPERM)))
+	assert.False(t, xattrUnsupported(listErr(unix.EACCES)))
+	assert.False(t, xattrUnsupported(errors.New("boom")))
+	assert.False(t, xattrUnsupported(nil))
+}

--- a/mount-index.go
+++ b/mount-index.go
@@ -1,5 +1,4 @@
-//go:build !windows
-// +build !windows
+//go:build !windows && !netbsd && !openbsd && !dragonfly
 
 package desync
 

--- a/mount-sparse.go
+++ b/mount-sparse.go
@@ -1,5 +1,4 @@
-//go:build !windows
-// +build !windows
+//go:build !windows && !netbsd && !openbsd && !dragonfly
 
 package desync
 


### PR DESCRIPTION
FUSE turned out to be the only thing keeping desync off these three platforms. Everything else in the tree already builds for them through the existing platform abstractions — `ioctl_nonlinux.go`, `preallocate_other.go`, `blocksize.go` and friends absorbed all three without a single change.

## Excluding FUSE

The go-fuse bindings cover linux, darwin and freebsd only, and there's no near-term prospect of more: upstream's [Stance on BSD support](https://github.com/hanwen/go-fuse/issues/366) is closed, DragonFly's own FUSE driver [only got writes working in March 2024](https://lists.dragonflybsd.org/pipermail/commits/2024-March/923209.html), OpenBSD's [`fuse(4)`](https://man.openbsd.org/fuse.4) doesn't support partial reads and writes, and NetBSD has no FUSE device at all — it emulates one over PUFFS.

So `mount-index.go`, `mount-sparse.go` and `cmd/desync/mount-index.go` are excluded there, and the three platforms register the same stub Windows already used. That stub is no longer windows-only, and it gained a `Use` string, so `desync mount-index` now reports why it's unavailable instead of failing with "unknown command".

## Device nodes take the atomic path

All three have `mknodat(2)`, and x/sys types the device argument as `int` — exactly as on Linux. So `localfs_mknod_linux.go` becomes `localfs_mknod_mknodat.go` and they share it, rather than falling into Darwin's resolve-then-mknod fallback. FreeBSD stays separate only because it types the same argument `uint64`.

## Extended attributes are the one real gap

`pkg/xattr` builds its BSD implementation for `freebsd || netbsd` only. OpenBSD and DragonFly compile in `xattr_unsupported.go`, whose functions return `nil` and do nothing — so `tar` records no xattrs and `untar` discards them, with no error either way. That's honest on OpenBSD, whose kernel has no extended attributes at all; DragonFly has `extattr` the library just doesn't wire up. Called out in the platform table because it's silent.

File permissions needed nothing. `FilemodeToStatMode` is built from the `S_IF*`/`S_IS*` constants, whose values are identical across all of these.

## Verification

Locally, `go vet ./...` (which typechecks the test files too) passes on netbsd/{amd64,arm64,386}, openbsd/{amd64,arm64,riscv64} and dragonfly/amd64, with linux, darwin, freebsd and windows still green. `goreleaser build --snapshot` produces the five new binaries and nothing unexpected.

What that does *not* cover is runtime behaviour, which is why this adds a VM job per platform next to the existing FreeBSD one. Those jobs are the part of this PR I'd watch: the Go toolchain comes from each system's package repo, those lag, and go.mod sets a minimum — so each job echoes `go version` to make "package too old" readable straight off the log. **If a platform can't get a new enough Go, the honest fix is to drop its VM job and downgrade its README row to "Builds, untested" rather than claim support the CI doesn't back.**

## Release artifacts

netbsd and openbsd on amd64 and arm64, dragonfly on amd64 — its only Go port. goreleaser drops nonexistent combinations by itself, so the new `ignore` entries are only for targets that would otherwise build and ship (32-bit ARM and RISC-V), following the existing freebsd/arm precedent.