### PR TITLE
Stop TestFailoverMutliple failing on a loaded machine

### DIFF
--- a/failover_test.go
+++ b/failover_test.go
@@ -3,7 +3,7 @@ package desync
 import (
 	"context"
 	"crypto/rand"
-	"sync/atomic"
+	"sync"
 	"testing"
 	"time"
 
@@ -50,11 +50,23 @@ func TestFailoverSimple(t *testing.T) {
 }
 
 func TestFailoverMutliple(t *testing.T) {
-	// Create two stores, one that fails when x is 1 and the other fails when x is 0
-	var x int64
+	// Create two stores, one that fails when x is 1 and the other fails when x is 0.
+	//
+	// mu holds x still for the duration of a whole GetChunk call. The group
+	// tries each store at most once per call, so a switch landing between
+	// those two attempts leaves the call having seen both stores fail, and it
+	// returns an error - which is what the group documents it will do when
+	// every store fails, not a bug. Without this the test asks for something
+	// the implementation never promised, and fails whenever a goroutine is
+	// descheduled mid-call: rarely on an idle machine, readily on a loaded or
+	// emulated one.
+	var (
+		mu sync.RWMutex
+		x  int
+	)
 	storeA := &TestStore{
 		GetChunkFunc: func(id ChunkID) (*Chunk, error) {
-			if atomic.LoadInt64(&x) == 0 {
+			if x == 0 {
 				return nil, nil
 			}
 			return nil, errors.New("failed")
@@ -62,7 +74,7 @@ func TestFailoverMutliple(t *testing.T) {
 	}
 	storeB := &TestStore{
 		GetChunkFunc: func(id ChunkID) (*Chunk, error) {
-			if atomic.LoadInt64(&x) == 1 {
+			if x == 1 {
 				return nil, nil
 			}
 			return nil, errors.New("failed")
@@ -90,7 +102,10 @@ func TestFailoverMutliple(t *testing.T) {
 					return nil
 				default:
 					rand.Read(id[:])
-					if _, err := g.GetChunk(id); err != nil {
+					mu.RLock()
+					_, err := g.GetChunk(id)
+					mu.RUnlock()
+					if err != nil {
 						return err
 					}
 				}
@@ -105,8 +120,9 @@ func TestFailoverMutliple(t *testing.T) {
 			case <-gCtx.Done(): // done running
 				return nil
 			case <-failOver: // switch over to the other store
-				newX := (x + 1) % 2
-				atomic.StoreInt64(&x, newX)
+				mu.Lock()
+				x = (x + 1) % 2
+				mu.Unlock()
 			}
 		}
 	})


### PR DESCRIPTION
`TestFailoverMutliple` is flaky, and it isn't the implementation's fault.

The test flips which of two stores fails every 10 ms while 16 goroutines query the group, then asserts no error ever reaches the caller. But `GetChunk` tries each store at most once per call:

```go
for i := 0; i < len(g.stores); i++ {
```

So when a flip lands *between* a call's two attempts, that call sees store A fail, fails over to B, and finds B failing too — and returns an error. That's exactly what `FailoverGroup` documents:

> When all stores returned a failure, the group will pass up the failure to the caller.

The test was asking for a guarantee the implementation never made. The window is microseconds wide, so an idle machine almost never hits it; a loaded or emulated one does, because descheduling a goroutine mid-call widens the window to however long it waits.

## The fix

Hold the switch still for the duration of each call, so any one call always sees a consistent pair of stores. Everything the test is actually for survives: 16 goroutines still hammer the group concurrently, failover still happens every 10 ms, and the shared active-store state is still driven from all of them. The write lock is held only to flip a single int, and Go's `RWMutex` blocks new readers once a writer is waiting, so the flipper can't starve.

The `sync/atomic` use goes away with it — the mutex now orders those accesses. (The old code also read `x` non-atomically in the flipper while readers used `atomic.LoadInt64`, which was only safe because that goroutine was the sole writer.)

## Verification

Reproduced on master first, rather than assuming the diagnosis: 12 concurrent copies of the test binary at `GOMAXPROCS=1`, which fails within a few hundred runs with the same error and line number as the CI failure that prompted this.

| | runs | failures |
| --- | --- | --- |
| master | 300 | 1 |
| this branch | 940 | 0 |

`go test -race` is also clean, as is the full suite.

## Where this came from

It surfaced while adding NetBSD/OpenBSD/DragonFly CI in #403 — the emulated VMs make it hit often enough to notice (one failure in three OpenBSD runs). It's a pre-existing flake on every platform, not a BSD issue, so it's split out here and #403 doesn't depend on it.