### PR TITLE
Determine the size of a block device off Linux

### DIFF
--- a/ioctl_nonlinux.go
+++ b/ioctl_nonlinux.go
@@ -5,6 +5,8 @@ package desync
 
 import (
 	"errors"
+	"fmt"
+	"io"
 	"os"
 )
 
@@ -23,9 +25,28 @@ func GetFileSize(fileName string) (size uint64, err error) {
 	if err != nil {
 		return 0, err
 	}
-	fm := info.Mode()
-	if isDevice(fm) {
-		// TODO we probably should do something platform specific here to get the correct size
+	if !isDevice(info.Mode()) {
+		return uint64(info.Size()), nil
 	}
-	return uint64(info.Size()), nil
+
+	// Stat reports zero for a device, so the size has to come from the device
+	// itself. Linux has an ioctl for it; everywhere else, seeking to the end
+	// is what's portable across the BSDs and macOS. It reports the same value
+	// the ioctl does where both are available.
+	f, err := os.Open(fileName)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	n, err := f.Seek(0, io.SeekEnd)
+	if err != nil {
+		return 0, fmt.Errorf("determining the size of %s: %w", fileName, err)
+	}
+	if n <= 0 {
+		// A character device that isn't a disk, /dev/zero and friends, has no
+		// size to report. Returning the zero silently would produce an index
+		// for an empty blob.
+		return 0, fmt.Errorf("unable to determine the size of device %s", fileName)
+	}
+	return uint64(n), nil
 }

--- a/ioctl_test.go
+++ b/ioctl_test.go
@@ -1,0 +1,41 @@
+//go:build !windows
+
+package desync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetFileSizeRegularFile(t *testing.T) {
+	name := filepath.Join(t.TempDir(), "blob")
+	require.NoError(t, os.WriteFile(name, make([]byte, 4096), 0644))
+
+	size, err := GetFileSize(name)
+	require.NoError(t, err)
+	assert.EqualValues(t, 4096, size)
+}
+
+func TestGetFileSizeMissingFile(t *testing.T) {
+	_, err := GetFileSize(filepath.Join(t.TempDir(), "nope"))
+	require.Error(t, err)
+}
+
+// TestGetFileSizeSizelessDevice covers a character device that isn't a disk.
+// It has no size to report and has to say so: returning the zero quietly, which
+// is what the non-Linux implementation used to do for every device, produces an
+// index for an empty blob instead of failing.
+func TestGetFileSizeSizelessDevice(t *testing.T) {
+	info, err := os.Stat("/dev/zero")
+	if err != nil {
+		t.Skip("no /dev/zero on this system")
+	}
+	require.True(t, isDevice(info.Mode()), "/dev/zero is expected to be a device")
+
+	_, err = GetFileSize("/dev/zero")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
`GetFileSize` had a `TODO` where the device case should be, so on every platform but Linux it fell through to `info.Size()`, which is zero for a device. `desync make` against a block device produced an index for an empty blob and reported no problem.

Linux reads the size with `BLKGETSIZE64`. Seeking to the end is the portable equivalent across the BSDs and macOS, and it reports the same value the ioctl does. A device with no size to report — a character device like `/dev/zero` — now returns an error rather than the zero, which is the same outcome Linux already produces there.

**Verification.** The shipped function was compiled standalone and run against a real block device, since Linux builds the ioctl file instead:

```
/dev/zram0     size=8589934592     err=<nil>
/dev/zero      size=0              err=unable to determine the size of device /dev/zero
/etc/hostname  size=3              err=<nil>
/nonexistent   size=0              err=stat /nonexistent: no such file or directory
```

8589934592 is exactly what `BLKGETSIZE64` returns for that device, against `Stat().Size()` of 0.

The tests assert behaviour both implementations share, so they cover the ioctl path on Linux and the new path on the four BSDs in CI, including that `/dev/zero` is an error on each. What no test covers is a real disk on a BSD or macOS, which needs a device the runner can open; the equivalence above and lseek being POSIX are what that rests on.