### PR TITLE
Let 'config -w' create the config file it is pointed at

### DIFF
--- a/cmd/desync/config.go
+++ b/cmd/desync/config.go
@@ -245,6 +245,10 @@ func runConfig(ctx context.Context, write bool) error {
 var cfg Config
 var cfgFile string
 
+// Set when the config file given with --config doesn't exist. It's not fatal
+// right away since 'config -w' creates it, see checkConfigFile().
+var cfgFileErr error
+
 // Look for $HOME/.config/desync and if present, load into the global config
 // instance. Values defined in the file will be set accordingly, while anything
 // that's not in the file will retain its default values.
@@ -259,20 +263,31 @@ func initConfig() {
 		}
 		defaultLocation = true
 	}
-	if _, err := os.Stat(cfgFile); os.IsNotExist(err) {
-		if defaultLocation { // no problem if the default config doesn't exist
-			return
-		}
-		die(err)
-	}
+	cfgFileErr = nil
 	f, err := os.Open(cfgFile)
 	if err != nil {
-		die(err)
+		if !os.IsNotExist(err) {
+			die(err)
+		}
+		if !defaultLocation { // no problem if the default config doesn't exist
+			cfgFileErr = err
+		}
+		return
 	}
 	defer f.Close()
 	if err = json.NewDecoder(f).Decode(&cfg); err != nil {
 		die(errors.Wrap(err, "reading "+cfgFile))
 	}
+}
+
+// A config file the user asked for with --config has to be there for every
+// command that reads it. The config command is the one that writes it, so it
+// is allowed to name a file that doesn't exist yet.
+func checkConfigFile(cmd *cobra.Command) error {
+	if cmd.Name() == "config" {
+		return nil
+	}
+	return cfgFileErr
 }
 
 // Digest algorithm to be used by desync globally.

--- a/cmd/desync/config_test.go
+++ b/cmd/desync/config_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -161,4 +162,30 @@ func TestGetOCICredentialsWithoutDockerConfigPath(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, cred.Username)
 	require.Empty(t, cred.Password)
+}
+
+// A config file given with --config that doesn't exist yet is what 'config -w'
+// is meant to create, so it must not be fatal before the command runs.
+func TestConfigFileMissing(t *testing.T) {
+	oldCfgFile, oldCfg := cfgFile, cfg
+	t.Cleanup(func() { cfgFile, cfg, cfgFileErr = oldCfgFile, oldCfg, nil })
+
+	cfgFile = filepath.Join(t.TempDir(), "config.json")
+	initConfig()
+	require.Error(t, cfgFileErr)
+
+	// Only the config command gets to carry on without it
+	ctx := context.Background()
+	require.NoError(t, checkConfigFile(newConfigCommand(ctx)))
+	require.Error(t, checkConfigFile(newCatCommand(ctx)))
+
+	require.NoError(t, runConfig(ctx, true))
+	b, err := os.ReadFile(cfgFile)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(b, &Config{}))
+
+	// Now that it's there, every command is happy with it
+	initConfig()
+	require.NoError(t, cfgFileErr)
+	require.NoError(t, checkConfigFile(newCatCommand(ctx)))
 }

--- a/cmd/desync/root.go
+++ b/cmd/desync/root.go
@@ -26,6 +26,9 @@ stores can also be combined into one failover group by separating them with
 '|', for example -s "http://server1/store|http://server2/store".`,
 		// Makes cobra provide --version. The 'version' command prints more.
 		Version: currentBuild().Version,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return checkConfigFile(cmd)
+		},
 	}
 	// Registered here so cobra doesn't claim -v as its shorthand, which users
 	// would reasonably expect to mean --verbose.


### PR DESCRIPTION
A config file named with `--config` had to exist before any command ran, including the one whose job is to write it. `desync --config new.json config -w`, the example in the command's own help and in `docs/configuration.md`, failed with `no such file or directory` and wrote nothing.

The missing file is now recorded during initialization rather than being fatal there, and reported before running any command other than `config`. A config file that exists but cannot be read or parsed remains fatal, and a missing config in the default location is still ignored.