### PR TITLE
Report output write errors, and don't print a size that isn't known

### DIFF
--- a/cmd/desync/chunk.go
+++ b/cmd/desync/chunk.go
@@ -79,6 +79,6 @@ func runChunk(ctx context.Context, opt chunkOptions, args []string) error {
 			return nil
 		}
 		sum := desync.Digest.Sum(b)
-		fmt.Printf("%d\t%d\t%x\n", start+opt.startPos, len(b), sum)
+		fmt.Fprintf(stdout, "%d\t%d\t%x\n", start+opt.startPos, len(b), sum)
 	}
 }

--- a/cmd/desync/chunk_test.go
+++ b/cmd/desync/chunk_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChunkCommand(t *testing.T) {
+	b := new(bytes.Buffer)
+	oldStdout := stdout
+	t.Cleanup(func() { stdout = oldStdout })
+	stdout = b
+
+	cmd := newChunkCommand(context.Background())
+	cmd.SetArgs([]string{"testdata/blob1"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	_, err := cmd.ExecuteC()
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSuffix(b.String(), "\n"), "\n")
+	require.NotEmpty(t, lines)
+
+	// Every line is a start/length/hash triple, and the chunks are contiguous
+	// from the starting position.
+	var next int
+	for _, line := range lines {
+		fields := strings.Split(line, "\t")
+		require.Len(t, fields, 3, "line %q", line)
+		start, err := strconv.Atoi(fields[0])
+		require.NoError(t, err)
+		require.Equal(t, next, start)
+		length, err := strconv.Atoi(fields[1])
+		require.NoError(t, err)
+		require.NotEmpty(t, fields[2])
+		next = start + length
+	}
+}

--- a/cmd/desync/info.go
+++ b/cmd/desync/info.go
@@ -64,22 +64,23 @@ func runInfo(ctx context.Context, opt infoOptions, args []string) error {
 	}
 
 	var results struct {
-		Total                           int    `json:"total"`
-		Unique                          int    `json:"unique"`
-		InStore                         uint64 `json:"in-store"`
-		InSeed                          uint64 `json:"in-seed"`
-		InCache                         uint64 `json:"in-cache"`
-		NotInSeedNorCache               uint64 `json:"not-in-seed-nor-cache"`
-		Size                            uint64 `json:"size"`
-		SizeNotInSeed                   uint64 `json:"dedup-size-not-in-seed"`
-		SizeNotInSeedNorCache           uint64 `json:"dedup-size-not-in-seed-nor-cache"`
-		SizeNotInSeedNorCacheCompressed uint64 `json:"dedup-size-not-in-seed-nor-cache-compressed"`
-		ChunkSizeMin                    uint64 `json:"chunk-size-min"`
-		ChunkSizeAvg                    uint64 `json:"chunk-size-avg"`
-		ChunkSizeMax                    uint64 `json:"chunk-size-max"`
+		Total                           int     `json:"total"`
+		Unique                          int     `json:"unique"`
+		InStore                         uint64  `json:"in-store"`
+		InSeed                          uint64  `json:"in-seed"`
+		InCache                         uint64  `json:"in-cache"`
+		NotInSeedNorCache               uint64  `json:"not-in-seed-nor-cache"`
+		Size                            uint64  `json:"size"`
+		SizeNotInSeed                   uint64  `json:"dedup-size-not-in-seed"`
+		SizeNotInSeedNorCache           uint64  `json:"dedup-size-not-in-seed-nor-cache"`
+		SizeNotInSeedNorCacheCompressed *uint64 `json:"dedup-size-not-in-seed-nor-cache-compressed,omitempty"`
+		ChunkSizeMin                    uint64  `json:"chunk-size-min"`
+		ChunkSizeAvg                    uint64  `json:"chunk-size-avg"`
+		ChunkSizeMax                    uint64  `json:"chunk-size-max"`
 	}
 
 	var estimateCompressedSize = opt.chunksInfo != ""
+	var compressedSize uint64
 	var chunksInfo []desync.ChunkAdditionalInfo
 	if opt.chunksInfo != "" {
 		b, err := os.ReadFile(opt.chunksInfo)
@@ -173,12 +174,11 @@ func runInfo(ctx context.Context, opt infoOptions, args []string) error {
 			results.SizeNotInSeedNorCache += chunk.Size
 			if estimateCompressedSize {
 				if chunkInfo, found := chunkIDMap[chunk.ID]; found {
-					results.SizeNotInSeedNorCacheCompressed += uint64(chunkInfo.CompressedSize)
+					compressedSize += uint64(chunkInfo.CompressedSize)
 					if chunkInfo.CompressedSize == 0 {
-						// We don't have the compressed info for at least one chunk. We shouldn't print that info
-						// because it would not be accurate.
+						// We don't have the compressed info for at least one chunk. We shouldn't report that
+						// info because it would not be accurate.
 						estimateCompressedSize = false
-						results.SizeNotInSeedNorCacheCompressed = 0
 					}
 					if chunkInfo.UncompressedSize != chunk.Size {
 						return fmt.Errorf("the chunks info file has an unexpected size for the chunk %s: %d instead of %d",
@@ -188,12 +188,16 @@ func runInfo(ctx context.Context, opt infoOptions, args []string) error {
 					// If the provided chunks info file is missing some chunks we stop estimating the size.
 					// Otherwise, the shown value at the end could end up being wrong.
 					estimateCompressedSize = false
-					results.SizeNotInSeedNorCacheCompressed = 0
 				}
 			}
 		}
 	}
 	results.Unique = len(deduped)
+	// Reported only when it could be worked out for every chunk. A zero here
+	// would otherwise read as "nothing to transfer" rather than "not known".
+	if estimateCompressedSize {
+		results.SizeNotInSeedNorCacheCompressed = &compressedSize
+	}
 
 	if len(opt.stores) > 0 {
 		store, err := multiStoreWithRouter(opt.cmdStoreOptions, opt.stores...)
@@ -228,19 +232,21 @@ func runInfo(ctx context.Context, opt infoOptions, args []string) error {
 			return err
 		}
 	case "plain":
-		fmt.Println("Blob size:", results.Size)
-		fmt.Println("Size of deduplicated chunks not in seed:", results.SizeNotInSeed)
-		fmt.Println("Size of deduplicated chunks not in seed nor cache:", results.SizeNotInSeedNorCache)
-		fmt.Println("Total chunks:", results.Total)
-		fmt.Println("Unique chunks:", results.Unique)
-		fmt.Println("Chunks in store:", results.InStore)
-		fmt.Println("Chunks in seed:", results.InSeed)
-		fmt.Println("Chunks in cache:", results.InCache)
-		fmt.Println("Chunks not in seed nor cache:", results.NotInSeedNorCache)
-		fmt.Println("Compressed chunks not in seed nor cache:", results.SizeNotInSeedNorCacheCompressed)
-		fmt.Println("Chunk size min:", results.ChunkSizeMin)
-		fmt.Println("Chunk size avg:", results.ChunkSizeAvg)
-		fmt.Println("Chunk size max:", results.ChunkSizeMax)
+		fmt.Fprintln(stdout, "Blob size:", results.Size)
+		fmt.Fprintln(stdout, "Size of deduplicated chunks not in seed:", results.SizeNotInSeed)
+		fmt.Fprintln(stdout, "Size of deduplicated chunks not in seed nor cache:", results.SizeNotInSeedNorCache)
+		fmt.Fprintln(stdout, "Total chunks:", results.Total)
+		fmt.Fprintln(stdout, "Unique chunks:", results.Unique)
+		fmt.Fprintln(stdout, "Chunks in store:", results.InStore)
+		fmt.Fprintln(stdout, "Chunks in seed:", results.InSeed)
+		fmt.Fprintln(stdout, "Chunks in cache:", results.InCache)
+		fmt.Fprintln(stdout, "Chunks not in seed nor cache:", results.NotInSeedNorCache)
+		if results.SizeNotInSeedNorCacheCompressed != nil {
+			fmt.Fprintln(stdout, "Compressed size of deduplicated chunks not in seed nor cache:", *results.SizeNotInSeedNorCacheCompressed)
+		}
+		fmt.Fprintln(stdout, "Chunk size min:", results.ChunkSizeMin)
+		fmt.Fprintln(stdout, "Chunk size avg:", results.ChunkSizeAvg)
+		fmt.Fprintln(stdout, "Chunk size max:", results.ChunkSizeMax)
 	default:
 		return fmt.Errorf("unsupported output format %q", opt.printFormat)
 	}

--- a/cmd/desync/info_test.go
+++ b/cmd/desync/info_test.go
@@ -28,7 +28,6 @@ func TestInfoCommand(t *testing.T) {
 				"size": 2097152,
 				"dedup-size-not-in-seed": 1114112,
 				"dedup-size-not-in-seed-nor-cache": 1114112,
-				"dedup-size-not-in-seed-nor-cache-compressed": 0,
 				"chunk-size-min": 2048,
 				"chunk-size-avg": 8192,
 				"chunk-size-max": 32768
@@ -45,7 +44,6 @@ func TestInfoCommand(t *testing.T) {
 				"size": 2097152,
 				"dedup-size-not-in-seed": 80029,
 				"dedup-size-not-in-seed-nor-cache": 80029,
-				"dedup-size-not-in-seed-nor-cache-compressed": 0,
 				"chunk-size-min": 2048,
 				"chunk-size-avg": 8192,
 				"chunk-size-max": 32768
@@ -96,7 +94,6 @@ func TestInfoCommand(t *testing.T) {
 				"size": 2097152,
 				"dedup-size-not-in-seed": 1114112,
 				"dedup-size-not-in-seed-nor-cache": 1114112,
-				"dedup-size-not-in-seed-nor-cache-compressed": 0,
 				"chunk-size-min": 2048,
 				"chunk-size-avg": 8192,
 				"chunk-size-max": 32768
@@ -125,4 +122,39 @@ func TestInfoCommand(t *testing.T) {
 			require.Equal(t, exp, got)
 		})
 	}
+}
+
+// The plain output has to go to the same writer as the JSON one, and only
+// report a compressed size when there was one to work out.
+func TestInfoCommandPlain(t *testing.T) {
+	run := func(t *testing.T, args ...string) string {
+		t.Helper()
+		b := new(bytes.Buffer)
+		oldStdout := stdout
+		t.Cleanup(func() { stdout = oldStdout })
+		stdout = b
+
+		cmd := newInfoCommand(context.Background())
+		cmd.SetArgs(append(args, "--format", "plain"))
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+		_, err := cmd.ExecuteC()
+		require.NoError(t, err)
+		return b.String()
+	}
+
+	out := run(t, "-s", "testdata/blob1.store", "testdata/blob1.caibx")
+	require.Contains(t, out, "Blob size: 2097152\n")
+	require.Contains(t, out, "Chunks in store: 131\n")
+	require.NotContains(t, out, "Compressed size", "nothing was given to estimate from")
+
+	out = run(t, "-s", "testdata/blob2.store", "--cache", "testdata/blob2.cache",
+		"--chunks-info", "testdata/blob2_chunks_info.json", "testdata/blob2.caibx")
+	require.Contains(t, out, "Compressed size of deduplicated chunks not in seed nor cache: 818145\n")
+
+	// The estimate is given up on when a chunk is missing from the info file,
+	// and an abandoned one must not read as a size of zero.
+	out = run(t, "-s", "testdata/blob2.store",
+		"--chunks-info", "testdata/blob2_chunks_info_missing.json", "testdata/blob2.caibx")
+	require.NotContains(t, out, "Compressed size")
 }

--- a/mtreefs.go
+++ b/mtreefs.go
@@ -28,8 +28,7 @@ func (fs MtreeFS) CreateDir(n NodeDirectory) error {
 	attr = append(attr, fmt.Sprintf("uid=%d", n.UID))
 	attr = append(attr, fmt.Sprintf("gid=%d", n.GID))
 	attr = append(attr, fmt.Sprintf("time=%d.%9d", n.MTime.Unix(), n.MTime.Nanosecond()))
-	fmt.Fprintln(fs.w, strings.Join(attr, " "))
-	return nil
+	return fs.write(attr)
 }
 
 func (fs MtreeFS) CreateFile(n NodeFile) error {
@@ -56,8 +55,7 @@ func (fs MtreeFS) CreateFile(n NodeFile) error {
 	default:
 		return fmt.Errorf("unsupported mtree hash algorithm %d", Digest.Algorithm())
 	}
-	fmt.Fprintln(fs.w, strings.Join(attr, " "))
-	return nil
+	return fs.write(attr)
 }
 
 func (fs MtreeFS) CreateSymlink(n NodeSymlink) error {
@@ -67,8 +65,7 @@ func (fs MtreeFS) CreateSymlink(n NodeSymlink) error {
 	attr = append(attr, fmt.Sprintf("uid=%d", n.UID))
 	attr = append(attr, fmt.Sprintf("gid=%d", n.GID))
 	attr = append(attr, fmt.Sprintf("time=%d.%9d", n.MTime.Unix(), n.MTime.Nanosecond()))
-	fmt.Fprintln(fs.w, strings.Join(attr, " "))
-	return nil
+	return fs.write(attr)
 }
 
 func (fs MtreeFS) CreateDevice(n NodeDevice) error {
@@ -82,8 +79,15 @@ func (fs MtreeFS) CreateDevice(n NodeDevice) error {
 	attr = append(attr, fmt.Sprintf("uid=%d", n.UID))
 	attr = append(attr, fmt.Sprintf("gid=%d", n.GID))
 	attr = append(attr, fmt.Sprintf("time=%d.%9d", n.MTime.Unix(), n.MTime.Nanosecond()))
-	fmt.Fprintln(fs.w, strings.Join(attr, " "))
-	return nil
+	return fs.write(attr)
+}
+
+// write emits one mtree line. The error matters: a listing that stopped
+// half-way through is not the one the caller asked for, and nothing further
+// down reports a short write.
+func (fs MtreeFS) write(attr []string) error {
+	_, err := fmt.Fprintln(fs.w, strings.Join(attr, " "))
+	return err
 }
 
 // Converts filenames into an mtree-compatible format following the rules outlined in mtree(5):

--- a/mtreefs_test.go
+++ b/mtreefs_test.go
@@ -2,6 +2,7 @@ package desync
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -63,3 +64,44 @@ func TestMtreeFSNoKeywordInjection(t *testing.T) {
 		assert.NotEqual(t, "ignore", f, "injected keyword must not appear as its own field")
 	}
 }
+
+// A listing that couldn't be written is not the listing that was asked for,
+// and nothing downstream notices a short write, so every entry has to report
+// its own.
+func TestMtreeFSWriteError(t *testing.T) {
+	writeErr := errors.New("no space left on device")
+	mtime := time.Unix(0, 0)
+
+	for _, test := range []struct {
+		name  string
+		write func(fs MtreeFS) error
+	}{
+		{"directory", func(fs MtreeFS) error {
+			return fs.CreateDir(NodeDirectory{Name: "dir", MTime: mtime})
+		}},
+		{"file", func(fs MtreeFS) error {
+			return fs.CreateFile(NodeFile{Name: "file", Data: strings.NewReader("data"), MTime: mtime})
+		}},
+		{"symlink", func(fs MtreeFS) error {
+			return fs.CreateSymlink(NodeSymlink{Name: "link", Target: "file", MTime: mtime})
+		}},
+		{"device", func(fs MtreeFS) error {
+			return fs.CreateDevice(NodeDevice{Name: "dev", MTime: mtime})
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fs := MtreeFS{w: failWriter{writeErr}}
+			require.ErrorIs(t, test.write(fs), writeErr)
+		})
+	}
+
+	// The header is the first thing written, so it fails there too.
+	_, err := NewMtreeFS(failWriter{writeErr})
+	require.ErrorIs(t, err, writeErr)
+}
+
+// failWriter stands in for output that has stopped accepting anything, a full
+// disk or a closed pipe.
+type failWriter struct{ err error }
+
+func (w failWriter) Write([]byte) (int, error) { return 0, w.err }


### PR DESCRIPTION
`MtreeFS` discarded the error from every line it wrote and returned nil unconditionally, so `desync mtree` against output that has stopped accepting writes — a full disk, a closed pipe — produced a truncated listing and exited 0. Each entry now reports its own write, as `NewMtreeFS` already did for the header.

The plain output of `info` and the output of `chunk` went straight to `os.Stdout` rather than the package writer the JSON branch uses. That is also why neither had any tests; both now do.

`info` reported a compressed size of `0` in three different situations: when there genuinely was nothing to transfer, when no `--chunks-info` was given so no estimate was attempted, and when the estimate was deliberately abandoned because the info file was missing a chunk or a compressed size. The last two are "not known", not "zero". The value is now reported only when it was actually worked out, so the JSON field is absent and the plain line missing otherwise.

The plain label read `Compressed chunks not in seed nor cache:` for what is a byte count, where every sibling size line says "Size of…". It now reads `Compressed size of deduplicated chunks not in seed nor cache:`.

Note for anyone parsing the JSON: `dedup-size-not-in-seed-nor-cache-compressed` is now omitted rather than reported as `0` when it could not be estimated. Three of the existing test fixtures expected that zero and no longer carry the field.