### PR TITLE
Require a writable store to build a SwapWriteStore

### DIFF
--- a/cmd/desync/chunkserver.go
+++ b/cmd/desync/chunkserver.go
@@ -131,8 +131,8 @@ func runChunkServer(ctx context.Context, opt chunkServerOptions, args []string) 
 	// on the fly. Wrap the store into a SwapStore and start a handler for SIGHUP,
 	// reloading the store config from file.
 	if opt.storeFile != "" {
-		if _, ok := s.(desync.WriteStore); ok {
-			s = desync.NewSwapWriteStore(s)
+		if ws, ok := s.(desync.WriteStore); ok {
+			s = desync.NewSwapWriteStore(ws)
 		} else {
 			s = desync.NewSwapStore(s)
 		}

--- a/swapstore.go
+++ b/swapstore.go
@@ -31,8 +31,10 @@ func NewSwapStore(s Store) *SwapStore {
 }
 
 // NewSwapWriteStore initializes as new instance of a swap store that supports
-// writing and swapping at runtime.
-func NewSwapWriteStore(s Store) *SwapWriteStore {
+// writing and swapping at runtime. It takes a WriteStore rather than a Store so
+// that handing it one that can't be written to is a compile error instead of a
+// panic on the first write.
+func NewSwapWriteStore(s WriteStore) *SwapWriteStore {
 	return &SwapWriteStore{SwapStore{s: s}}
 }
 
@@ -81,5 +83,7 @@ func (s *SwapStore) Swap(new Store) error {
 func (s *SwapWriteStore) StoreChunk(chunk *Chunk) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	// Safe: the constructor only takes a WriteStore, and Swap won't replace a
+	// writable store with one that isn't.
 	return s.s.(WriteStore).StoreChunk(chunk)
 }


### PR DESCRIPTION
`NewSwapWriteStore` accepted a plain `Store` while `StoreChunk` asserted the wrapped store was a `WriteStore`. Handing it one that isn't compiled fine, constructed without complaint, and then died on the first write:

```
panic: interface conversion: desync.roStore is not desync.WriteStore: missing method StoreChunk
```

Taking a `WriteStore` makes that a compile error. `Swap` already refuses to replace a writable store with one that isn't, so between the two the assertion in `StoreChunk` now holds by construction, and it carries a comment saying so.

`chunk-server` already checked `s.(desync.WriteStore)` before wrapping, so this was never reachable from the command line — only through the library. It now passes the value the assertion produces instead of re-passing the interface.

**API change:** `NewSwapWriteStore(Store)` becomes `NewSwapWriteStore(WriteStore)`. Any caller it breaks is a caller that would have panicked at runtime.

There are no tests: the fix is that the bad call no longer compiles, and any test for it would have to bypass the constructor to reconstruct the state the change removes.