### PR TITLE
Fix TestDocumentationLinks with vendored dependencies

### DIFF
--- a/docs_test.go
+++ b/docs_test.go
@@ -53,7 +53,7 @@ func TestDocumentationLinks(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if d.IsDir() && (d.Name() == ".git" || d.Name() == "testdata") {
+		if d.IsDir() && (d.Name() == ".git" || d.Name() == "testdata" || d.Name() == "vendor") {
 			return filepath.SkipDir
 		}
 		if !d.IsDir() && filepath.Ext(path) == ".md" {


### PR DESCRIPTION
Some build systems utilize `go mod vendor` to support offline hermetic builds, and this command copies only Go packages and does not copy directories with documentation if they do not have any Go source code in them, thus breaking the test. But there is no reason to even check vendored code's documentation links, so just skip them.

Before this PR the following sequence of commands is broken:
```
go mod vendor
go test ./...
```
It failed with the next error:
```
--- FAIL: TestDocumentationLinks (0.03s)
    docs_test.go:84: 
        	Error Trace:	/Users/matshch/repos/desync/docs_test.go:84
        	Error:      	Received unexpected error:
        	            	stat vendor/cel.dev/expr/doc/intro.md: no such file or directory
        	Test:       	TestDocumentationLinks
        	Messages:   	vendor/cel.dev/expr/README.md links to doc/intro.md, which does not exist
```

By skipping the `vendor` directory in the test, we bypass this issue entirely.