### PR TITLE
Report an unsupported platform instead of panicking

### DIFF
--- a/blocksize.go
+++ b/blocksize.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package desync
 

--- a/cmd/desync/tar_test.go
+++ b/cmd/desync/tar_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package main
 

--- a/ioctl_nonlinux.go
+++ b/ioctl_nonlinux.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package desync
 

--- a/localfs_other.go
+++ b/localfs_other.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package desync
 
@@ -308,7 +307,10 @@ func (fs *LocalFS) Next() (*File, error) {
 		major = uint64(unix.Major(uint64(sys.Rdev)))
 		minor = uint64(unix.Minor(uint64(sys.Rdev)))
 	default:
-		panic("unsupported platform")
+		// Unreachable on every platform this file builds for, but a returned
+		// error is what the write side does for the same assertion in
+		// verifyDeviceNode, and a walk has somewhere to report to.
+		return nil, fmt.Errorf("%s: unsupported platform", entry.path)
 	}
 
 	// Extract the Xattrs if any


### PR DESCRIPTION
Two pieces of cleanup in the same files.

`LocalFS.Next` asserts that the stat result is a `*syscall.Stat_t` and panics when it isn't. It never is anything else on the platforms this file builds for, so the arm is unreachable — but the write side makes the identical assertion in `verifyDeviceNode` and returns an error there, and `Next()` already returns `(*File, error)`, so it has somewhere to report to. A library shouldn't take the process down for a case it can describe.

The second part drops the four remaining legacy `// +build` lines, in `blocksize.go`, `ioctl_nonlinux.go`, `localfs_other.go` and `cmd/desync/tar_test.go`. `//go:build` has been the authoritative form since Go 1.17 and the module requires much newer, so the second line is only there to be forgotten when a constraint changes — which is how it drifts out of sync with the line above it.