### PR TITLE
Keep 'chop --ignore' reading the file in order

### DIFF
--- a/cmd/desync/chop.go
+++ b/cmd/desync/chop.go
@@ -75,9 +75,45 @@ func runChop(ctx context.Context, opt chopOptions, args []string) error {
 	if err != nil {
 		return err
 	}
-	chunks, err := chunksToStore(c.Chunks, opt)
-	if err != nil {
-		return err
+	chunks := c.Chunks
+
+	// If requested, skip/ignore all chunks that are referenced in other indexes or text files
+	if len(opt.ignoreIndexes) > 0 || len(opt.ignoreChunks) > 0 {
+		m := make(map[desync.ChunkID]desync.IndexChunk)
+		for _, c := range chunks {
+			m[c.ID] = c
+		}
+
+		// Remove chunks referenced in indexes
+		for _, f := range opt.ignoreIndexes {
+			i, err := readCaibxFile(f, opt.cmdStoreOptions)
+			if err != nil {
+				return err
+			}
+			for _, c := range i.Chunks {
+				delete(m, c.ID)
+			}
+		}
+
+		// Remove chunks referenced in ASCII text files
+		for _, f := range opt.ignoreChunks {
+			ids, err := readChunkIDFile(f)
+			if err != nil {
+				return err
+			}
+			for _, id := range ids {
+				delete(m, id)
+			}
+		}
+
+		// Back into the order they appear in the index. ChopFile's workers
+		// seek to each chunk's offset, so the order they are handed out in is
+		// the order the file gets read in, and map iteration order would make
+		// that a different random walk over the whole file on every run.
+		chunks = slices.Collect(maps.Values(m))
+		slices.SortFunc(chunks, func(a, b desync.IndexChunk) int {
+			return cmp.Compare(a.Start, b.Start)
+		})
 	}
 
 	// If this is a terminal, we want a progress bar
@@ -85,52 +121,6 @@ func runChop(ctx context.Context, opt chopOptions, args []string) error {
 
 	// Chop up the file into chunks and store them in the target store
 	return desync.ChopFile(ctx, dataFile, chunks, s, opt.n, pb)
-}
-
-// chunksToStore drops the chunks that are referenced in any of the ignore
-// indexes or chunk ID files, keeping the order they appear in the index and
-// one entry per chunk ID.
-func chunksToStore(chunks []desync.IndexChunk, opt chopOptions) ([]desync.IndexChunk, error) {
-	if len(opt.ignoreIndexes) == 0 && len(opt.ignoreChunks) == 0 {
-		return chunks, nil
-	}
-
-	m := make(map[desync.ChunkID]desync.IndexChunk, len(chunks))
-	for _, c := range chunks {
-		m[c.ID] = c
-	}
-
-	// Remove chunks referenced in indexes
-	for _, f := range opt.ignoreIndexes {
-		i, err := readCaibxFile(f, opt.cmdStoreOptions)
-		if err != nil {
-			return nil, err
-		}
-		for _, c := range i.Chunks {
-			delete(m, c.ID)
-		}
-	}
-
-	// Remove chunks referenced in ASCII text files
-	for _, f := range opt.ignoreChunks {
-		ids, err := readChunkIDFile(f)
-		if err != nil {
-			return nil, err
-		}
-		for _, id := range ids {
-			delete(m, id)
-		}
-	}
-
-	// Back into the order they appear in the index. ChopFile's workers seek to
-	// each chunk's offset, so the order they are handed out in is the order
-	// the file gets read in, and map iteration order would make that a
-	// different random walk over the whole file on every run.
-	out := slices.Collect(maps.Values(m))
-	slices.SortFunc(out, func(a, b desync.IndexChunk) int {
-		return cmp.Compare(a.Start, b.Start)
-	})
-	return out, nil
 }
 
 // Read a list of chunk IDs from a file. Blank lines are skipped.

--- a/cmd/desync/chop.go
+++ b/cmd/desync/chop.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"bufio"
+	"cmp"
 	"context"
 	"errors"
+	"maps"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/folbricht/desync"
@@ -72,41 +75,9 @@ func runChop(ctx context.Context, opt chopOptions, args []string) error {
 	if err != nil {
 		return err
 	}
-	chunks := c.Chunks
-
-	// If requested, skip/ignore all chunks that are referenced in other indexes or text files
-	if len(opt.ignoreIndexes) > 0 || len(opt.ignoreChunks) > 0 {
-		m := make(map[desync.ChunkID]desync.IndexChunk)
-		for _, c := range chunks {
-			m[c.ID] = c
-		}
-
-		// Remove chunks referenced in indexes
-		for _, f := range opt.ignoreIndexes {
-			i, err := readCaibxFile(f, opt.cmdStoreOptions)
-			if err != nil {
-				return err
-			}
-			for _, c := range i.Chunks {
-				delete(m, c.ID)
-			}
-		}
-
-		// Remove chunks referenced in ASCII text files
-		for _, f := range opt.ignoreChunks {
-			ids, err := readChunkIDFile(f)
-			if err != nil {
-				return err
-			}
-			for _, id := range ids {
-				delete(m, id)
-			}
-		}
-
-		chunks = make([]desync.IndexChunk, 0, len(m))
-		for _, c := range m {
-			chunks = append(chunks, c)
-		}
+	chunks, err := chunksToStore(c.Chunks, opt)
+	if err != nil {
+		return err
 	}
 
 	// If this is a terminal, we want a progress bar
@@ -114,6 +85,52 @@ func runChop(ctx context.Context, opt chopOptions, args []string) error {
 
 	// Chop up the file into chunks and store them in the target store
 	return desync.ChopFile(ctx, dataFile, chunks, s, opt.n, pb)
+}
+
+// chunksToStore drops the chunks that are referenced in any of the ignore
+// indexes or chunk ID files, keeping the order they appear in the index and
+// one entry per chunk ID.
+func chunksToStore(chunks []desync.IndexChunk, opt chopOptions) ([]desync.IndexChunk, error) {
+	if len(opt.ignoreIndexes) == 0 && len(opt.ignoreChunks) == 0 {
+		return chunks, nil
+	}
+
+	m := make(map[desync.ChunkID]desync.IndexChunk, len(chunks))
+	for _, c := range chunks {
+		m[c.ID] = c
+	}
+
+	// Remove chunks referenced in indexes
+	for _, f := range opt.ignoreIndexes {
+		i, err := readCaibxFile(f, opt.cmdStoreOptions)
+		if err != nil {
+			return nil, err
+		}
+		for _, c := range i.Chunks {
+			delete(m, c.ID)
+		}
+	}
+
+	// Remove chunks referenced in ASCII text files
+	for _, f := range opt.ignoreChunks {
+		ids, err := readChunkIDFile(f)
+		if err != nil {
+			return nil, err
+		}
+		for _, id := range ids {
+			delete(m, id)
+		}
+	}
+
+	// Back into the order they appear in the index. ChopFile's workers seek to
+	// each chunk's offset, so the order they are handed out in is the order
+	// the file gets read in, and map iteration order would make that a
+	// different random walk over the whole file on every run.
+	out := slices.Collect(maps.Values(m))
+	slices.SortFunc(out, func(a, b desync.IndexChunk) int {
+		return cmp.Compare(a.Start, b.Start)
+	})
+	return out, nil
 }
 
 // Read a list of chunk IDs from a file. Blank lines are skipped.

--- a/cmd/desync/chop_test.go
+++ b/cmd/desync/chop_test.go
@@ -2,14 +2,11 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
-	"github.com/folbricht/desync"
 	"github.com/stretchr/testify/require"
 )
 
@@ -64,58 +61,4 @@ func TestChopErrors(t *testing.T) {
 			require.Error(t, err)
 		})
 	}
-}
-
-// ChopFile's workers seek to each chunk's offset, so the order the chunks are
-// handed over in is the order the file gets read in. Filtering must not turn
-// a sequential read into a random walk over the whole file.
-func TestChopChunksToStore(t *testing.T) {
-	// The options have to come from a flagset, they're consulted when a store
-	// location is resolved.
-	var storeOpt cmdStoreOptions
-	flags := newTestOptionsCommand(&storeOpt)
-	flags.SetArgs(nil)
-	_, err := flags.ExecuteC()
-	require.NoError(t, err)
-
-	index, err := readCaibxFile("testdata/blob1.caibx", storeOpt)
-	require.NoError(t, err)
-	require.NotEmpty(t, index.Chunks)
-
-	// Ignore a scattering of chunks, so what's left isn't contiguous
-	var b strings.Builder
-	for i, c := range index.Chunks {
-		if i%3 == 0 {
-			fmt.Fprintln(&b, c.ID)
-		}
-	}
-	idFile := filepath.Join(t.TempDir(), "ignore.txt")
-	require.NoError(t, os.WriteFile(idFile, []byte(b.String()), 0644))
-
-	opt := chopOptions{cmdStoreOptions: storeOpt, ignoreChunks: []string{idFile}}
-
-	// Map iteration order is randomized per run, so a single pass proves
-	// little.
-	for range 10 {
-		chunks, err := chunksToStore(index.Chunks, opt)
-		require.NoError(t, err)
-		require.NotEmpty(t, chunks)
-		require.Less(t, len(chunks), len(index.Chunks))
-
-		starts := make([]uint64, 0, len(chunks))
-		seen := make(map[desync.ChunkID]struct{}, len(chunks))
-		for _, c := range chunks {
-			starts = append(starts, c.Start)
-			_, dup := seen[c.ID]
-			require.False(t, dup, "chunk %s handed over more than once", c.ID)
-			seen[c.ID] = struct{}{}
-		}
-		require.IsIncreasing(t, starts, "chunks must be in the order they appear in the index")
-	}
-
-	// Without anything to ignore the index is passed through untouched,
-	// duplicate chunk IDs and all.
-	chunks, err := chunksToStore(index.Chunks, chopOptions{cmdStoreOptions: storeOpt})
-	require.NoError(t, err)
-	require.Equal(t, index.Chunks, chunks)
 }

