### PR TITLE
Verify a device node carries the number it was created with

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ desync extract -s http://server/store -c /tmp/cache index.caibx /path/to/largefi
 | FreeBSD | Supported | Tested in CI in a VM and release binaries are published, but it sees far less real-world use than Linux. |
 | NetBSD | Supported | No `mount-index`. Extended attributes work only on filesystems that implement them, and are skipped elsewhere. Tested in CI in a VM and release binaries are published, but it sees far less real-world use than Linux. |
 | OpenBSD | Supported | No `mount-index`, and extended attributes are silently dropped by `tar` and `untar`. Otherwise as NetBSD. |
-| DragonFly | Supported | No `mount-index`. Extended attributes are silently dropped by `tar` and `untar`, and device entries don't round-trip: `mknod` reports success but the node reads back with no device number. Otherwise as NetBSD. |
+| DragonFly | Supported | No `mount-index`. Extended attributes are silently dropped by `tar` and `untar`, and `untar` refuses device entries: `mknod` reports success there but doesn't record the device number, so the node is rejected rather than written with the wrong device. Otherwise as NetBSD. |
 
 ## Design Philosophy
 

--- a/localfs_mkdev_test.go
+++ b/localfs_mkdev_test.go
@@ -68,7 +68,8 @@ func TestCreateDeviceRoundTrip(t *testing.T) {
 	// of NODEV (0xffffffff) for every pair tried here, 0:0 included, so the
 	// major/minor can't survive the trip through the kernel. TestMkdev above
 	// still passes there, which places the problem in mknod rather than in
-	// desync's encoding.
+	// desync's encoding. CreateDevice now rejects such a node outright, which
+	// TestCreateDeviceRejectsUnrecordedNumber covers.
 	if runtime.GOOS == "dragonfly" {
 		t.Skip("dragonfly does not preserve device numbers through mknod")
 	}
@@ -106,4 +107,60 @@ func TestCreateDeviceRoundTrip(t *testing.T) {
 		assert.Equal(t, tc.major, found.DevMajor, "DevMajor of %d:%d", tc.major, tc.minor)
 		assert.Equal(t, tc.minor, found.DevMinor, "DevMinor of %d:%d", tc.major, tc.minor)
 	}
+}
+
+// TestCreateDeviceRejectsUnrecordedNumber checks that a node the filesystem
+// didn't record the device number for is reported rather than left in place
+// carrying the wrong device. DragonFly is the platform where that actually
+// happens, so it is the only one that can exercise it - should its mknod
+// start recording the number, this fails and the skip above can go too.
+func TestCreateDeviceRejectsUnrecordedNumber(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("creating device nodes requires root")
+	}
+	if runtime.GOOS != "dragonfly" {
+		t.Skip("no other platform is known to accept a device number without recording it")
+	}
+
+	fs := NewLocalFS(t.TempDir(), LocalFSOptions{})
+	err := fs.CreateDevice(NodeDevice{
+		Name:  "dev",
+		Mode:  os.ModeDevice | os.ModeCharDevice | 0666,
+		Major: 1,
+		Minor: 3,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "recorded device")
+}
+
+// TestCreateDeviceVerifiesNumber checks that a node whose recorded major/minor
+// doesn't match what was asked for is reported rather than accepted. Creating
+// the node with one pair and verifying it against another stands in for a
+// filesystem that doesn't record the number it was given, which is otherwise
+// only reproducible on DragonFly.
+func TestCreateDeviceVerifiesNumber(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("creating device nodes requires root")
+	}
+	if runtime.GOOS == "dragonfly" {
+		t.Skip("dragonfly does not preserve device numbers through mknod")
+	}
+
+	dir := t.TempDir()
+	fs := NewLocalFS(dir, LocalFSOptions{})
+	require.NoError(t, fs.CreateDevice(NodeDevice{
+		Name:  "dev",
+		Mode:  os.ModeDevice | os.ModeCharDevice | 0666,
+		Major: 1,
+		Minor: 3,
+	}))
+	require.NoError(t, fs.Close())
+
+	r, err := os.OpenRoot(dir)
+	require.NoError(t, err)
+	defer r.Close()
+
+	err = verifyDeviceNode(r, NodeDevice{Name: "dev", Major: 9, Minor: 9})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "recorded device 1:3, not 9:9")
 }

--- a/localfs_other.go
+++ b/localfs_other.go
@@ -157,6 +157,36 @@ func (fs *LocalFS) SetSymlinkPermissions(n NodeSymlink) error {
 	return nil
 }
 
