### PR TITLE
Let the config file set the concurrency for a store

### DIFF
--- a/cmd/desync/options.go
+++ b/cmd/desync/options.go
@@ -26,7 +26,13 @@ type cmdStoreOptions struct {
 // MergedWith takes store options as read from the config, and applies command-line
 // provided options on top of them and returns the merged result.
 func (o cmdStoreOptions) MergedWith(opt desync.StoreOptions) desync.StoreOptions {
-	opt.N = o.n
+	// Unlike the options below, the flag carries a default rather than a zero
+	// value, so it can't just win when it wasn't given. Take the concurrency
+	// from the config unless the flag was set, or the config didn't name a
+	// usable one.
+	if opt.N < 1 || o.FlagSet.Lookup("concurrency").Changed {
+		opt.N = o.n
+	}
 
 	if o.FlagSet.Lookup("client-cert").Changed {
 		opt.ClientCert = o.clientCert

--- a/cmd/desync/options_test.go
+++ b/cmd/desync/options_test.go
@@ -123,6 +123,66 @@ func TestStoreOptionsValidate(t *testing.T) {
 	}
 }
 
+// The concurrency flag carries a default rather than a zero value, so the
+// merge has to tell "not given" from "given as 10" to let a config file set it.
+func TestConcurrencyOption(t *testing.T) {
+	const defaultConcurrency = 10
+	for _, test := range []struct {
+		name           string
+		args           []string
+		cfgFileContent []byte
+		storeHit       int
+		storeMiss      int
+	}{
+		{"config sets the concurrency",
+			[]string{""},
+			[]byte(`{"store-options": {"/store/*/":{"n": 50}}}`),
+			50, defaultConcurrency,
+		},
+		{"the flag overrides the config",
+			[]string{"--concurrency", "20"},
+			[]byte(`{"store-options": {"/store/*/":{"n": 50}}}`),
+			20, 20,
+		},
+		{"the flag set to the default still overrides",
+			[]string{"--concurrency", "10"},
+			[]byte(`{"store-options": {"/store/*/":{"n": 50}}}`),
+			defaultConcurrency, defaultConcurrency,
+		},
+		{"config without a concurrency",
+			[]string{""},
+			[]byte(`{"store-options": {"/store/*/":{"uncompressed": true}}}`),
+			defaultConcurrency, defaultConcurrency,
+		},
+		{"a config concurrency no store could use is ignored",
+			[]string{""},
+			[]byte(`{"store-options": {"/store/*/":{"n": 0}}}`),
+			defaultConcurrency, defaultConcurrency,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := filepath.Join(t.TempDir(), "desync-options")
+			require.NoError(t, os.WriteFile(f, test.cfgFileContent, 0644))
+			cfgFile = f
+			initConfig()
+
+			var cmdOpt cmdStoreOptions
+			cmd := newTestOptionsCommand(&cmdOpt)
+			cmd.SetArgs(test.args)
+			_, err := cmd.ExecuteC()
+			require.NoError(t, err)
+
+			configOptions, err := cfg.GetStoreOptionsFor("/store/20230901")
+			require.NoError(t, err)
+			require.Equal(t, test.storeHit, cmdOpt.MergedWith(configOptions).N)
+
+			configOptions, err = cfg.GetStoreOptionsFor("/missingStore")
+			require.NoError(t, err)
+			require.Equal(t, test.storeMiss, cmdOpt.MergedWith(configOptions).N)
+		})
+	}
+}
+
 func TestServerOptionsValidate(t *testing.T) {
 	for _, test := range []struct {
 		name    string

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,7 @@ This can be combined with store failover by providing the same syntax as used in
   | Option | Description | Default |
   | --- | --- | --- |
   | `timeout` | Time limit for chunk read/write in nanoseconds. Negative = infinite. Applies to HTTP(S), S3 and OCI stores. | 1 minute |
+  | `n` | Number of concurrent requests made to this store. The `--concurrency` option takes precedence when it is given. | 10 |
   | `error-retry` | Number of times to retry failed chunk requests. | 0 |
   | `error-retry-base-interval` | Nanoseconds to wait before first retry. Attempt N waits N times this interval. | 0 |
   | `client-cert` | Certificate file for mutual SSL. | — |


### PR DESCRIPTION
`MergedWith` assigned the concurrency from the command line unconditionally, unlike every other option, which is only taken when its flag was given. A `"n"` in `store-options` was therefore always overwritten with the flag default of 10 and never had any effect, despite being a documented field of `StoreOptions`.

The flag carries a default rather than a zero value, so "not given" cannot be told from "given as 10" by the value alone. It now uses the same `Changed` check as the other options, falling back to the flag when the config names no concurrency, or one no store could use — `remotessh` and `sftp` size a channel by it, so a zero or negative value there would be worse than ignoring it.

The option is now listed in the store-options table in `docs/configuration.md`.