### PR TITLE
Exit non-zero when a server fails to start

### DIFF
--- a/cmd/desync/indexserver.go
+++ b/cmd/desync/indexserver.go
@@ -140,10 +140,8 @@ func serve(ctx context.Context, opt cmdServerOptions, addresses ...string) error
 		tlsConfig.ClientCAs = certPool
 	}
 
-	// Run the server(s) in a goroutine, and use the main goroutine to wait for
-	// a signal or a failing server (ctx gets cancelled in that case)
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	// Run the server(s) in goroutines and use the main goroutine to wait for
+	// either a signal or one of them giving up.
 	serverErr := make(chan error, len(addresses))
 	for _, addr := range addresses {
 		go func() {
@@ -161,18 +159,15 @@ func serve(ctx context.Context, opt cmdServerOptions, addresses ...string) error
 				err = server.ListenAndServeTLS(opt.cert, opt.key)
 			}
 			serverErr <- err
-			cancel()
 		}()
 	}
-	// wait for either INT/TERM or an issue with the server
-	<-ctx.Done()
 
 	// A server only stops on its own when it fails, so report that and let the
 	// process exit non-zero. Shutting down on a signal isn't an error.
 	select {
 	case err := <-serverErr:
 		return err
-	default:
+	case <-ctx.Done():
 		return nil
 	}
 }

--- a/cmd/desync/indexserver.go
+++ b/cmd/desync/indexserver.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -145,10 +144,11 @@ func serve(ctx context.Context, opt cmdServerOptions, addresses ...string) error
 	// a signal or a failing server (ctx gets cancelled in that case)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	serverErr := make(chan error, len(addresses))
 	for _, addr := range addresses {
-		go func(a string) {
+		go func() {
 			server := &http.Server{
-				Addr:              a,
+				Addr:              addr,
 				TLSConfig:         tlsConfig,
 				ErrorLog:          log.New(stderr, "", log.LstdFlags),
 				ReadHeaderTimeout: 30 * time.Second,
@@ -160,11 +160,19 @@ func serve(ctx context.Context, opt cmdServerOptions, addresses ...string) error
 			} else {
 				err = server.ListenAndServeTLS(opt.cert, opt.key)
 			}
-			fmt.Fprintln(stderr, err)
+			serverErr <- err
 			cancel()
-		}(addr)
+		}()
 	}
 	// wait for either INT/TERM or an issue with the server
 	<-ctx.Done()
-	return nil
+
+	// A server only stops on its own when it fails, so report that and let the
+	// process exit non-zero. Shutting down on a signal isn't an error.
+	select {
+	case err := <-serverErr:
+		return err
+	default:
+		return nil
+	}
 }

--- a/cmd/desync/indexserver_test.go
+++ b/cmd/desync/indexserver_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
@@ -159,4 +161,31 @@ func startIndexServer(t *testing.T, args ...string) (string, context.CancelFunc)
 	// Wait a little for the server to start
 	time.Sleep(time.Second)
 	return addr, cancel
+}
+
+// A server that fails to start has to report that. Without it, a service that
+// never came up looks like a clean shutdown to whatever supervises it.
+func TestServerStartFailure(t *testing.T) {
+	// Hold on to an address so the servers can't bind to it
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l.Close()
+
+	for _, test := range []struct {
+		name    string
+		command func(context.Context) *cobra.Command
+	}{
+		{"chunk-server", newChunkServerCommand},
+		{"index-server", newIndexServerCommand},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			http.DefaultServeMux = &http.ServeMux{}
+			cmd := test.command(context.Background())
+			cmd.SetArgs([]string{"-s", t.TempDir(), "-l", l.Addr().String()})
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+			_, err := cmd.ExecuteC()
+			require.ErrorContains(t, err, l.Addr().String())
+		})
+	}
 }


### PR DESCRIPTION
The chunk and index servers printed the error from `ListenAndServe` to stderr and then returned nil, so a server that never came up exited with status 0. `desync chunk-server -s store -l 127.0.0.1:1` reported `bind: permission denied` and exited 0, which supervisors and CI read as a clean shutdown.

The error is now handed back to the caller so cobra reports it and the process exits 1. Shutting down because the context was cancelled, which is what a signal does, still returns nil.