### PR TITLE
Point the installation instructions at the release binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,15 @@ rsync is the right tool when both ends are machines you control and the destinat
 
 ## Installation
 
-Install the latest release into `$HOME/go/bin`:
+Download an archive for your platform from the [releases page](https://github.com/folbricht/desync/releases), unpack it, and put the `desync` binary somewhere on your `PATH`. Archives are published per operating system and architecture; see [Platform Support](#platform-support) for what is covered. Each release also carries a `checksums.txt` to verify the download against.
+
+To build from the latest source instead, into `$HOME/go/bin`:
 
 ```text
 go install -v github.com/folbricht/desync/cmd/desync@latest
 ```
 
-Or build from source:
+Or from a clone, which is also what you want for working on desync:
 
 ```text
 git clone https://github.com/folbricht/desync.git


### PR DESCRIPTION
The Installation section covered `go install` and building from a clone, so the release archives were not mentioned anywhere in the docs. Someone who doesn't have a Go toolchain, which is most people installing a CLI, had no path through the README.

Leads with the releases page now, links to the Platform Support table for what is actually published, and points at `checksums.txt`. The two source builds stay, with a note on which is which.

The checksum is described rather than given as a command on purpose: `sha256sum` is not what the BSDs or macOS ship, and desync publishes binaries for both.