### PR TITLE
Build release binaries static and trimmed, ship Windows as zip

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,17 @@ before:
 
 builds:
   - main: ./cmd/desync
+    # Build static binaries. Without this, cgo is enabled for whichever target
+    # matches the release runner itself (linux/amd64) and disabled for all the
+    # rest, since cross-compiling turns it off. That made the most-downloaded
+    # artifact the only one dynamically linked against the runner's glibc, so
+    # it wouldn't run on musl or on a distro older than the runner's image.
+    env:
+      - CGO_ENABLED=0
+    flags:
+      # Keep the builder's directory layout out of the binary so a release can
+      # be reproduced from the tag alone.
+      - -trimpath
     ldflags:
       - -s -w
       - -X main.version={{.Tag}}
@@ -62,6 +73,11 @@ archives:
       - README*
       - src: man/*
         dst: man
+    # zip on Windows, tar.gz everywhere else. Windows has no unpacker for a
+    # .tar.gz outside of Windows 11, and zip is what's expected there anyway.
+    format_overrides:
+      - goos: windows
+        formats: [ zip ]
 
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
Three fixes to the release artifacts.

**Static binaries.** `CGO_ENABLED` was unset, so cgo was enabled for the one target that matches the release runner, `linux/amd64`, and disabled for every other one, because cross-compiling turns it off. The published `desync_1.1.1_linux_amd64` binary is dynamically linked and needs glibc 2.34, while `linux_arm64` from the same release is static. That left the most-downloaded artifact as the only one that won't run on musl, or on a distro whose glibc predates the runner image's.

**`-trimpath`.** The v1.1.1 binaries carry 1672 references to `/home/runner/work/desync/...`. Removing them makes a release reproducible from the tag.

**Windows archives are zip**, everything else stays tar.gz. Windows has no built-in unpacker for a `.tar.gz` before Windows 11, and zip is the convention there.