### PR TITLE
Don't panic when a waiter gets a nil chunk from a failed request

### DIFF
--- a/dedupqueue.go
+++ b/dedupqueue.go
@@ -30,19 +30,7 @@ func (q *DedupQueue) GetChunk(id ChunkID) (*Chunk, error) {
 	req, isInFlight := q.getChunkQueue.loadOrStore(id)
 
 	if isInFlight { // The request is already in-flight, wait for it to come back
-		data, err := req.wait()
-		switch b := data.(type) {
-		case nil:
-			return nil, err
-		case *Chunk:
-			// The chunk in the request is shared with all waiters. Chunk
-			// materializes its plain data and ID lazily without locking,
-			// so hand every caller its own copy. The copies still share
-			// the underlying (read-only) chunk data.
-			return b.clone(), err
-		default:
-			return nil, fmt.Errorf("internal error: unexpected type %T", data)
-		}
+		return req.waitForChunk()
 	}
 
 	// This request is the first one for this chunk, execute as normal
@@ -132,6 +120,27 @@ func newRequest() *request {
 func (r *request) wait() (any, error) {
 	<-r.done
 	return r.data, r.err
+}
+
+// waitForChunk waits for a chunk request to complete and returns a copy of
+// what it published. The chunk in the request is shared with all waiters, and
+// Chunk materializes its plain data and ID lazily without locking, so hand
+// every caller its own copy. The copies still share the underlying
+// (read-only) chunk data.
+//
+// A store that fails returns a nil chunk alongside its error, and that nil is
+// published as a *Chunk held in an interface, which is not an untyped nil.
+// It has to be tested for on its own, or cloning it panics (see issue #408).
+func (r *request) waitForChunk() (*Chunk, error) {
+	data, err := r.wait()
+	b, ok := data.(*Chunk)
+	if !ok {
+		return nil, fmt.Errorf("internal error: unexpected type %T", data)
+	}
+	if b == nil {
+		return nil, err
+	}
+	return b.clone(), err
 }
 
 // Set the result data and marks this request as complete.

--- a/dedupqueue_test.go
+++ b/dedupqueue_test.go
@@ -119,3 +119,38 @@ func TestDedupQueueChunkNotShared(t *testing.T) {
 		seen[c] = struct{}{}
 	}
 }
+
+// TestDedupQueueChunkMissing covers a store that fails: the chunk it returns
+// alongside the error is nil, and every waiter piled onto that same request
+// has to receive the error rather than a chunk. Cloning the nil used to panic,
+// see issue #408.
+func TestDedupQueueChunkMissing(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		store := &TestStore{
+			GetChunkFunc: func(id ChunkID) (*Chunk, error) {
+				// The fake clock only advances once all other goroutines are
+				// blocked, so they're all registered as waiters by the time
+				// this returns
+				time.Sleep(time.Millisecond)
+				return nil, ChunkMissing{ID: id}
+			},
+		}
+		q := NewDedupQueue(store)
+
+		var (
+			wg    sync.WaitGroup
+			start = make(chan struct{})
+		)
+		for range 10 {
+			wg.Go(func() {
+				<-start
+				b, err := q.GetChunk(ChunkID{0})
+				assert.IsType(t, ChunkMissing{}, err)
+				assert.Nil(t, b)
+			})
+		}
+
+		close(start)
+		wg.Wait()
+	})
+}

--- a/writededupqueue.go
+++ b/writededupqueue.go
@@ -1,7 +1,5 @@
 package desync
 
-import "fmt"
-
 var _ WriteStore = &WriteDedupQueue{}
 
 // WriteDedupQueue wraps a writable store and provides deduplication of incoming chunk requests and store
@@ -31,19 +29,7 @@ func (q *WriteDedupQueue) GetChunk(id ChunkID) (*Chunk, error) {
 	q.storeChunkQueue.mu.Unlock()
 
 	if isInFlight {
-		data, err := req.wait()
-		switch b := data.(type) {
-		case nil:
-			return nil, err
-		case *Chunk:
-			// The chunk in the request is shared with all waiters. Chunk
-			// materializes its plain data and ID lazily without locking,
-			// so hand every caller its own copy. The copies still share
-			// the underlying (read-only) chunk data.
-			return b.clone(), err
-		default:
-			return nil, fmt.Errorf("internal error: unexpected type %T", data)
-		}
+		return req.waitForChunk()
 	}
 
 	// If the chunk is not currently being stored get the chunk as usual


### PR DESCRIPTION
Fixes #408.

A store that fails returns a nil chunk alongside its error. `DedupQueue.GetChunk` publishes that result to every caller waiting on the same in-flight request, where it arrives as a `*Chunk` held in an `any`. A typed nil in an interface is not an untyped nil, so the `case nil` arm never matched it — `case *Chunk` did, with a nil `b`, and `clone()` dereferenced it:

```
github.com/folbricht/desync.(*Chunk).clone(...)
	chunk.go:32
github.com/folbricht/desync.(*DedupQueue).GetChunk(...)
	dedupqueue.go:42
```

The first requester already guarded this a few lines below; only the waiters were missing it. `WriteDedupQueue.GetChunk` carried a second copy of the same switch, so both waiter paths now share one helper and can't drift apart again. The `case nil` arm went with it: `markDone` is only ever handed a `*Chunk`, so it was unreachable, and its presence is what made the switch look like it covered the nil case.

Two ways to reach it:

- `untar -c <cache>` on Windows, where `cmd/desync/store.go` wraps local stores in a `WriteDedupQueue`. Every cache miss on a fresh cache returns nil plus `ChunkMissing`, so any two goroutines asking for the same chunk at once can hit it.
- `chunk-server` on **any** platform, where `cmd/desync/chunkserver.go` wraps the store unconditionally. There an upstream failure took down the server process.

Present since `clone()` was introduced in #372, so v1.0.4, v1.1.0 and v1.1.1 are all affected.

The regression test panics on master and passes here. It uses `synctest` like `TestDedupQueueParallel`, so the waiters are guaranteed to have piled onto the request before it completes rather than relying on a sleep.