### PR TITLE
Report close failures when writing a tar archive

### DIFF
--- a/cmd/desync/untar.go
+++ b/cmd/desync/untar.go
@@ -72,11 +72,7 @@ func runUntar(ctx context.Context, opt untarOptions, args []string) (err error) 
 		lfs := desync.NewLocalFS(target, opt.LocalFSOptions)
 		// Closing applies any directory metadata that is still outstanding,
 		// which is the case when the extraction failed part-way through.
-		defer func() {
-			if cerr := lfs.Close(); cerr != nil && err == nil {
-				err = cerr
-			}
-		}()
+		defer closeInto(lfs, &err)
 		fs = lfs
 	case "gnu-tar": // GNU tar, either file or STDOUT
 		var w *os.File
@@ -87,10 +83,14 @@ func runUntar(ctx context.Context, opt untarOptions, args []string) (err error) 
 			if err != nil {
 				return err
 			}
-			defer w.Close()
+			defer closeInto(w, &err)
 		}
 		gtar := desync.NewTarWriter(w)
-		defer gtar.Close()
+		// Closing is what writes the padding and the end-of-archive blocks,
+		// so a failure here leaves a truncated archive behind. It has to
+		// happen before the file below it is closed, which the defer order
+		// takes care of.
+		defer closeInto(gtar, &err)
 		fs = gtar
 	default:
 		return fmt.Errorf("invalid output format '%s'", opt.outFormat)
@@ -128,4 +128,14 @@ func runUntar(ctx context.Context, opt untarOptions, args []string) (err error) 
 	}
 
 	return desync.UnTarIndex(ctx, fs, index, s, opt.n, desync.NewProgressBar("Unpacking "))
+}
+
+// closeInto closes c, reporting a failure through err unless something has
+// already gone wrong. Closing is where buffered output is flushed and, for an
+// archive, where the trailer is written, so a dropped error there is a
+// truncated result reported as a success.
+func closeInto(c io.Closer, err *error) {
+	if cerr := c.Close(); cerr != nil && *err == nil {
+		*err = cerr
+	}
 }

--- a/cmd/desync/untar_test.go
+++ b/cmd/desync/untar_test.go
@@ -3,15 +3,10 @@
 package main
 
 import (
-	"archive/tar"
-	"bytes"
 	"context"
-	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -68,62 +63,3 @@ func TestUntarCommandRepair(t *testing.T) {
 	_, err = cmd.ExecuteC()
 	require.NoError(t, err)
 }
-
-// The end-of-archive blocks are written when the tar writer is closed, so an
-// archive that is missing them was reported as complete without ever being so.
-func TestUntarCommandGnuTar(t *testing.T) {
-	out := filepath.Join(t.TempDir(), "tree.tar")
-
-	cmd := newUntarCommand(context.Background())
-	cmd.SetArgs([]string{"--output-format", "gnu-tar", "testdata/tree.catar", out})
-	_, err := cmd.ExecuteC()
-	require.NoError(t, err)
-
-	b, err := os.ReadFile(out)
-	require.NoError(t, err)
-
-	// The archive has to be readable...
-	r := tar.NewReader(bytes.NewReader(b))
-	var names []string
-	for {
-		hdr, err := r.Next()
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		require.NoError(t, err)
-		names = append(names, hdr.Name)
-	}
-	require.NotEmpty(t, names)
-
-	// ...and end with the two zero-filled blocks that mark the end of one.
-	// Readers treat those as optional, so nothing above notices them missing.
-	require.Greater(t, len(b), 1024)
-	require.Equal(t, make([]byte, 1024), b[len(b)-1024:])
-}
-
-func TestCloseInto(t *testing.T) {
-	closeErr := errors.New("close failed")
-	earlier := errors.New("something earlier")
-
-	for _, test := range []struct {
-		name  string
-		close error
-		err   error
-		want  error
-	}{
-		{"a clean close changes nothing", nil, nil, nil},
-		{"a failed close is reported", closeErr, nil, closeErr},
-		{"an earlier failure is kept", closeErr, earlier, earlier},
-		{"a clean close keeps an earlier failure", nil, earlier, earlier},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			err := test.err
-			closeInto(closerFunc(func() error { return test.close }), &err)
-			require.Equal(t, test.want, err)
-		})
-	}
-}
-
-type closerFunc func() error
-
-func (f closerFunc) Close() error { return f() }

--- a/cmd/desync/untar_test.go
+++ b/cmd/desync/untar_test.go
@@ -3,10 +3,15 @@
 package main
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -63,3 +68,62 @@ func TestUntarCommandRepair(t *testing.T) {
 	_, err = cmd.ExecuteC()
 	require.NoError(t, err)
 }
+
+// The end-of-archive blocks are written when the tar writer is closed, so an
+// archive that is missing them was reported as complete without ever being so.
+func TestUntarCommandGnuTar(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "tree.tar")
+
+	cmd := newUntarCommand(context.Background())
+	cmd.SetArgs([]string{"--output-format", "gnu-tar", "testdata/tree.catar", out})
+	_, err := cmd.ExecuteC()
+	require.NoError(t, err)
+
+	b, err := os.ReadFile(out)
+	require.NoError(t, err)
+
+	// The archive has to be readable...
+	r := tar.NewReader(bytes.NewReader(b))
+	var names []string
+	for {
+		hdr, err := r.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		names = append(names, hdr.Name)
+	}
+	require.NotEmpty(t, names)
+
+	// ...and end with the two zero-filled blocks that mark the end of one.
+	// Readers treat those as optional, so nothing above notices them missing.
+	require.Greater(t, len(b), 1024)
+	require.Equal(t, make([]byte, 1024), b[len(b)-1024:])
+}
+
+func TestCloseInto(t *testing.T) {
+	closeErr := errors.New("close failed")
+	earlier := errors.New("something earlier")
+
+	for _, test := range []struct {
+		name  string
+		close error
+		err   error
+		want  error
+	}{
+		{"a clean close changes nothing", nil, nil, nil},
+		{"a failed close is reported", closeErr, nil, closeErr},
+		{"an earlier failure is kept", closeErr, earlier, earlier},
+		{"a clean close keeps an earlier failure", nil, earlier, earlier},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.err
+			closeInto(closerFunc(func() error { return test.close }), &err)
+			require.Equal(t, test.want, err)
+		})
+	}
+}
+
+type closerFunc func() error
+
+func (f closerFunc) Close() error { return f() }


### PR DESCRIPTION
The gnu-tar output path closed both the tar writer and the file it wrote to with the error discarded. Closing the tar writer is what writes the padding and the two end-of-archive blocks, so a failure there — a full disk, a broken pipe — left a truncated archive behind and still exited 0.

Nothing downstream reports it either: both `archive/tar` and GNU tar read an archive with no end-of-archive marker without complaint. On the test archive the difference is 8704 bytes against 7680, and neither reader minds.

Both closes now go into the returned error, the way the disk output path already handled its own. `closeInto` replaces the three copies of that pattern this would otherwise need, and is covered directly; the command test checks that the archive it writes ends with the marker, since parsing it is not enough to notice.