### PR TITLE
Add --no-same-xattrs to untar, and stop dropping xattrs quietly

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,11 @@ desync extract -s http://server/store -c /tmp/cache index.caibx /path/to/largefi
 | --- | --- | --- |
 | Linux | Full support | All features including FUSE, reflinks (Btrfs/XFS) |
 | macOS | Supported | Minor incompatibilities possible when exchanging catar files with Linux (filemodes) |
-| Windows | Partial | Subset of commands. No `mount-index`. Device entries unsupported in tar; `--no-same-owner` and `--no-same-permissions` ignored in `untar`. |
+| Windows | Partial | Subset of commands. No `mount-index`. Device entries unsupported in tar; `--no-same-owner`, `--no-same-permissions` and `--no-same-xattrs` ignored in `untar`, which never applies extended attributes there. |
 | FreeBSD | Supported | Tested in CI in a VM and release binaries are published, but it sees far less real-world use than Linux. |
-| NetBSD | Supported | No `mount-index`. Extended attributes work only on filesystems that implement them, and are skipped elsewhere. Tested in CI in a VM and release binaries are published, but it sees far less real-world use than Linux. |
-| OpenBSD | Supported | No `mount-index`, and extended attributes are silently dropped by `tar` and `untar`. Otherwise as NetBSD. |
-| DragonFly | Supported | No `mount-index`. Extended attributes are silently dropped by `tar` and `untar`, and `untar` refuses device entries: `mknod` reports success there but doesn't record the device number, so the node is rejected rather than written with the wrong device. Otherwise as NetBSD. |
+| NetBSD | Supported | No `mount-index`. Extended attributes work only on filesystems that implement them; `tar` skips them elsewhere and `untar` needs `--no-same-xattrs` there. Tested in CI in a VM and release binaries are published, but it sees far less real-world use than Linux. |
+| OpenBSD | Supported | No `mount-index`. Extended attributes are unavailable: `tar` records none, and `untar` refuses an archive that carries them unless `--no-same-xattrs` is given. Otherwise as NetBSD. |
+| DragonFly | Supported | No `mount-index`. Extended attributes as on OpenBSD. `untar` also refuses device entries: `mknod` reports success there but doesn't record the device number, so the node is rejected rather than written with the wrong device. Otherwise as NetBSD. |
 
 ## Design Philosophy
 

--- a/cmd/desync/untar.go
+++ b/cmd/desync/untar.go
@@ -48,6 +48,7 @@ the output can be set to GNU tar, either an archive or STDOUT with '-'.
 	flags.BoolVarP(&opt.readIndex, "index", "i", false, "read index file (caidx), not catar")
 	flags.BoolVar(&opt.NoSameOwner, "no-same-owner", false, "extract files as current user")
 	flags.BoolVar(&opt.NoSamePermissions, "no-same-permissions", false, "use current user's umask instead of what is in the archive")
+	flags.BoolVar(&opt.NoSameXattrs, "no-same-xattrs", false, "don't apply extended attributes from the archive")
 	flags.StringVar(&opt.outFormat, "output-format", "disk", "output format, 'disk' or 'gnu-tar'")
 	addStoreOptions(&opt.cmdStoreOptions, flags)
 	return cmd

--- a/docs/cli/desync_untar.md
+++ b/docs/cli/desync_untar.md
@@ -39,6 +39,7 @@ desync untar <catar|index> <target> [flags]
   -i, --index                                read index file (caidx), not catar
       --no-same-owner                        extract files as current user
       --no-same-permissions                  use current user's umask instead of what is in the archive
+      --no-same-xattrs                       don't apply extended attributes from the archive
       --output-format string                 output format, 'disk' or 'gnu-tar' (default "disk")
   -s, --store strings                        source store(s), used with -i
   -t, --trust-insecure                       trust invalid certificates

--- a/localfs.go
+++ b/localfs.go
@@ -50,6 +50,13 @@ type LocalFSOptions struct {
 	// Ignore the incoming permissions when writing files. Use the current default instead.
 	NoSamePermissions bool
 
+	// Don't apply the extended attributes from the archive when writing files.
+	// Without this, an archive carrying attributes cannot be extracted onto a
+	// filesystem that has no support for them, which is the right default: the
+	// alternative is writing files that silently lack what the archive said
+	// they should have.
+	NoSameXattrs bool
+
 	// Reads all timestamps as zero. Used in tar operations to avoid unnecessary changes.
 	NoTime bool
 }

