### PR TITLE
Don't fail 'cat' when --length runs past the end of the blob

### DIFF
--- a/cmd/desync/cat.go
+++ b/cmd/desync/cat.go
@@ -98,7 +98,11 @@ func runCat(ctx context.Context, opt catOptions, args []string) error {
 	}
 
 	if opt.length > 0 {
-		_, err = io.CopyN(outFile, readSeeker, int64(opt.length))
+		// Fewer bytes left in the blob than were asked for is the end of the
+		// data, not a failure. Everything available has been written by then.
+		if _, err = io.CopyN(outFile, readSeeker, int64(opt.length)); errors.Is(err, io.EOF) {
+			err = nil
+		}
 	} else {
 		_, err = io.Copy(outFile, readSeeker)
 	}

--- a/cmd/desync/cat_test.go
+++ b/cmd/desync/cat_test.go
@@ -26,6 +26,10 @@ func TestCatCommand(t *testing.T) {
 			[]string{"--store", "testdata/blob1.store", "-o", "1024", "testdata/blob1.caibx"}, 1024, 0},
 		{"cat with offset and length",
 			[]string{"--store", "testdata/blob1.store", "-o", "1024", "-l", "2048", "testdata/blob1.caibx"}, 1024, 2048},
+		// Asking for more than is left just gets what's there, the same way
+		// cat(1) doesn't fail at the end of a file.
+		{"cat with length past the end of the blob",
+			[]string{"--store", "testdata/blob1.store", "-o", "2097000", "-l", "4096", "testdata/blob1.caibx"}, 2097000, 4096},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			cmd := newCatCommand(context.Background())
@@ -43,7 +47,7 @@ func TestCatCommand(t *testing.T) {
 			start := test.offset
 			end := len(f)
 			if test.length > 0 {
-				end = start + test.length
+				end = min(start+test.length, len(f))
 			}
 			require.Equal(t, f[start:end], b.Bytes())
 		})


### PR DESCRIPTION
`io.CopyN` returns `io.EOF` when the source has fewer bytes left than were asked for, and that was handed straight back to the caller. `desync cat -o 2097000 -l 4096 blob.caibx` on a 2097152-byte blob wrote the 152 bytes that were there and then exited 1 with `Error: EOF`. Reaching the end of the data is not a failure, and a reader that stops there is what `cat` is expected to do.

An offset that lands past the end of the blob still fails, with the clearer message the seek already produces.