+// verifyDeviceNode reads back a device node just created and confirms it
+// carries the major and minor it was asked for.
+//
+// mknod can report success and still not record the device number, and whether
+// it does depends on the kernel and on the filesystem underneath rather than
+// on the operating system alone. DragonFly stores NODEV, and NetBSD did the
+// same through mknodat until desync stopped using it there. Neither is
+// distinguishable from success without reading the node back, and a device
+// node pointing at the wrong device is a worse outcome than an extraction that
+// stops and says so.
+func verifyDeviceNode(r *os.Root, n NodeDevice) error {
+	fi, err := r.Lstat(n.Name)
+	if err != nil {
+		return fmt.Errorf("mknod %s: %w", n.Name, err)
+	}
+	sys, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("mknod %s: unsupported platform", n.Name)
+	}
+	// As in Next, both accessors mask the value, so sign-extending a signed
+	// dev_t on the way in is harmless.
+	major := uint64(unix.Major(uint64(sys.Rdev)))
+	minor := uint64(unix.Minor(uint64(sys.Rdev)))
+	if major != n.Major || minor != n.Minor {
+		return fmt.Errorf("mknod %s: filesystem recorded device %d:%d, not %d:%d",
+			n.Name, major, minor, n.Major, n.Minor)
+	}
+	return nil
+}
+
 func (fs *LocalFS) CreateDevice(n NodeDevice) error {
 	r, err := fs.writeRoot()
 	if err != nil {
@@ -175,6 +205,10 @@ func (fs *LocalFS) CreateDevice(n NodeDevice) error {
 	// always confines the operation to the extraction root.
 	if err := fs.createDeviceNode(r, n); err != nil {
 		return fmt.Errorf("mknod %s: %w", n.Name, err)
+	}
+
+	if err := verifyDeviceNode(r, n); err != nil {
+		return err
 	}
 
 	if !fs.opts.NoSameOwner {


### PR DESCRIPTION
`CreateDevice` passed on whatever error `mknod` returned and never checked the result:

```go
if err := fs.createDeviceNode(r, n); err != nil {
    return fmt.Errorf("mknod %s: %w", n.Name, err)
}
// nothing verified n.Major/n.Minor actually landed
```

So a filesystem that accepts a device number without recording it produced a node pointing at the wrong device — silently, with a successful exit.

## This isn't hypothetical, and it isn't one platform

Two are known to do exactly that:

- **DragonFly** — `mknod` reports success and stores `NODEV`.
- **NetBSD** — did the same through `mknodat` until #403 switched it to `mknod`. Before that fix, `untar` there wrote `rdev`-0 nodes and reported success. That is fixed on master; it is listed here because it is the second independent instance of the same silent failure, not because it is still broken.

Neither reports anything. NetBSD was caught only because `TestCreateDeviceRoundTrip` runs as root in a VM job. A filesystem behaving the same way under Linux or macOS would go unnoticed, because that test never runs there — GitHub's hosted runners are not root, so it skips:

| platform | round-trip exercised in CI? |
| --- | --- |
| FreeBSD, OpenBSD, NetBSD, DragonFly | yes — VM jobs run as root |
| Linux, macOS | no — test skips |

Whether a device number survives depends on the kernel *and the filesystem underneath*, not on the operating system, so it isn't something a build tag can express. Overlay, network and FUSE filesystems are the obvious places this could bite on Linux.

## The change

Read the node back after creating it and compare major/minor, in the shared `CreateDevice` rather than the per-platform files. One `lstat` per device node, and device nodes are rare in archives.

On DragonFly `untar` now refuses device entries instead of writing wrong ones. That's the intended trade — an extraction that stops and says so beats a node pointing somewhere else — and the platform table says so.

## Verification

Run as root, which no GitHub-hosted runner does:

- `TestCreateDeviceRoundTrip` **passes as root on Linux**, where it is otherwise always skipped. Linux records device numbers faithfully and the check raises no false failures.
- `TestCreateDeviceVerifiesNumber` (new, portable) creates a node as 1:3 and verifies it against 9:9, standing in for a filesystem that ignores the number. It's caught with the expected message. This covers detection of a mismatch; the round-trip test alone only shows the check does not trip over a correct node.
- `TestCreateDeviceRejectsUnrecordedNumber` (new, DragonFly-only) covers the real integration case in the DragonFly VM job. Should DragonFly's `mknod` ever start recording the number, it fails, flagging that the skip can be removed.
- Full suite, `golangci-lint`, and `go vet` across linux/darwin/windows and all four BSDs.

Builds on #403, now merged — that is where both instances surfaced, and its VM jobs are what give the BSD coverage this relies on. This branch is cut from master with #403 in it, so it needs nothing else first.