--- a/localfs_other.go
+++ b/localfs_other.go
@@ -44,6 +44,16 @@ func (fs *LocalFS) skipXattrs(name string, xattrs Xattrs) (bool, error) {
 	return false, nil
 }
 
+// xattrWriteError names the filesystem as the reason an attribute couldn't be
+// written, since the bare errno for it reads only "operation not supported".
+// Worded to match the platform-level case in skipXattrs.
+func xattrWriteError(name string, err error) error {
+	if xattrUnsupported(err) {
+		return fmt.Errorf("%s: extended attributes are not supported by this filesystem: %w", name, err)
+	}
+	return fmt.Errorf("%s: %w", name, err)
+}
+
 // setXattrs applies extended attributes to a regular file or directory using
 // an fd opened through the root handle, so that no symlink in the path can be
 // followed.
@@ -58,7 +68,7 @@ func (fs *LocalFS) setXattrs(r *os.Root, name string, xattrs Xattrs) error {
 	defer f.Close()
 	for key, value := range xattrs {
 		if err := xattr.FSet(f, key, []byte(value)); err != nil {
-			return fmt.Errorf("%s: %w", name, err)
+			return xattrWriteError(name, err)
 		}
 	}
 	return nil
@@ -75,7 +85,7 @@ func (fs *LocalFS) setXattrsNoFollow(name string, xattrs Xattrs) error {
 	dst := filepath.Join(fs.rootReal, name)
 	for key, value := range xattrs {
 		if err := xattr.LSet(dst, key, []byte(value)); err != nil {
-			return fmt.Errorf("%s: %w", name, err)
+			return xattrWriteError(name, err)
 		}
 	}
 	return nil

--- a/localfs_other.go
+++ b/localfs_other.go
@@ -28,12 +28,28 @@ func NewLocalFS(root string, opts LocalFSOptions) *LocalFS {
 	}
 }
 
+// skipXattrs reports whether a node has any extended attributes worth applying,
+// and refuses to carry on quietly where the platform has no support for them at
+// all. pkg/xattr compiles in stubs that report success and do nothing on those
+// platforms - OpenBSD and DragonFly today - so without this check an archive's
+// attributes would be dropped without a word. Callers who don't want them can
+// say so with NoSameXattrs.
+func (fs *LocalFS) skipXattrs(name string, xattrs Xattrs) (bool, error) {
+	if len(xattrs) == 0 || fs.opts.NoSameXattrs {
+		return true, nil
+	}
+	if !xattr.XATTR_SUPPORTED {
+		return false, fmt.Errorf("%s: extended attributes are not supported on this platform", name)
+	}
+	return false, nil
+}
+
 // setXattrs applies extended attributes to a regular file or directory using
 // an fd opened through the root handle, so that no symlink in the path can be
 // followed.
-func setXattrs(r *os.Root, name string, xattrs Xattrs) error {
-	if len(xattrs) == 0 {
-		return nil
+func (fs *LocalFS) setXattrs(r *os.Root, name string, xattrs Xattrs) error {
+	if skip, err := fs.skipXattrs(name, xattrs); skip || err != nil {
+		return err
 	}
 	f, err := r.Open(name)
 	if err != nil {
@@ -53,8 +69,8 @@ func setXattrs(r *os.Root, name string, xattrs Xattrs) error {
 // root is used. All intermediate components were created by us through the
 // root handle and are therefore confined to it.
 func (fs *LocalFS) setXattrsNoFollow(name string, xattrs Xattrs) error {
-	if len(xattrs) == 0 {
-		return nil
+	if skip, err := fs.skipXattrs(name, xattrs); skip || err != nil {
+		return err
 	}
 	dst := filepath.Join(fs.rootReal, name)
 	for key, value := range xattrs {
@@ -99,7 +115,7 @@ func (fs *LocalFS) SetDirPermissions(n NodeDirectory) error {
 		if err := r.Chown(n.Name, n.UID, n.GID); err != nil {
 			return fmt.Errorf("%s: %w", n.Name, err)
 		}
-		if err := setXattrs(r, n.Name, n.Xattrs); err != nil {
+		if err := fs.setXattrs(r, n.Name, n.Xattrs); err != nil {
 			return err
 		}
 	}
@@ -122,7 +138,7 @@ func (fs *LocalFS) SetFilePermissions(n NodeFile) error {
 		if err := r.Chown(n.Name, n.UID, n.GID); err != nil {
 			return fmt.Errorf("%s: %w", n.Name, err)
 		}
-		if err := setXattrs(r, n.Name, n.Xattrs); err != nil {
+		if err := fs.setXattrs(r, n.Name, n.Xattrs); err != nil {
 			return err
 		}
 	}

--- a/localfs_xattr_test.go
+++ b/localfs_xattr_test.go
@@ -95,3 +95,20 @@ func TestCreateFileNoSameXattrs(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "content", string(b))
 }
+
+// TestXattrWriteError checks that an unsupported filesystem is named as the
+// reason and that nothing else is reworded. Which errnos mean "unsupported" is
+// xattrUnsupported's business and is covered above.
+func TestXattrWriteError(t *testing.T) {
+	setErr := func(err error) error {
+		return &xattr.Error{Op: "xattr.FSet", Path: "/mnt/f", Name: "user.test", Err: err}
+	}
+
+	err := xattrWriteError("f", setErr(unix.EOPNOTSUPP))
+	assert.Contains(t, err.Error(), "extended attributes are not supported by this filesystem")
+	assert.ErrorIs(t, err, unix.EOPNOTSUPP, "the errno stays wrapped")
+
+	err = xattrWriteError("f", setErr(unix.EACCES))
+	assert.NotContains(t, err.Error(), "not supported by this filesystem")
+	assert.ErrorIs(t, err, unix.EACCES)
+}

--- a/localfs_xattr_test.go
+++ b/localfs_xattr_test.go
@@ -4,10 +4,14 @@ package desync
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/pkg/xattr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 )
 
@@ -27,4 +31,67 @@ func TestXattrUnsupported(t *testing.T) {
 	assert.False(t, xattrUnsupported(listErr(unix.EACCES)))
 	assert.False(t, xattrUnsupported(errors.New("boom")))
 	assert.False(t, xattrUnsupported(nil))
+}
+
+// TestSkipXattrs covers the decision the two setters share: what to apply,
+// what to leave alone, and when to refuse rather than drop attributes an
+// archive is carrying. Deliberately free of any actual xattr call, since
+// whether one succeeds depends on the filesystem under the test's temp dir.
+func TestSkipXattrs(t *testing.T) {
+	var (
+		none = Xattrs{}
+		some = Xattrs{"user.test": "value"}
+	)
+
+	t.Run("nothing to apply", func(t *testing.T) {
+		fs := NewLocalFS(t.TempDir(), LocalFSOptions{})
+		skip, err := fs.skipXattrs("f", none)
+		require.NoError(t, err)
+		assert.True(t, skip)
+	})
+
+	t.Run("opted out", func(t *testing.T) {
+		fs := NewLocalFS(t.TempDir(), LocalFSOptions{NoSameXattrs: true})
+		skip, err := fs.skipXattrs("f", some)
+		require.NoError(t, err)
+		assert.True(t, skip, "NoSameXattrs must skip even when the archive carries some")
+	})
+
+	t.Run("attributes present", func(t *testing.T) {
+		fs := NewLocalFS(t.TempDir(), LocalFSOptions{})
+		skip, err := fs.skipXattrs("f", some)
+		if xattr.XATTR_SUPPORTED {
+			require.NoError(t, err)
+			assert.False(t, skip)
+		} else {
+			// OpenBSD and DragonFly, where pkg/xattr is a set of no-op stubs.
+			// Applying them would report success and write nothing.
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "not supported on this platform")
+		}
+	})
+}
+
+// TestCreateFileNoSameXattrs checks the flag end to end: a node carrying
+// attributes is written without error and without them, on every platform,
+// including those where applying them could not have worked.
+func TestCreateFileNoSameXattrs(t *testing.T) {
+	dir := t.TempDir()
+	fs := NewLocalFS(dir, LocalFSOptions{NoSameXattrs: true})
+	// Owned by the caller so the chown alongside the xattrs succeeds without
+	// root, and NoSameOwner left off because the setters are only reached when
+	// ownership is being applied.
+	require.NoError(t, fs.CreateFile(NodeFile{
+		Name:   "f",
+		Mode:   0644,
+		UID:    os.Getuid(),
+		GID:    os.Getgid(),
+		Data:   strings.NewReader("content"),
+		Xattrs: Xattrs{"user.test": "value"},
+	}))
+	require.NoError(t, fs.Close())
+
+	b, err := os.ReadFile(filepath.Join(dir, "f"))
+	require.NoError(t, err)
+	assert.Equal(t, "content", string(b))
 }


### PR DESCRIPTION
Extracting an archive carrying extended attributes did one of three things depending on where it ran:

| platform | `untar` of an archive with xattrs |
| --- | --- |
| Linux, macOS, FreeBSD | applies them |
| NetBSD, on a filesystem without extattr | fails |
| OpenBSD, DragonFly | **reports success and writes nothing** |

The third row is the problem. `pkg/xattr` compiles in stubs that `return nil` on those platforms, so files end up missing what the archive said they should have, with a zero exit code. It is the same shape as the device-number bug fixed in #405: doing something other than what the archive asked for, quietly.

## The change

Refuse rather than pretend, which collapses the three cases into one consistent behaviour, and add `--no-same-xattrs` so a caller can decline the attributes deliberately.

The flag fills a gap in the existing set — every other class of metadata could already be opted out of:

| metadata | opt-out |
| --- | --- |
| ownership | `--no-same-owner` |
| permissions | `--no-same-permissions` |
| extended attributes | `--no-same-xattrs` (new) |

`untar` only. `tar` has no owner or permission flags to match, and its `--no-time` exists to stop timestamps churning chunks between runs rather than as a metadata opt-out, so there is nothing on that side to be symmetric with.

Beyond the BSDs this covers extracting onto any filesystem without xattr support — vfat, or a restricted container build.

## Two paths to the same outcome

Failure arrives by one of two routes, and both now say the same kind of thing:

| situation | message |
| --- | --- |
| platform has no xattr support (OpenBSD, DragonFly) | `f: extended attributes are not supported on this platform` |
| platform supports them, this filesystem does not (vfat, tmpfs on NetBSD) | `f: extended attributes are not supported by this filesystem: ...` |

The second route already failed before this change — `setXattrs` has always propagated that error — but it surfaced as a bare `xattr.FSet /mnt/f user.test: operation not supported`, naming neither the attributes as the cause nor the fact that they can be skipped. It is also the case most people will meet, since it covers Linux. The errno stays wrapped, so callers can still test for it, and every other failure keeps its own wording.

Three cases still succeed, by design: an archive that carries no attributes (the common one, so ordinary archives still extract onto vfat), `--no-same-owner` (see below), and Windows.

Measured against a vfat loop image rather than reasoned about:

| invocation | before | after |
| --- | --- | --- |
| default | `xattr.FSet ...: operation not supported` | `extended attributes are not supported by this filesystem: ...` |
| `--no-same-xattrs` | n/a | succeeds |
| `--no-same-owner` | succeeds | succeeds |
| archive without xattrs | succeeds | succeeds |

## Noted, not changed

`--no-same-owner` already skips extended attributes as a side effect: all four call sites sit inside `if !fs.opts.NoSameOwner`. That looks deliberate, since both need privileges, but it does mean `--no-same-owner` has been a partial xattr opt-out all along. Changing it is a separate decision and is left alone here.

Windows never applied extended attributes, so the flag is accepted and ignored there, as `--no-same-owner` and `--no-same-permissions` already are.

## Tests

`TestSkipXattrs` covers the decision the two setters share, with no actual xattr call — whether one succeeds depends on the filesystem under the test's temp dir, which differs across the CI matrix, so asserting on real attributes would be flaky. It asserts the refusal on platforms where `xattr.XATTR_SUPPORTED` is false, which is what the OpenBSD and DragonFly VM jobs exercise.

`TestXattrWriteError` covers the rewording, including that an unrelated failure such as `EACCES` is left alone and that the errno stays wrapped.

`TestCreateFileNoSameXattrs` threads the flag through `CreateFile` end to end. The node is owned by the caller so the `chown` alongside the xattrs succeeds without root, and `NoSameOwner` is deliberately left off, since turning it on would skip the setters entirely and test nothing.

Platform table and generated CLI reference updated.

