### PR TITLE
Reject a --concurrency below 1

### DIFF
--- a/cmd/desync/options.go
+++ b/cmd/desync/options.go
@@ -57,6 +57,11 @@ func (o cmdStoreOptions) validate() error {
 	if (o.clientKey == "") != (o.clientCert == "") {
 		return errors.New("--client-key and --client-cert options need to be provided together")
 	}
+	if o.n < 1 {
+		// Without workers, nothing reads from the queues the commands feed
+		// chunks into, and they'd block forever.
+		return errors.New("--concurrency needs to be at least 1")
+	}
 	return nil
 }
 

--- a/cmd/desync/options_test.go
+++ b/cmd/desync/options_test.go
@@ -99,6 +99,30 @@ func TestErrorRetryOptions(t *testing.T) {
 	}
 }
 
+func TestStoreOptionsValidate(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		opt     cmdStoreOptions
+		wantErr string
+	}{
+		{"defaults", cmdStoreOptions{n: 10}, ""},
+		{"TLS client auth", cmdStoreOptions{n: 10, clientCert: "c", clientKey: "k"}, ""},
+		{"key without cert", cmdStoreOptions{n: 10, clientKey: "k"}, "--client-key and --client-cert"},
+		{"cert without key", cmdStoreOptions{n: 10, clientCert: "c"}, "--client-key and --client-cert"},
+		{"zero concurrency", cmdStoreOptions{n: 0}, "--concurrency"},
+		{"negative concurrency", cmdStoreOptions{n: -1}, "--concurrency"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.opt.validate()
+			if test.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
 func TestServerOptionsValidate(t *testing.T) {
 	for _, test := range []struct {
 		name    string

--- a/cmd/desync/verify.go
+++ b/cmd/desync/verify.go
@@ -39,6 +39,9 @@ invalid chunks are deleted from the store.`,
 }
 
 func runVerify(ctx context.Context, opt verifyOptions, args []string) error {
+	if err := opt.cmdStoreOptions.validate(); err != nil {
+		return err
+	}
 	if opt.store == "" {
 		return errors.New("no store provided")
 	}

--- a/cmd/desync/verify_test.go
+++ b/cmd/desync/verify_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -50,4 +51,15 @@ func TestVerifyCommand(t *testing.T) {
 	// Confirm sure the bad chunk file is gone from the store
 	_, err = os.Stat(invalidChunkFile)
 	require.True(t, os.IsNotExist(err))
+}
+
+// Without workers there's nothing to read the chunks the store feeds them, so
+// the command has to refuse rather than block forever.
+func TestVerifyCommandConcurrency(t *testing.T) {
+	cmd := newVerifyCommand(context.Background())
+	cmd.SetArgs([]string{"-s", t.TempDir(), "-n", "0"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	_, err := cmd.ExecuteC()
+	require.ErrorContains(t, err, "--concurrency")
 }


### PR DESCRIPTION
Commands start one worker per `--concurrency` and then feed chunks into an unbuffered channel. With `-n 0` or a negative value there are no workers to read from it, so the command blocks forever. Because the main goroutine never reaches its context check, the process cannot be interrupted with SIGINT or SIGTERM either and has to be killed. `desync info -n 0`, `desync cache -n 0` and `desync extract -n 0` all behave that way.

The value is now rejected up front in the store options validation, which every command using the shared `-n` flag already calls. `verify`, which defines its own `--concurrency` flag and did not validate its store options at all, now does.