--- a/cmd/desync/chop_test.go
+++ b/cmd/desync/chop_test.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/folbricht/desync"
 	"github.com/stretchr/testify/require"
 )
 
@@ -61,4 +64,58 @@ func TestChopErrors(t *testing.T) {
 			require.Error(t, err)
 		})
 	}
+}
+
+// ChopFile's workers seek to each chunk's offset, so the order the chunks are
+// handed over in is the order the file gets read in. Filtering must not turn
+// a sequential read into a random walk over the whole file.
+func TestChopChunksToStore(t *testing.T) {
+	// The options have to come from a flagset, they're consulted when a store
+	// location is resolved.
+	var storeOpt cmdStoreOptions
+	flags := newTestOptionsCommand(&storeOpt)
+	flags.SetArgs(nil)
+	_, err := flags.ExecuteC()
+	require.NoError(t, err)
+
+	index, err := readCaibxFile("testdata/blob1.caibx", storeOpt)
+	require.NoError(t, err)
+	require.NotEmpty(t, index.Chunks)
+
+	// Ignore a scattering of chunks, so what's left isn't contiguous
+	var b strings.Builder
+	for i, c := range index.Chunks {
+		if i%3 == 0 {
+			fmt.Fprintln(&b, c.ID)
+		}
+	}
+	idFile := filepath.Join(t.TempDir(), "ignore.txt")
+	require.NoError(t, os.WriteFile(idFile, []byte(b.String()), 0644))
+
+	opt := chopOptions{cmdStoreOptions: storeOpt, ignoreChunks: []string{idFile}}
+
+	// Map iteration order is randomized per run, so a single pass proves
+	// little.
+	for range 10 {
+		chunks, err := chunksToStore(index.Chunks, opt)
+		require.NoError(t, err)
+		require.NotEmpty(t, chunks)
+		require.Less(t, len(chunks), len(index.Chunks))
+
+		starts := make([]uint64, 0, len(chunks))
+		seen := make(map[desync.ChunkID]struct{}, len(chunks))
+		for _, c := range chunks {
+			starts = append(starts, c.Start)
+			_, dup := seen[c.ID]
+			require.False(t, dup, "chunk %s handed over more than once", c.ID)
+			seen[c.ID] = struct{}{}
+		}
+		require.IsIncreasing(t, starts, "chunks must be in the order they appear in the index")
+	}
+
+	// Without anything to ignore the index is passed through untouched,
+	// duplicate chunk IDs and all.
+	chunks, err := chunksToStore(index.Chunks, chopOptions{cmdStoreOptions: storeOpt})
+	require.NoError(t, err)
+	require.Equal(t, index.Chunks, chunks)
 }


### PR DESCRIPTION
`ChopFile` starts a worker per `--concurrency`, each with its own file handle, and every worker seeks to `c.Start` before reading. The order the chunks are handed over in is therefore the order the file gets read in, and nothing downstream reorders or buffers.

Without `--ignore` that list comes straight from the index, in ascending offset order, so the workers read a sliding window that advances through the file. With `--ignore` the list was rebuilt by ranging over the filter map, and Go randomizes map iteration deliberately — a different random start bucket per loop — so the file was read in a different random order on every run, with no readahead value and no reproducibility.

The survivors are sorted by offset again, which restores the index order exactly since filtering only ever deletes. Keying the filter map by chunk ID also collapses repeated chunks; `ChunkStorage` already skips storing a chunk twice, but `readChunkFromFile` runs first, so the dedup still saves a seek and a read per repeat and is kept.

The filtering moved into `chunksToStore` so the ordering can be asserted. The test runs it ten times, since one pass of a randomized map proves little, and also checks that no chunk ID is handed over twice and that an unfiltered index is passed through untouched.