### PR TITLE
Pass the tar error over a channel in 'mtree'

### DIFF
--- a/cmd/desync/mtree.go
+++ b/cmd/desync/mtree.go
@@ -55,7 +55,7 @@ func runMtree(ctx context.Context, opt mtreeOptions, args []string) error {
 	}
 
 	input := args[0]
-	mtreeFS, err := desync.NewMtreeFS(os.Stdout)
+	mtreeFS, err := desync.NewMtreeFS(stdout)
 	if err != nil {
 		return err
 	}
@@ -76,15 +76,20 @@ func runMtree(ctx context.Context, opt mtreeOptions, args []string) error {
 		inFS := desync.NewLocalFS(input, desync.LocalFSOptions{})
 
 		// Run the tar bit in a goroutine, writing to the pipe
-		var tarErr error
+		tarErr := make(chan error, 1)
 		go func() {
-			tarErr = desync.Tar(ctx, w, inFS)
-			w.CloseWithError(tarErr)
+			err := desync.Tar(ctx, w, inFS)
+			w.CloseWithError(err)
+			tarErr <- err
 		}()
 		untarErr := desync.UnTar(ctx, r, mtreeFS)
 
-		if tarErr != nil {
-			return tarErr
+		// UnTar can give up before the stream ends, leaving Tar blocked on a
+		// pipe nobody reads. Closing the read end lets it finish, so its
+		// error can be collected rather than raced on.
+		r.CloseWithError(untarErr)
+		if err := <-tarErr; err != nil {
+			return err
 		}
 		return untarErr
 	}

--- a/cmd/desync/mtree_test.go
+++ b/cmd/desync/mtree_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMtreeCommand(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		args []string
+	}{
+		{"local directory", []string{"testdata"}},
+		{"catar archive", []string{"testdata/tree.catar"}},
+		{"index", []string{"-s", "testdata/tree.store", "-i", "testdata/tree.caidx"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			b := new(bytes.Buffer)
+			oldStdout := stdout
+			t.Cleanup(func() { stdout = oldStdout })
+			stdout = b
+
+			cmd := newMtreeCommand(context.Background())
+			cmd.SetArgs(test.args)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+			_, err := cmd.ExecuteC()
+			require.NoError(t, err)
+
+			require.True(t, strings.HasPrefix(b.String(), "#mtree v1.0\n"))
+			require.Greater(t, strings.Count(b.String(), "\n"), 1, "no entries were written")
+		})
+	}
+}
+
+// Walking a directory runs the tar half in a goroutine. When the untar half
+// stops first, as a cancelled context makes it, the two must not both touch
+// the error it reports.
+func TestMtreeCommandCancelled(t *testing.T) {
+	oldStdout := stdout
+	t.Cleanup(func() { stdout = oldStdout })
+	stdout = io.Discard
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cmd := newMtreeCommand(ctx)
+	cmd.SetArgs([]string{"testdata"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	_, err := cmd.ExecuteC()
+	require.Error(t, err)
+}


### PR DESCRIPTION
Walking a directory runs `Tar` in a goroutine writing into a pipe while `UnTar` reads it. `UnTar` can stop before the stream ends — a cancelled context being one way — and the main goroutine then read `tarErr` while the `Tar` goroutine was still assigning it. The equivalent in `tar.go` is safe only because `ChunkStream` cannot return nil before the pipe writer closes.

The error now goes over a channel, and the read end of the pipe is closed first so `Tar` is not left blocked writing into a pipe nobody reads, which is what makes waiting for it safe.

`mtree` had no tests, so this adds them for all three input kinds. The cancelled-context case reproduces the race: `go test -race` reports `DATA RACE` on it before the change and passes twenty consecutive runs after. CI already runs the race detector over the package.

The command writes to the package's `stdout` writer rather than `os.Stdout` directly, which is what lets the output be checked at all.