### PR TITLE
Take the default when the prune prompt gets an empty line

### DIFF
--- a/cmd/desync/main.go
+++ b/cmd/desync/main.go
@@ -17,6 +17,7 @@ import (
 var (
 	stdout io.Writer = os.Stdout
 	stderr io.Writer = os.Stderr
+	stdin  io.Reader = os.Stdin
 )
 
 var sighup = make(chan os.Signal, 1)

--- a/cmd/desync/prune.go
+++ b/cmd/desync/prune.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
-	"os"
+	"io"
+	"slices"
+	"strings"
 
 	"github.com/folbricht/desync"
 	"github.com/spf13/cobra"
@@ -48,6 +51,12 @@ func runPrune(ctx context.Context, opt pruneOptions, args []string) error {
 	if opt.store == "" {
 		return errors.New("no store provided")
 	}
+	// The confirmation prompt below reads STDIN, which an index read from
+	// there has already consumed. Say so rather than ask a question that
+	// can't be answered.
+	if !opt.yes && slices.Contains(args, "-") {
+		return errors.New("--yes is required when reading an index from STDIN")
+	}
 
 	// Open the target store
 	sr, err := storeFromLocation(opt.store, opt.cmdStoreOptions)
@@ -82,18 +91,24 @@ func runPrune(ctx context.Context, opt pruneOptions, args []string) error {
 
 	// If the -y option wasn't provided, ask the user to confirm before doing anything
 	if !opt.yes {
-		fmt.Printf("Warning: The provided index files reference %d unique chunks. Are you sure\nyou want to delete all other chunks from '%s'?\n", len(ids), s)
+		fmt.Fprintf(stdout, "Warning: The provided index files reference %d unique chunks. Are you sure\nyou want to delete all other chunks from '%s'?\n", len(ids), s)
+		in := bufio.NewReader(stdin)
 	ask:
 		for {
-			var a string
-			fmt.Printf("[y/N]: ")
-			if _, err := fmt.Fscanln(os.Stdin, &a); err != nil {
+			fmt.Fprint(stdout, "[y/N]: ")
+			// Read the whole line rather than a word, so that just hitting
+			// enter is the "no" the prompt offers as the default.
+			a, err := in.ReadString('\n')
+			if err != nil && !errors.Is(err, io.EOF) {
 				return err
 			}
-			switch a {
+			switch strings.TrimSpace(a) {
 			case "y", "Y":
 				break ask
 			case "n", "N", "":
+				return nil
+			}
+			if errors.Is(err, io.EOF) { // nothing left to answer with
 				return nil
 			}
 		}

--- a/cmd/desync/prune_test.go
+++ b/cmd/desync/prune_test.go
@@ -2,6 +2,10 @@ package main
 
 import (
 	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -22,4 +26,84 @@ func TestPruneCommand(t *testing.T) {
 	pruneCmd.SetArgs([]string{"-s", store, "testdata/blob2.caibx", "--yes"})
 	_, err = pruneCmd.ExecuteC()
 	require.NoError(t, err)
+}
+
+// The prompt offers "N" as the default, so an empty line has to decline
+// rather than fail, and only an explicit yes may delete anything.
+func TestPruneCommandConfirmation(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		answer string
+		pruned bool
+	}{
+		{name: "enter takes the default", answer: "\n"},
+		{name: "no", answer: "n\n"},
+		{name: "upper case no", answer: "N\n"},
+		{name: "closed input", answer: ""},
+		{name: "unanswerable, then closed input", answer: "maybe"},
+		{name: "yes", answer: "y\n", pruned: true},
+		{name: "yes after an unusable answer", answer: "maybe\ny\n", pruned: true},
+		{name: "yes with surrounding space", answer: "  Y  \n", pruned: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			store := chopBlob1Into(t)
+			before := countChunks(t, store)
+
+			oldStdin, oldStdout := stdin, stdout
+			t.Cleanup(func() { stdin, stdout = oldStdin, oldStdout })
+			stdin = strings.NewReader(test.answer)
+			stdout = io.Discard
+
+			// blob2 references different chunks, so a prune that goes ahead
+			// empties the store built from blob1.
+			cmd := newPruneCommand(context.Background())
+			cmd.SetArgs([]string{"-s", store, "testdata/blob2.caibx"})
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+			_, err := cmd.ExecuteC()
+			require.NoError(t, err)
+
+			if test.pruned {
+				require.Less(t, countChunks(t, store), before)
+			} else {
+				require.Equal(t, before, countChunks(t, store))
+			}
+		})
+	}
+}
+
+// An index read from STDIN leaves nothing for the prompt to read, so the
+// command has to say so instead of asking.
+func TestPruneCommandIndexFromStdin(t *testing.T) {
+	cmd := newPruneCommand(context.Background())
+	cmd.SetArgs([]string{"-s", t.TempDir(), "-"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	_, err := cmd.ExecuteC()
+	require.ErrorContains(t, err, "--yes")
+}
+
+func chopBlob1Into(t *testing.T) string {
+	t.Helper()
+	store := t.TempDir()
+	cmd := newChopCommand(context.Background())
+	cmd.SetArgs([]string{"-s", store, "testdata/blob1.caibx", "testdata/blob1"})
+	_, err := cmd.ExecuteC()
+	require.NoError(t, err)
+	return store
+}
+
+func countChunks(t *testing.T, store string) int {
+	t.Helper()
+	var n int
+	require.NoError(t, filepath.WalkDir(store, func(_ string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && strings.HasSuffix(d.Name(), ".cacnk") {
+			n++
+		}
+		return nil
+	}))
+	return n
 }


### PR DESCRIPTION
`fmt.Fscanln` reports an empty line as `unexpected newline`, so pressing enter at the `[y/N]:` prompt exited 1 with that message, and the `case "n", "N", "":` branch meant to handle it was unreachable. The prompt now reads a whole line, so the default it offers is the one it takes, surrounding whitespace is ignored, and input that is closed without an answer declines rather than failing.

An index read from STDIN consumes the very input the prompt needs, leaving it to answer EOF. `desync prune -s store -` without `--yes` now says so up front rather than failing partway through.

The prompt writes to the package's `stdout` writer and reads from a new `stdin` one, which is what lets the tests answer it. The confirmation is covered for both the answers that decline and the ones that go ahead, checking the store contents either way.