### PR TITLE
Accept an index from anywhere in 'mtree'

### DIFF
--- a/cmd/desync/mtree.go
+++ b/cmd/desync/mtree.go
@@ -55,9 +55,15 @@ func runMtree(ctx context.Context, opt mtreeOptions, args []string) error {
 	}
 
 	input := args[0]
-	mtreeFS, err := desync.NewMtreeFS(stdout)
-	if err != nil {
-		return err
+
+	// An index doesn't have to be a local file, it can be read from STDIN or
+	// a store, so it isn't looked for on the filesystem. A catar or a
+	// directory always is one.
+	if opt.readIndex {
+		if stat, err := os.Stat(input); err == nil && stat.IsDir() {
+			return errors.New("-i can't be used with input directory")
+		}
+		return mtreeIndex(ctx, opt, input)
 	}
 
 	stat, err := os.Stat(input)
@@ -65,8 +71,11 @@ func runMtree(ctx context.Context, opt mtreeOptions, args []string) error {
 		return err
 	}
 
-	if opt.readIndex && stat.IsDir() {
-		return errors.New("-i can't be used with input directory")
+	// Nothing is written until the input is known to be readable, so a
+	// failure doesn't leave a header on its own behind.
+	mtreeFS, err := desync.NewMtreeFS(stdout)
+	if err != nil {
+		return err
 	}
 
 	// Input is a directory, not an archive. So Tar it into an Untar stream
@@ -94,25 +103,28 @@ func runMtree(ctx context.Context, opt mtreeOptions, args []string) error {
 		return untarErr
 	}
 
-	// If we got a catar file unpack that and exit
-	if !opt.readIndex {
-		f, err := os.Open(input)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-		var r io.Reader = f
-		return desync.UnTar(ctx, r, mtreeFS)
+	// What's left is a catar file, unpack that
+	f, err := os.Open(input)
+	if err != nil {
+		return err
 	}
+	defer f.Close()
+	return desync.UnTar(ctx, f, mtreeFS)
+}
 
+func mtreeIndex(ctx context.Context, opt mtreeOptions, input string) error {
 	s, err := MultiStoreWithCache(opt.cmdStoreOptions, opt.cache, opt.stores...)
 	if err != nil {
 		return err
 	}
 	defer s.Close()
 
-	// The input must be an index, read it whole
+	// Read the index whole before writing anything
 	index, err := readCaibxFile(input, opt.cmdStoreOptions)
+	if err != nil {
+		return err
+	}
+	mtreeFS, err := desync.NewMtreeFS(stdout)
 	if err != nil {
 		return err
 	}

--- a/cmd/desync/mtree_test.go
+++ b/cmd/desync/mtree_test.go
@@ -94,7 +94,7 @@ func TestMtreeCommandIndexLocations(t *testing.T) {
 			f, err := os.Open("testdata/tree.caidx")
 			require.NoError(t, err)
 			oldStdin := os.Stdin
-			t.Cleanup(func() { os.Stdin = oldStdin; f.Close() })
+			t.Cleanup(func() { os.Stdin = oldStdin; _ = f.Close() })
 			os.Stdin = f
 		}, "-")
 	})

--- a/cmd/desync/mtree_test.go
+++ b/cmd/desync/mtree_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -55,4 +57,62 @@ func TestMtreeCommandCancelled(t *testing.T) {
 	cmd.SetErr(io.Discard)
 	_, err := cmd.ExecuteC()
 	require.Error(t, err)
+}
+
+// An index is a location like any other, so it can come from a store or from
+// STDIN, the way every other command that reads one accepts them.
+func TestMtreeCommandIndexLocations(t *testing.T) {
+	addr, cancel := startIndexServer(t, "-s", "testdata")
+	defer cancel()
+
+	run := func(t *testing.T, setup func(t *testing.T), input string) {
+		t.Helper()
+		b := new(bytes.Buffer)
+		oldStdout := stdout
+		t.Cleanup(func() { stdout = oldStdout })
+		stdout = b
+		if setup != nil {
+			setup(t)
+		}
+
+		cmd := newMtreeCommand(context.Background())
+		cmd.SetArgs([]string{"-s", "testdata/tree.store", "-i", input})
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+		_, err := cmd.ExecuteC()
+		require.NoError(t, err)
+		require.True(t, strings.HasPrefix(b.String(), "#mtree v1.0\n"))
+		require.Greater(t, strings.Count(b.String(), "\n"), 1, "no entries were written")
+	}
+
+	t.Run("from an index server", func(t *testing.T) {
+		run(t, nil, fmt.Sprintf("http://%s/tree.caidx", addr))
+	})
+
+	t.Run("from STDIN", func(t *testing.T) {
+		run(t, func(t *testing.T) {
+			f, err := os.Open("testdata/tree.caidx")
+			require.NoError(t, err)
+			oldStdin := os.Stdin
+			t.Cleanup(func() { os.Stdin = oldStdin; f.Close() })
+			os.Stdin = f
+		}, "-")
+	})
+}
+
+// Nothing should reach stdout when the input can't be read, least of all a
+// header with no entries under it.
+func TestMtreeCommandMissingInput(t *testing.T) {
+	b := new(bytes.Buffer)
+	oldStdout := stdout
+	t.Cleanup(func() { stdout = oldStdout })
+	stdout = b
+
+	cmd := newMtreeCommand(context.Background())
+	cmd.SetArgs([]string{"-s", "testdata/tree.store", "-i", "testdata/does-not-exist.caidx"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	_, err := cmd.ExecuteC()
+	require.Error(t, err)
+	require.Empty(t, b.String())
 }


### PR DESCRIPTION
The input was handed to `os.Stat` before anything looked at whether it was meant to be an index, so `mtree -i` only ever accepted a local file. `desync mtree -i -s store -` and an index named by URL both failed with `no such file or directory`, while every other command that reads an index takes both — `untar -i` with the same URL works.

The index case is now handled first and its location handed to the index store; the filesystem is only consulted for a catar or a directory, which are always local. The friendly message for `-i` on a directory is kept.

The `#mtree v1.0` header used to be written before any of this, so a failure left a header on stdout with nothing under it. Nothing is written now until the input is known to be readable.

Based on #425, which touches the same function; the diff shown here is just this change.